### PR TITLE
Made pow-operator right associative.

### DIFF
--- a/src/parser/Parser.js
+++ b/src/parser/Parser.js
@@ -748,11 +748,36 @@ Parser.prototype.parse_multiplydivide = function (scope) {
 Parser.prototype.parse_pow = function (scope) {
     var node = this.parse_factorial(scope);
 
+    // a counter to keep track of the number of encountered '^' operators
+    var n = 0;
+
     while (this.token == '^') {
+        n++;
         var name = this.token;
         var fn = pow;
         this.getToken();
-        var params = [node, this.parse_factorial(scope)];
+
+        var params;
+
+        // are there more than 1 successive '^' operators?
+        if(n > 1) {
+
+            // get the previous node's left and right children
+            var left_node = node.params[0];
+            var right_node = node.params[1];
+
+            // let the right child become the left child of the previous node
+            node.params[0] = right_node;
+
+            // let the newly discovered value become the right child of the previous node
+            node.params[1] = this.parse_factorial(scope);
+
+            // let the old node become the right child of the next (new) node
+            params = [left_node, node];
+        }
+        else {
+            params = [node, this.parse_factorial(scope)];
+        }
 
         node = new Symbol(name, fn, params);
     }

--- a/test/all.js
+++ b/test/all.js
@@ -18,7 +18,10 @@ require('./function/trigonometry.js');
 require('./function/units.js');
 require('./function/util.js');
 
-// TODO: test Parser
+// test Parser
+require('./parser/eval.js');
+// TODO: more Parser tests
+
 // TODO: test Workspace
 // TODO: test Scope
 // TODO: test Node, Assignment, Block, Constant, FunctionAssignment, Symbol, ArrayNode

--- a/test/parser/eval.js
+++ b/test/parser/eval.js
@@ -1,0 +1,11 @@
+// test Parser's eval function
+
+var assert = require('assert'),
+    math = require('../../math.js'),
+    parser = new math.parser.Parser();
+
+// pow
+assert.equal(parser.eval('2^3'), 8);
+assert.equal(parser.eval('(2^3)^2'), 64);
+assert.equal(parser.eval('2^(3^2)'), 512);
+assert.equal(parser.eval('2^3^2'), 512);


### PR DESCRIPTION
Hi Jos, as usual with your work: great stuff! I did find a little bug though: your parser handles the power operator like any other binary operator (left associative), while the power operator is (in most cases) right associative. I.e., the expression `a^b^c` is now being parsed as:

```
    ^
   / \
  ^   c
 / \
a   b
```

while it should be parsed as:

```
  ^ 
 / \
a   ^
   / \
  b   c
```

Since the parser is a LL (top-down) parser, this desired structure is a bit tricky to get. A possible solution: 

For the input `"a^b^c"` the parser would first create `(^ a b)` and would then encounter `"^c"`. Now instead of creating the AST `(^ (^ a b) c)`, you do the following inside `Parser.prototype.parse_pow`:
- make the 'old' left child of `(^ a b)` (node `a`) the left child of the new node: `(^ a (^ . b))`
- move the old right child, node `b`, to the left: `(^ a (^ b . ))`
- put the new node, `c`, to the right of `b`: `(^ a (^ b c))`

My pull request has the scheme above implemented, including some unit tests.

Cheers,

Bart.
