### PR TITLE
move the 'in' unit conversion keyword to 'to'

### DIFF
--- a/lib/expression/docs/function/units/to.js
+++ b/lib/expression/docs/function/units/to.js
@@ -1,9 +1,9 @@
 module.exports = {
-  'name': 'in',
+  'name': 'to',
   'category': 'Units',
   'syntax': [
-    'x in unit',
-    'in(x, unit)'
+    'x to unit',
+    'to(x, unit)'
   ],
   'description': 'Change the unit of a value.',
   'examples': [

--- a/lib/expression/docs/index.js
+++ b/lib/expression/docs/index.js
@@ -109,7 +109,7 @@ exports.sin = require('./function/trigonometry/sin');
 exports.tan = require('./function/trigonometry/tan');
 
 // functions - units
-exports['in'] = require('./function/units/in');
+exports.to = require('./function/units/to');
 
 // functions - utils
 exports.clone =  require('./function/utils/clone');

--- a/lib/function/expression/parse.js
+++ b/lib/function/expression/parse.js
@@ -139,7 +139,7 @@ module.exports = function (math, settings) {
     // map with all named delimiters
   var NAMED_DELIMITERS = {
       'mod': true,
-      'in': true
+      'to': true
   };
 
   var expression = '';  // current expression
@@ -678,7 +678,7 @@ module.exports = function (math, settings) {
     // TODO: precedence of And above Or?
     // TODO: implement a method for unit to number conversion
     operators = {
-      'in' : math['in']
+      'to' : math.to
       /* TODO: implement conditions
        'and' : 'and',
        '&&' : 'and',

--- a/lib/function/units/to.js
+++ b/lib/function/units/to.js
@@ -11,8 +11,8 @@ module.exports = function (math) {
   /**
    * Change the unit of a value.
    *
-   *     x in unit
-   *     in(x, unit)
+   *     x to unit
+   *     to(x, unit)
    *
    * For matrices, the function is evaluated element wise.
    *
@@ -20,23 +20,23 @@ module.exports = function (math) {
    * @param {Unit | Array | Matrix} unit
    * @return {Unit | Array | Matrix} res
    */
-  math['in'] = function unit_in(x, unit) {
+  math.to = function unit_to(x, unit) {
     if (arguments.length != 2) {
-      throw new math.error.ArgumentsError('in', arguments.length, 2);
+      throw new math.error.ArgumentsError('to', arguments.length, 2);
     }
 
     if (isUnit(x)) {
       if (isUnit(unit) || isString(unit)) {
-        return x['in'](unit);
+        return x.to(unit);
       }
     }
 
     // TODO: add support for string, in that case, convert to unit
 
     if (isCollection(x) || isCollection(unit)) {
-      return collection.deepMap2(x, unit, unit_in);
+      return collection.deepMap2(x, unit, unit_to);
     }
 
-    throw new math.error.UnsupportedTypeError('in', x, unit);
+    throw new math.error.UnsupportedTypeError('to', x, unit);
   };
 };

--- a/lib/math.js
+++ b/lib/math.js
@@ -211,7 +211,7 @@ function mathjs (settings) {
   require('./function/trigonometry/tan.js')(math, _settings);
 
   // functions - units
-  require('./function/units/in.js')(math, _settings);
+  require('./function/units/to.js')(math, _settings);
 
   // functions - utils
   require('./function/utils/clone.js')(math, _settings);

--- a/lib/type/Unit.js
+++ b/lib/type/Unit.js
@@ -341,7 +341,7 @@ Unit.prototype.equals = function(other) {
  * @param {String | Unit} plainUnit   A plain unit, without value. Can have prefix, like "cm"
  * @returns {Unit} unit having fixed, specified unit
  */
-Unit.prototype['in'] = function (plainUnit) {
+Unit.prototype['to'] = function (plainUnit) {
   var other;
   if (isString(plainUnit)) {
     other = new Unit(null, plainUnit);
@@ -380,7 +380,7 @@ Unit.prototype['in'] = function (plainUnit) {
  * @return {Number} value
  */
 Unit.prototype.toNumber = function (plainUnit) {
-  var other = this['in'](plainUnit);
+  var other = this['to'](plainUnit);
   var prefix = this.fixPrefix ? other._bestPrefix() : other.prefix;
   return other._unnormalize(other.value, prefix.value);
 };
@@ -637,7 +637,7 @@ var UNITS = [
   {'name': 'angstrom', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.NONE, 'value': 1e-10, 'offset': 0},
 
   {'name': 'm', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.SHORT, 'value': 1, 'offset': 0},
-  //{'name': 'in', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.NONE, 'value': 0.0254, 'offset': 0}, not supported, In is an operator
+  {'name': 'in', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.NONE, 'value': 0.0254, 'offset': 0},
   {'name': 'ft', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.NONE, 'value': 0.3048, 'offset': 0},
   {'name': 'yd', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.NONE, 'value': 0.9144, 'offset': 0},
   {'name': 'mi', 'base': BASE_UNITS.LENGTH, 'prefixes': PREFIXES.NONE, 'value': 1609.344, 'offset': 0},

--- a/test/function/expression/parse.test.js
+++ b/test/function/expression/parse.test.js
@@ -142,29 +142,29 @@ describe('parse', function() {
     it('should correctly parse negative temperatures', function () {
       approx.deepEqual(parseAndEval('-6 celsius'), new Unit(-6, 'celsius'));
       approx.deepEqual(parseAndEval('--6 celsius'), new Unit(6, 'celsius'));
-      approx.deepEqual(parseAndEval('-6 celsius in fahrenheit'),
-          new Unit(21.2, 'fahrenheit').in('fahrenheit'));
+      approx.deepEqual(parseAndEval('-6 celsius to fahrenheit'),
+          new Unit(21.2, 'fahrenheit').to('fahrenheit'));
     });
 
     it('should convert units', function() {
       var scope = {};
-      approx.deepEqual(parseAndEval('(5.08 cm * 1000) in inch', scope),
-          math.unit(2000, 'inch').in('inch'));
-      approx.deepEqual(parseAndEval('(5.08 cm * 1000) in mm', scope),
-          math.unit(50800, 'mm').in('mm'));
-      approx.deepEqual(parseAndEval('ans in inch', scope),
-          math.unit(2000, 'inch').in('inch'));
+      approx.deepEqual(parseAndEval('(5.08 cm * 1000) to inch', scope),
+          math.unit(2000, 'inch').to('inch'));
+      approx.deepEqual(parseAndEval('(5.08 cm * 1000) to mm', scope),
+          math.unit(50800, 'mm').to('mm'));
+      approx.deepEqual(parseAndEval('ans to inch', scope),
+          math.unit(2000, 'inch').to('inch'));
 
-      approx.deepEqual(parseAndEval('10 celsius in fahrenheit'),
-          math.unit(50, 'fahrenheit').in('fahrenheit'));
-      approx.deepEqual(parseAndEval('20 celsius in fahrenheit'),
-          math.unit(68, 'fahrenheit').in('fahrenheit'));
-      approx.deepEqual(parseAndEval('50 fahrenheit in celsius'),
-          math.unit(10, 'celsius').in('celsius'));
+      approx.deepEqual(parseAndEval('10 celsius to fahrenheit'),
+          math.unit(50, 'fahrenheit').to('fahrenheit'));
+      approx.deepEqual(parseAndEval('20 celsius to fahrenheit'),
+          math.unit(68, 'fahrenheit').to('fahrenheit'));
+      approx.deepEqual(parseAndEval('50 fahrenheit to celsius'),
+          math.unit(10, 'celsius').to('celsius'));
     });
 
-    it('should evaluate operator "in" with correct precedence ', function () {
-      approx.equal(parseAndEval('5.08 cm * 1000 in inch').toNumber('inch'),
+    it('should evaluate operator "to" with correct precedence ', function () {
+      approx.equal(parseAndEval('5.08 cm * 1000 to inch').toNumber('inch'),
           new Unit(2000, 'inch').toNumber('inch'));
     });
   });
@@ -587,9 +587,9 @@ describe('parse', function() {
       assert.deepEqual(parseAndEval('3:-1:-0.1'), new Matrix([3,2,1,0]));
     });
 
-    it('should parse in', function() {
-      approx.deepEqual(parseAndEval('2.54 cm in inch'), math.unit(1, 'inch').in('inch'));
-      approx.deepEqual(parseAndEval('2.54 cm + 2 inch in foot'), math.unit(0.25, 'foot').in('foot'));
+    it('should parse to', function() {
+      approx.deepEqual(parseAndEval('2.54 cm to inch'), math.unit(1, 'inch').to('inch'));
+      approx.deepEqual(parseAndEval('2.54 cm + 2 inch to foot'), math.unit(0.25, 'foot').to('foot'));
     });
 
     it('should parse \' (transpose)', function() {
@@ -638,9 +638,9 @@ describe('parse', function() {
 
       });
 
-      it('should evaluate function "in" ', function () {
-        approx.deepEqual(parseAndEval('in(5.08 cm * 1000, inch)'),
-            math.unit(2000, 'inch').in('inch'));
+      it('should evaluate function "to" ', function () {
+        approx.deepEqual(parseAndEval('to(5.08 cm * 1000, inch)'),
+            math.unit(2000, 'inch').to('inch'));
       });
     });
 

--- a/test/function/units/to.test.js
+++ b/test/function/units/to.test.js
@@ -3,29 +3,29 @@ var assert = require('assert'),
     math = require('../../../index')(),
     unit = math.unit;
 
-describe('in', function() {
+describe('to', function() {
 
   it('should perform the given unit conversion', function() {
     // TODO: improve these tests
     var a = math.unit('500 cm'); a.fixPrefix = true;
-    approx.deepEqual(math.in(unit('5m'), unit('cm')), a);
+    approx.deepEqual(math.to(unit('5m'), unit('cm')), a);
 
     var b = math.unit('1 foot'); b.fixPrefix = true;
-    approx.deepEqual(math.in(unit('12 inch'), unit('foot')), b);
+    approx.deepEqual(math.to(unit('12 inch'), unit('foot')), b);
 
     var c = math.unit('1 inch'); c.fixPrefix = true;
-    approx.deepEqual(math.in(unit('2.54 cm'), unit('inch')), c);
+    approx.deepEqual(math.to(unit('2.54 cm'), unit('inch')), c);
 
     var d = math.unit('68 fahrenheit'); d.fixPrefix = true;
-    approx.deepEqual(math.in(unit('20 celsius'), unit('fahrenheit')), d);
+    approx.deepEqual(math.to(unit('20 celsius'), unit('fahrenheit')), d);
 
     var e = math.unit('0.002 m3'); e.fixPrefix = true;
-    approx.deepEqual(math.in(unit('2 litre'), unit('m3')), e);
+    approx.deepEqual(math.to(unit('2 litre'), unit('m3')), e);
   });
 
   it('should perform the given unit conversion on each element of an array', function() {
     // TODO: do not use math.format here
-    assert.deepEqual(math.format(math.in([
+    assert.deepEqual(math.format(math.to([
       unit('1cm'),
       unit('2 inch'),
       unit('2km')], unit('foot')), 5),
@@ -34,34 +34,34 @@ describe('in', function() {
 
   it('should perform the given unit conversion on each element of a matrix', function() {
     var a = math.matrix([[unit('1cm'), unit('2cm')],[unit('3cm'),unit('4cm')]]);
-    var b = math.in(a, unit('mm'));
+    var b = math.to(a, unit('mm'));
     assert.ok(b instanceof math.type.Matrix);
     // TODO: do not use math.format here
     assert.equal(math.format(b), '[[10 mm, 20 mm], [30 mm, 40 mm]]');
   });
 
   it('should throw an error if converting between incompatible units', function() {
-    assert.throws(function () {math.in(unit('20 kg'), unit('cm'))});
-    assert.throws(function () {math.in(unit('20 celsius'), unit('litre'))});
-    assert.throws(function () {math.in(unit('5 cm'), unit('2 m'))});
+    assert.throws(function () {math.to(unit('20 kg'), unit('cm'))});
+    assert.throws(function () {math.to(unit('20 celsius'), unit('litre'))});
+    assert.throws(function () {math.to(unit('5 cm'), unit('2 m'))});
   });
 
   it('should throw an error if called with a wrong number of arguments', function() {
-    assert.throws(function () {math.in(unit('20 kg'))});
-    assert.throws(function () {math.in(unit('20 kg'), unit('m'), unit('cm'))});
+    assert.throws(function () {math.to(unit('20 kg'))});
+    assert.throws(function () {math.to(unit('20 kg'), unit('m'), unit('cm'))});
   });
 
   it('should throw an error if called with a non-plain unit', function() {
-    assert.throws( function () {math.unit(5000, 'cm').in('5mm'); });
+    assert.throws( function () {math.unit(5000, 'cm').to('5mm'); });
   });
 
   it('should throw an error if called with a number', function() {
-    assert.throws(function () {math.in(5, unit('m'))}, TypeError);
-    assert.throws(function () {math.in(unit('5cm'), 2)}, TypeError);
+    assert.throws(function () {math.to(5, unit('m'))}, TypeError);
+    assert.throws(function () {math.to(unit('5cm'), 2)}, TypeError);
   });
 
   it('should throw an error if called with a string', function() {
-    assert.throws(function () {math.in('5cm', unit('cm'))}, TypeError);
+    assert.throws(function () {math.to('5cm', unit('cm'))}, TypeError);
   });
 
 });


### PR DESCRIPTION
This also enables 'in' as an alias of 'inch'.  refs #120

Should have read the contributing guidelines, my bad!
