### PR TITLE
Fixed mean to use "size" instead of calculating it

### DIFF
--- a/lib/function/statistics/mean.js
+++ b/lib/function/statistics/mean.js
@@ -43,20 +43,14 @@ module.exports = function (math) {
    * Calculate the mean value in an n-dimensional array, returning a
    * n-1 dimensional array
    * @param {Array} array
-   * @param {Number} dimension
+   * @param {Number} dim
    * @return {Number} mean
    * @private
    */
   function _nmean(array, dim){
-	  var sum, len, tmp;
+	  var sum;
 	  sum = collection.reduce(array, dim, math.add);
-	  tmp = array;
-	  while(dim>0){
-          tmp = tmp[0];
-          dim--;
-	  };
-	  len = tmp.length;
-	  return math.divide(sum, len);
+	  return math.divide(sum, size(array)[dim]);
   };
 
   /**


### PR DESCRIPTION
Now using 'size', to calculate the mean of an n-dimensional array it's very easy:

``` javascript
  function _nmean(array, dim){
          var sum;
          sum = collection.reduce(array, dim, math.add);
          return math.divide(sum, size(array)[dim]);
  };
```
