### PR TITLE
add prettyprinting of math expressions utilizing scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ function mathjs (options) {
   require('./lib/function/expression/eval.js')(math);
   require('./lib/function/expression/help.js')(math);
   require('./lib/function/expression/parse.js')(math);
+  require('./lib/function/expression/prettyprint.js')(math);
 
   // functions - arithmetic
   require('./lib/function/arithmetic/abs.js')(math);

--- a/lib/function/expression/prettyprint.js
+++ b/lib/function/expression/prettyprint.js
@@ -1,0 +1,241 @@
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      Scope = require('../../expression/Scope'),
+      OperatorNode = require('../../expression/node/OperatorNode'),
+      SymbolNode = require('../../expression/node/SymbolNode'),
+      collection = require('../../type/collection'),
+      isString = util.string.isString,
+      isNumber = util.number.isNumber,
+      isCollection = collection.isCollection;
+
+  /**
+   * Pretty print an expression.
+   *
+   * Syntax:
+   *
+   *     math.prettyprint(expr)
+   *     math.prettyprint(expr, scope)
+   *     math.prettyprint([expr1, expr2, expr3, ...])
+   *     math.prettyprint([expr1, expr2, expr3, ...], scope)
+   *
+   * Example:
+   *
+   *     math.prettyprint('x^x^(x+1)');            // "x^x^(x + 1)"
+   *
+   *     var scope = {a:3}
+   *     math.prettyprint('a * x', scope);         // "3x"
+   *
+   *     scope = {a:1, b: 0}
+   *     math.prettyprint('a * x + b * x', scope); // "x"
+   *
+   *
+   *
+   * @param {String | String[] | Matrix} expr
+   * @param {Scope | Object} [scope]
+   * @return {*} res
+   * @throws {Error}
+   */
+  math.prettyprint = function _eval (expr, scope) {
+    if (arguments.length != 1 && arguments.length != 2) {
+      throw new util.error.ArgumentsError('prettyprint', arguments.length, 1, 2);
+    }
+
+    // instantiate a scope
+    var prettyprintScope;
+    if (scope) {
+      if (scope instanceof Scope) {
+        prettyprintScope = scope;
+      }
+      else {
+        prettyprintScope = new Scope(math, scope);
+      }
+    }
+    else {
+      prettyprintScope = new Scope(math);
+    }
+
+    if (isString(expr)) {
+      // prettyprint a single expression
+      var node = math.parse(expr, prettyprintScope);
+      enablePretty(node)
+      return node.expr.toString();
+    }
+    else if (isCollection(expr)) {
+      // prettyprint an array or matrix with expressions
+      return collection.deepMap(expr, function (elem) {
+        var node = math.parse(elem, prettyprintScope);
+        return node.expr.toString;
+      });
+    }
+    else {
+      // oops
+      throw new TypeError('String or matrix expected');
+    }
+  };
+
+  function operatorNodetoString () {
+    /*
+     * Replaces OperatorNode.prototype.toString
+     * so that when toString is called this
+     * instance function is called instead.
+     */
+    var params = this.params;
+    var lprec = ["+","-"] // lower precendence
+
+    switch (params.length) {
+      case 1:
+      if (this.name == '-') {
+        // special case: unary minus
+        return '-' + params[0].toString();
+      }
+      else {
+        // for example '5!'
+        return params[0].toString() + this.name;
+      }
+
+      case 2: // for example '2+3'
+      var lhs = params[0].toString()
+        , rhs = params[1].toString()
+        , spc = " "
+
+      /*
+       * DEAL WITH 1's and 0's
+       * want 1 * x -> x
+       * x * 1 -> x
+       * 1 * 1 -> 1
+       * 0 * x -> "0"
+       * sin(x) * 0 -> "0"
+       */
+      if (lhs === "1" && this.name === "*")
+        return rhs;
+
+      if (rhs === "1" && this.name === "*")
+        return lhs;
+
+      if (lhs === "0")
+        return (precedence(this) === 8) ? rhs : "0";
+
+      if (rhs === "0")
+        return (precedence(this) === 8) ? lhs : "0";
+
+      /*
+       * DEAL WITH MULTIPLICATIONS
+       * 3 * x -> 3x
+       * x * 3 -> 3x
+       * 3 * 3 -> 3 * 3
+       * x * x -> x * x
+       */
+      if (this.name === "*") {
+        if (!isNaN(lhs) !== !isNaN(rhs)) {
+
+          if (!isNaN(lhs) && (params[1] instanceof SymbolNode))
+            return lhs + rhs;
+
+          if (!isNaN(rhs) && (params[0] instanceof SymbolNode))
+            return rhs + lhs;
+        }
+      }
+
+      /*
+       * determine precedence of this
+       * node and adjacent nodes.
+       */
+      if (this.name === "^")
+        spc = ""
+
+      if (params[0] instanceof OperatorNode) {
+
+        if (precedence(this) >= precedence(params[0]))
+          lhs = lhs;
+        else
+          lhs = "(" + lhs + ")";
+      }
+
+      if (params[1] instanceof OperatorNode) {
+
+        if (precedence(this) >= precedence(params[1]))
+          rhs = rhs;
+        else
+          rhs = "(" + rhs + ")";
+      }
+
+      return lhs + spc + this.name + spc + rhs;
+
+      default: // this should occur. format as a function call
+      return this.name + '(' + this.params.join(', ') + ')';
+
+    }
+
+  };
+
+
+  function symbolNodetoString () {
+    var value = this.scope.symbols[this.name]
+    if (isNumber(value))
+      return value.toString()
+    else
+      return this.name
+  }
+
+  function enablePretty (node) {
+    /**
+     * Over-ride Object.prototype.toString
+     * method with an Object.toString method.
+     *
+     */
+    var operators = node.find({
+      type: OperatorNode
+    });
+
+    var symbols = node.find({
+      type: SymbolNode
+    });
+
+    operators.forEach( function (o) {
+      o.toString = operatorNodetoString
+    })
+
+    symbols.forEach( function (o) {
+      o.toString = symbolNodetoString
+    })
+
+
+  };
+
+
+
+  function precedence (node) {
+    /*
+     * Precendence hack for deciding if we
+     * should pretty print brackets or not.
+     */
+    var prec = null;
+    var precs = {
+      "^" :1    // power
+    , "!" :2    // factorial
+    , "'" :3    // transpose
+    , ":" :4    // range [GUESSING AT THIS]
+    , "/" :5    // divide
+    , "./":5    // element-wise divide
+    , "*" :6    // multiply
+    , ".*":6    // element-wise multiply
+    , "%" :7    // mod
+    , "+" :8    // add
+    , "-" :8    // subtract
+    , "in":9    // unit conversion
+    , "<" :10   // smaller
+    , ">" :10   // larger
+    , "<=":10   // smaller or equal to
+    , ">=":10   // larger or equal to
+    , "==":11   // equal to
+    , "!=":11   // unequal
+    , "=" :12   // assignment
+    }
+    if (node.name)
+      prec = precs[node.name]
+
+    return prec
+  }
+
+};

--- a/test/expression/print.test.js
+++ b/test/expression/print.test.js
@@ -1,0 +1,93 @@
+// test printing
+
+var assert = require('assert'),
+    approx = require('../../tools/approx'),
+    math = require('../../index')();
+
+describe('pretty printer', function() {
+
+  it ('should be a method', function () {
+    assert.ok(typeof(math.prettyprint) === "function");
+  });
+
+
+  it ('should return a string', function () {
+    var pretty = math.prettyprint('sqrt(x^a)');
+    assert.ok(typeof(pretty) === "string");
+  });
+
+  it ('should prettyprint expressions', function () {
+
+    var pretty = math.prettyprint('a + b * (c + 1)');
+    assert.equal(pretty, "a + b * (c + 1)");
+
+    pretty = math.prettyprint('x^x^(x+1)');
+    assert.equal(pretty, "x^x^(x + 1)");
+
+    pretty = math.prettyprint('sin(x-1) / x * x^(3-x)');
+    assert.equal(pretty, "sin(x - 1) / x * x^(3 - x)");
+
+    pretty = math.prettyprint('(1-y) * b * 3/(1+y)');
+    assert.equal(pretty, '((1 - y) * b * 3) / (1 + y)');
+
+  });
+
+  it ('should substitute scope variables', function () {
+    var scope = {
+      a: 1
+    };
+    var pretty = math.prettyprint('a', scope);
+    assert.equal(pretty, "1");
+
+    pretty = math.prettyprint('a + b*x', scope);
+    assert.equal(pretty, "1 + b * x");
+
+  });
+
+  it ("should remove unnecessary multiplication operators", function () {
+
+    var scope = {
+      a: 3
+    };
+    var pretty = math.prettyprint('a * x', scope);
+    assert.equal(pretty, "3x");
+
+    pretty = math.prettyprint('x * a', scope);
+    assert.equal(pretty, "3x");
+
+    pretty = math.prettyprint('a * a', scope);
+    assert.equal(pretty, "3 * 3");
+
+    pretty = math.prettyprint('x * x', scope);
+    assert.equal(pretty, "x * x");
+
+  })
+
+
+  it ("should cleanup unnecessary 1's and 0's", function () {
+    var scope = {
+      a: 1
+    };
+    var pretty = math.prettyprint('a * x', scope);
+    assert.equal(pretty, "x");
+
+    scope = {
+      a: 1
+    , b: 0
+    };
+    pretty = math.prettyprint('a * x + b * x', scope);
+    assert.equal(pretty, "x");
+
+    scope = {
+      a: 0
+    };
+    pretty = math.prettyprint('a * x', scope);
+    assert.equal(pretty, "0");
+
+    pretty = math.prettyprint('sin(x) * a', scope);
+    assert.equal(pretty, "0");
+
+  });
+
+
+});


### PR DESCRIPTION
This is a code demo for this recently [open issue](https://github.com/josdejong/mathjs/issues/111). I needed expression pretty printing and dealing with the mathjs nodetree seemed a good route. This isn't a serious patch, but it has accompanying tests and doesn't interfere with the existing codebase, rather calling `math.prettyprint(expr[, scope])` just cycles through the instances of SymbolNodes and OperatorNodes and adds a prettier `toString()` instance method to each which effectively override the Prototype `toString` methods.

We'll be using it over at [Plotly](https://plot.ly/)

Thanks for the great work!
