### PR TITLE
Determinant bug (det) fix

### DIFF
--- a/lib/function/matrix/det.js
+++ b/lib/function/matrix/det.js
@@ -21,7 +21,16 @@ module.exports = function (math) {
       throw new math.error.ArgumentsError('det', arguments.length, 1);
     }
 
-    var size = array.size(x.valueOf());
+    if (!(x instanceof Matrix)) {
+      if (x instanceof Array) {
+        x = new Matrix(x);
+      } else {
+        throw new TypeError('Determinant is only defined for Matrix or Array.');
+      }
+    } 
+
+    var size = x.size();
+
     switch (size.length) {
       case 0:
         // scalar
@@ -44,7 +53,7 @@ module.exports = function (math) {
         var rows = size[0];
         var cols = size[1];
         if (rows == cols) {
-          return _det(x.valueOf(), rows, cols);
+          return _det(x.clone().valueOf(), rows, cols);
         }
         else {
           throw new RangeError('Matrix must be square ' +
@@ -97,7 +106,7 @@ module.exports = function (math) {
             lead++;
             if (lead == cols) {
               // We found the last pivot.
-              if (object.deepEqual(matrix, eye(rows).valueOf())) {
+              if (object.deepEqual(matrix, math.eye(rows).valueOf())) {
                 return math.round(d, 6);
               } else {
                 return 0;

--- a/test/function/matrix/det.test.js
+++ b/test/function/matrix/det.test.js
@@ -3,15 +3,7 @@ var assert = require('assert'),
 
 describe('det', function() {
 
-  it('should calculate correctly the determinant of a number', function() {
-    assert.equal(math.det(3), 3);
-  });
-
-  it('should calculate correctly the determinant of a bignumber', function() {
-    assert.deepEqual(math.det(math.bignumber(3)), math.bignumber(3));
-  });
-
-  it('should calculate correctly the determinant of a 2x2 matrix', function() {
+  it('should calculate correctly the determinant of a NxN matrix', function() {
     assert.equal(math.det([5]), 5);
     assert.equal(math.det([[1,2],[3,4]]), -2);
     assert.equal(math.det(math.matrix([[1,2],[3,4]])), -2);
@@ -25,7 +17,44 @@ describe('det', function() {
       [ 3, 0,  5],
       [-1, 9, 11]
     ]), -8);
+    assert.equal(math.det([
+      [1,7,4,3,7], 
+      [0,7,0,3,7], 
+      [0,7,4,3,0], 
+      [1,7,5,9,7], 
+      [2,7,4,3,7]
+    ]), -1176);
     assert.equal(math.det(math.diag([4,-5,6])), -120);
   });
+
+  it('should return 1 for the identiy matrix',function() {
+    assert.equal(math.det(math.eye(7)), 1);
+    assert.equal(math.det(math.eye(2)), 1);
+    assert.equal(math.det(math.eye(1)), 1);
+  });
+
+  it('should not change the value of the initial matrix', function() {
+    var m_test = [[1,2,3],[4,5,6],[7,8,9]];
+    math.det(m_test);
+    assert.deepEqual(m_test, [[1,2,3],[4,5,6],[7,8,9]]);
+  });
+
+  it('should not accept a non-square matrix', function() {
+    assert.throws(function() { math.det([1,2]); });
+    assert.throws(function() { math.det([[1,2,3],[1,2,3]]); });
+    assert.throws(function() { math.det([0,1],[0,1],[0,1]); });
+  });
+
+  it('should not accept other types than Matrix or Array', function() {
+    assert.throws(function() { math.det(1); });
+    assert.throws(function() { math.det(new BigNumber(10)); });
+    assert.throws(function() { math.det(false); });
+  });
+
+  it('should not accept arrays with dimensions higher than 2', function() {
+    assert.throws(function() { math.det([[[1]]]); });
+    assert.throws(function() { math.det(math.matrix([[[1]]])); });
+  });
+
 
 });


### PR DESCRIPTION
Hi,

I had weird errors using the det function. Sometimes it changed the original matrix to the identiy matrix of the same dimensions and sometimes I got method not found errors for the eye-function.

I now fixed the bug by cloning the input array and prefixing the eye-function with 'math'. I also added a few more tests to improve to code coverage and also account for this case.

Additionally I enforced the input to be Array or Matrix since the determinant only makes sense for this data types (which was also specified in the docstring). 

Best,
Finn
