### PR TITLE
Adds the ifElse function.

### DIFF
--- a/lib/expression/docs/function/utils/ifElse.js
+++ b/lib/expression/docs/function/utils/ifElse.js
@@ -1,0 +1,12 @@
+module.exports = {
+  'name': 'ifElse',
+  'category': 'Utils',
+  'syntax': [
+    'ifElse(conditionalExpr, trueExpr, falseExpr)'
+  ],
+  'description': 'Executes a ternary operation.',
+  'examples': [
+    'ifElse(10 > 0, 10, 0)'
+  ],
+  'seealso': []
+};

--- a/lib/expression/docs/index.js
+++ b/lib/expression/docs/index.js
@@ -119,5 +119,6 @@ exports.map =  require('./function/utils/map');
 exports.forEach =  require('./function/utils/forEach');
 exports.format =  require('./function/utils/format');
 // exports.print =  require('./function/utils/print'); // TODO: add documentation for print as soon as the parser supports objects.
+exports.ifElse =  require('./function/utils/ifElse');
 exports['import'] =  require('./function/utils/import');
 exports['typeof'] =  require('./function/utils/typeof');

--- a/lib/function/utils/ifElse.js
+++ b/lib/function/utils/ifElse.js
@@ -1,0 +1,17 @@
+module.exports = function (math) {
+
+  /**
+   * Executes a ternary operation
+   * @param {*} conditionalExpr           The conditional expression
+   * @param {*} trueExpr                  The true expression
+   * @param {*} falseExpr                 The false expression
+   * @return {*}                          The evaluated return expression
+   */
+  math.ifElse = function ifElse(conditionalExpr, trueExpr, falseExpr) {
+    if (arguments.length != 3) {
+      throw new math.error.ArgumentsError('ifElse', arguments.length, 3);
+    }
+
+    return conditionalExpr ? trueExpr : falseExpr;
+  };
+};

--- a/lib/math.js
+++ b/lib/math.js
@@ -221,6 +221,7 @@ function mathjs (settings) {
   // functions - utils
   require('./function/utils/clone.js')(math, _settings);
   require('./function/utils/format.js')(math, _settings);
+  require('./function/utils/ifElse.js')(math, _settings);
   require('./function/utils/import.js')(math, _settings);
   require('./function/utils/map.js')(math, _settings);
   require('./function/utils/print.js')(math, _settings);

--- a/test/function/utils/ifElse.test.js
+++ b/test/function/utils/ifElse.test.js
@@ -1,0 +1,47 @@
+// test format
+var assert = require('assert'),
+    math = require('../../../index')();
+
+describe('ifElse', function() {
+
+  it('should evaluate to true', function() {
+    assert.equal(math.ifElse(true, 1, 0), 1);
+    assert.equal(math.ifElse(1, 1, 0), 1);
+    assert.equal(math.ifElse({}, 1, 0), 1);
+    assert.equal(math.ifElse(1 > 0, 1, 0), 1);
+    assert.equal(math.ifElse('foo' == 'foo', 1, 0), 1);
+    assert.equal(math.ifElse(10 == 10, 1, 0), 1);
+    assert.equal(math.ifElse(5 == 2 + 3, 1, 0), 1);
+    assert.equal(math.ifElse(true, 'foo', 'bar'), 'foo');
+    assert.equal(math.ifElse(1, 'foo', 'bar'), 'foo');
+    assert.equal(math.ifElse({}, 'foo', 'bar'), 'foo');
+    assert.equal(math.ifElse(1 > 0, 'foo', 'bar'), 'foo');
+    assert.equal(math.ifElse('foo' == 'foo', 'foo', 'bar'), 'foo');
+    assert.equal(math.ifElse(10 == 10, 'foo', 'bar'), 'foo');
+    assert.equal(math.ifElse(5 == 2 + 3, 'foo', 'bar'), 'foo');
+  });
+
+  it('should evaluate to false', function() {
+    assert.equal(math.ifElse(false, 1, 0), 0);
+    assert.equal(math.ifElse(0, 1, 0), 0);
+    assert.equal(math.ifElse(null, 1, 0), 0);
+    assert.equal(math.ifElse(0 > 1, 1, 0), 0);
+    assert.equal(math.ifElse('foo' != 'foo', 1, 0), 0);
+    assert.equal(math.ifElse(10 != 10, 1, 0), 0);
+    assert.equal(math.ifElse(5 != 2 + 3, 1, 0), 0);
+    assert.equal(math.ifElse(false, 'foo', 'bar'), 'bar');
+    assert.equal(math.ifElse(0, 'foo', 'bar'), 'bar');
+    assert.equal(math.ifElse(null, 'foo', 'bar'), 'bar');
+    assert.equal(math.ifElse(0 > 1, 'foo', 'bar'), 'bar');
+    assert.equal(math.ifElse('foo' != 'foo', 'foo', 'bar'), 'bar');
+    assert.equal(math.ifElse(10 != 10, 'foo', 'bar'), 'bar');
+    assert.equal(math.ifElse(5 != 2 + 3, 'foo', 'bar'), 'bar');
+  });
+
+  it('should throw an error if called with invalid number of arguments', function() {
+    assert.throws(function() { math.ifElse(true); });
+    assert.throws(function() { math.ifElse(true, true); });
+    assert.throws(function() { math.ifElse(true, true, true, true); });
+  });
+
+});


### PR DESCRIPTION
This is a utility function for computing ternary operations.  Granted, the same could have been achieved by adding parsing support for '?' & ':' reserved delimiters.

```
var result = ifElse(conditionalExpr, trueExpr, falseExpr);

returns conditionalExpr ? trueExpr : falseExpr;
```

Very simple.  Only throws missing/excessive argument exception.  Added lots of tests.

Relevant to Bug #116, could be a fix for it as well.  
