### PR TITLE
Added function xgcd (extended-gcd) + unit tests.

### DIFF
--- a/src/function/arithmetic/xgcd.js
+++ b/src/function/arithmetic/xgcd.js
@@ -1,0 +1,44 @@
+/**
+ * Calculate the extended greatest common divisor for two or
+ * more values.
+ *
+ *     xgcd(a, b)
+ *
+ * @param {Number} args    two integer numbers
+ * @return {Array}         an array containing 3 integers [div, m, n]
+ *                         where div = gcd(a, b) and a*m + b*n = div
+ *
+ * @see http://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
+ */
+math.xgcd = function xgcd(args) {
+
+    var a = arguments[0],
+        b = arguments[1];
+
+    if (arguments.length == 2) {
+
+        // two arguments
+        if (isNumber(a) && isNumber(b)) {
+
+            if (!isInteger(a) || !isInteger(b)) {
+                throw new Error('Parameters in function xgcd must be integer numbers');
+            }
+
+            if(b == 0) {
+                return [a, 1, 0];
+            }
+
+            var tmp = xgcd(b, a % b),
+                div = tmp[0],
+                x = tmp[1],
+                y = tmp[2];
+
+            return [div, y, x - y * Math.floor(a / b)];
+        }
+
+        throw newUnsupportedTypeError('xgcd', a, b);
+    }
+
+    // zero or one argument
+    throw new SyntaxError('Function xgcd expects two arguments');
+};

--- a/test/function/arithmetic.js
+++ b/test/function/arithmetic.js
@@ -193,3 +193,22 @@ assert.deepEqual(math.subtract(0, 3), -3);
 
 // TODO: test unaryminus
 // TODO: test unequal
+
+// test xgcd
+
+// xgcd(36163, 21199) = 1247 => -7(36163) + 12(21199) = 1247
+assert.deepEqual([1247, -7, 12], math.xgcd(36163, 21199));
+
+// xgcd(120, 23) = 1 => -9(120) + 47(23) = 1
+assert.deepEqual([1, -9, 47], math.xgcd(120, 23));
+
+// some unit tests from: https://github.com/sjkaliski/numbers.js/blob/master/test/basic.test.js
+assert.deepEqual([5, -3, 5], math.xgcd(65, 40));
+assert.deepEqual([5, 5, -3], math.xgcd(40, 65));
+assert.deepEqual([21, -16, 27], math.xgcd(1239, 735));
+assert.deepEqual([21, 5, -2], math.xgcd(105, 252));
+assert.deepEqual([21, -2, 5], math.xgcd(252, 105));
+
+// invalid input (only 2 params are permitted!)
+assert.throws(function () {math.xgcd(1)});
+assert.throws(function () {math.xgcd(1, 2, 3)});


### PR DESCRIPTION
The implementation is not copied from somewhere, I based it on the Wiki article, which I placed as an `@see` in the doc-comment.

I did "borrow" some unit tests from another math-library, which I mentioned in the comments of the unit tests.

I didn't add support arrays and/or matrices, since that didn't seem logical to me given that `xgcd` returns and array holding 3 values.

Feel free to rename `xgcd` to `egcd`, of course.
