### PR TITLE
Faster matrix power

### DIFF
--- a/lib/function/arithmetic/pow.js
+++ b/lib/function/arithmetic/pow.js
@@ -106,18 +106,17 @@ module.exports = function (math) {
             '(size is ' + s[0] + 'x' + s[1] + ')');
       }
 
-      if (y == 0) {
-        // return the identity matrix
-        return math.eye(s[0]);
-      }
-      else {
-        // value > 0
-        var res = x;
-        for (var i = 1; i < y; i++) {
-          res = math.multiply(x, res);
+      // compute power of matrix
+      var res = math.eye(s[0]).valueOf();
+      var px = x;
+      while (y >= 1) {
+        if ((y & 1) == 1) {
+          res = math.multiply(px, res);
         }
-        return res;
+        y >>= 1;
+        px = math.multiply(px, px);
       }
+      return res;
     }
     else if (x instanceof Matrix) {
       return new Matrix(pow(x.valueOf(), y));

--- a/test/function/arithmetic/pow.test.js
+++ b/test/function/arithmetic/pow.test.js
@@ -123,6 +123,19 @@ describe('pow', function() {
     approx.deepEqual(pow(matrix(a), 2), matrix(res));
   });
 
+  it('should return identity matrix for power 0', function() {
+    var a = [[1,2],[3,4]];
+    var res = [[1,0],[0,1]];
+    approx.deepEqual(pow(a, 0), res);
+    approx.deepEqual(pow(matrix(a), 0), matrix(res));
+  });
+
+  it('should compute large size of square matrix', function() {
+    var a = math.eye(30).valueOf();
+    approx.deepEqual(pow(a, 1000), a);
+    approx.deepEqual(pow(matrix(a), 1000), matrix(a));
+  });
+
   it('should throw an error when calculating the power of a non square matrix', function() {
     assert.throws(function () {pow([1,2,3,4],2);});
     assert.throws(function () {pow([[1,2,3],[4,5,6]],2);});


### PR DESCRIPTION
Hello.

I noticed that in math.js power of matrix (A^P, size(A)=N) code has computational complexity O(N^3P) that can be improved to O(N^3logP). Optimized code is included in my pull request. I also added some test cases in pow.test.js:
- power 0 of square matrix (A^0) test
  - in original code it fails. 
- power of larger size of square matrix test
  - in original code it takes long (in my environment >= 10s) time.

I'd appreciate it if you could give me some feedback. Thanks.
