### PR TITLE
Add support for polar coordinates in complex numbers

### DIFF
--- a/lib/function/construction/complex.js
+++ b/lib/function/construction/complex.js
@@ -26,6 +26,10 @@ module.exports = function (math) {
    *     complex(array : Array)              converts the elements of the array
    *                                         or matrix element wise into a
    *                                         complex value.
+   *     complex({re: number, im: number})   creates a complex value with provided
+   *                                         values for real an imaginary part.
+   *     complex({r: number, phi: number})   creates a complex value with provided
+   *                                         polar coordinates
    *
    * Example usage:
    *     var a = math.complex(3, -4);     // 3 - 4i
@@ -76,12 +80,15 @@ module.exports = function (math) {
           return collection.deepMap(arg, complex);
         }
 
-        if(typeof arg === 'object' && 'r' in arg && 'phi' in arg) {
-          // polar coordinates
-          return Complex.fromPolar(arg.r, arg.phi);
-        }
+        if (typeof arg === 'object') {
+          if('re' in arg && 'im' in arg) {
+            return new Complex(arg.re, arg.im);
+          } else if ('r' in arg && 'phi' in arg) {
+            return Complex.fromPolar(arg.r, arg.phi);
+          }
+        } 
 
-        throw new TypeError('Two numbers or a single string expected in function complex');
+        throw new TypeError('Two numbers, single string or an fitting object expected in function complex');
 
       case 2:
         // re and im provided

--- a/lib/type/Complex.js
+++ b/lib/type/Complex.js
@@ -36,6 +36,23 @@ function Complex(re, im) {
       this.im = 0;
       break;
 
+    case 1:
+      var arg = arguments[0];
+      if (typeof arg === 'object') {
+        if('re' in arg && 'im' in arg) {
+          var construct = new Complex(arg.re, arg.im); // pass on input validation
+          this.re = construct.re;
+          this.im = construct.im;
+          break;
+        } else if ('r' in arg && 'phi' in arg) {
+          var construct = Complex.fromPolar(arg.r, arg.phi);
+          this.re = construct.re;
+          this.im = construct.im;
+          break;
+        }
+      } 
+      throw new SyntaxError('Object with the re and im or r and phi properties expected.');
+
     case 2:
       if (!isNumber(re) || !isNumber(im)) {
         throw new TypeError('Two numbers expected in Complex constructor');
@@ -45,7 +62,7 @@ function Complex(re, im) {
       break;
 
     default:
-      throw new SyntaxError('Two or zero arguments expected in Complex constructor');
+      throw new SyntaxError('One, two or three arguments expected in Complex constructor');
   }
 }
 
@@ -311,7 +328,7 @@ Complex.fromPolar = function fromPolar(args) {
 Complex.prototype.toPolar = function() {
   var polar = {};
   polar.r = math.sqrt(math.add(math.square(this.re), math.square(this.im)));
-  polar.phi = math.atan2(this.im, this.re);
+  polar.phi = math.arg(this);
   return polar;
 };
 

--- a/test/function/construction/complex.test.js
+++ b/test/function/construction/complex.test.js
@@ -44,6 +44,10 @@ describe('complex', function() {
     assert.deepEqual(polar, new math.type.Complex.fromPolar(1, 1));
   });
 
+  it('should accept an object with im and re as keys', function() {
+    assert.deepEqual(complex({re: 1, im: 2}), new math.type.Complex(1, 2));
+  });
+
   it('should throw an error if called with a string', function() {
     assert.throws(function () {complex('no valid complex number')}, SyntaxError);
   });

--- a/test/type/Complex.test.js
+++ b/test/type/Complex.test.js
@@ -36,6 +36,14 @@ describe('Complex', function () {
       assert.throws(function () { Complex(3, -4); });
     });
 
+    it('should accept an object with im and re as keys', function() {
+      assertComplex(new Complex({re: 1, im: 2}), 1, 2);
+    });
+
+    it('should accept an object with polar coordinates like fromPolar', function() {
+      assert.deepEqual(new Complex({r: 3, phi: 4}), Complex.fromPolar(3, 4));
+    });
+
   });
 
   describe('toString', function() {
@@ -210,7 +218,25 @@ describe('Complex', function () {
       assert.equal(fromDeg.im, 1);
       assert.equal(fromGrad.im, 1);
       assert.equal(fromRad.im, 0);
+    });
 
+    it('should only accept an object with r and phi keys for 1 argument', function() {
+      assert.throws(function() { Complex.fromPolar({}) }, TypeError);
+      assert.throws(function() { Complex.fromPolar({r: 1}) }, TypeError);
+      assert.throws(function() { Complex.fromPolar({phi: 1}) }, TypeError);
+      assert.throws(function() { Complex.fromPolar("") }, TypeError);
+    });
+
+    it('should only accept a number as r', function() {
+      assert.throws(function() { Complex.fromPolar("1", 0); });
+      assert.throws(function() { Complex.fromPolar(true, 0); });
+      assert.throws(function() { Complex.fromPolar({}, 0); });
+    });
+
+    it('should only accept units and numbers as phi', function() {
+      assert.throws(function() { Complex.fromPolar(1, "1")});
+      assert.throws(function() { Complex.fromPolar(1, true)});
+      assert.throws(function() { Complex.fromPolar(1, {})});
     });
   });
 


### PR DESCRIPTION
Okay I now implemented the most basic stuff discussed in #76.

Here are the API parts I used:

``` javascript
Complex.fromPolar(r, phi) // returns Complex
Complex.fromPolar({phi: [Number | Unit/Angle], r: Number}) // returns Complex
(new Complex()).toPolar() // returns {phi: Number, r: Number}

math.complex(({phi: [Number | Unit/Angle], r: Number}) // returns Complex
math.complex({re: Number | im: Number}) // return Complex

// Similar to math.complex also the constructor can be used 
new Complex(({phi: [Number | Unit/Angle], r: Number})
new Complex({re: Number | im: Number}) 
```

I didn't implement `math.polar`, because I thought it might be confusing since polar coordinates don't have to be complex numbers. 

What's missing is that there is no string parser yet. Otherwise I think this fixes #76 and basically also #22.
