### PR TITLE
Implement poly-time determinant without divisions.

### DIFF
--- a/lib/function/matrix/det.js
+++ b/lib/function/matrix/det.js
@@ -91,63 +91,38 @@ module.exports = function (math) {
     else {
       // this is an n x n matrix
       // TODO: support for bignumbers, complex numbers, etc
-      var a;
-      var d = 1;
-      var lead = 0;
-      for (var r = 0; r < rows; r++) {
-        if (lead >= cols) {
-          break;
+      function compute_mu(matrix) {
+        // Compute the matrix with zero lower triangle, same upper triangle,
+        // and diagonals given by the negated sum of the below diagonal
+        // elements.
+        var mu = new Array(matrix.length);
+        var sum = 0;
+        for (var i = 1; i < matrix.length; i++) {
+          sum += matrix[i][i];
         }
-        var i = r;
-        // Find the pivot element.
-        while (matrix[i][lead] == 0) {
-          i++;
-          if (i == rows) {
-            i = r;
-            lead++;
-            if (lead == cols) {
-              // We found the last pivot.
-              if (object.deepEqual(matrix, math.eye(rows).valueOf())) {
-                return math.round(d, 6); // FIXME: should d be rounded to 6 here?
-              } else {
-                return 0;
-              }
-            }
+        for (var i = 0; i < matrix.length; i++) {
+          mu[i] = new Array(matrix.length);
+          mu[i][i] = -sum;
+          for (var j = 0; j < i; j++) {
+            mu[i][j] = 0;
+          }
+          for (var j = i+1; j < matrix.length; j++) {
+            mu[i][j] = matrix[i][j];
+          }
+          if (i+1 < matrix.length) {
+            sum -= matrix[i+1][i+1];
           }
         }
-        if (i != r) {
-          // Swap rows i and r, which negates the determinant.
-          for (a = 0; a < cols; a++) {
-            var temp = matrix[i][a];
-            matrix[i][a] = matrix[r][a];
-            matrix[r][a] = temp;
-          }
-          d *= -1;
-        }
-        // Scale row r and the determinant simultaneously.
-        var div = matrix[r][lead];
-        for (a = 0; a < cols; a++) {
-          matrix[r][a] = matrix[r][a] / div;
-        }
-        d *= div;
-        // Back-substitute upwards.
-        for (var j = 0; j < rows; j++) {
-          if (j != r) {
-            // Taking linear combinations does not change the det.
-            var c = matrix[j][lead];
-            for (a = 0; a < cols; a++) {
-              matrix[j][a] = matrix[j][a] - matrix[r][a] * c;
-            }
-          }
-        }
-        lead++; // Now looking for a pivot further right.
+        return mu;
       }
-
-      // If reduction did not result in the identity, the matrix is singular.
-      if (object.deepEqual(matrix, math.eye(rows).valueOf())) {
-        return math.round(d, 6); // FIXME: should d be rounded to 6 here?
+      var fa = matrix;
+      for (var i = 0; i < rows-1; i++) {
+        fa = math.multiply(compute_mu(fa), matrix);
+      }
+      if (rows % 2 == 0) {
+        return -fa[0][0];
       } else {
-        return 0;
+        return fa[0][0];
       }
     }
   }


### PR DESCRIPTION
This is an implementation of det that runs in O(n^4) time and does not use any divisions, eliminating the rounding issues. While the time complexity has regressed from O(n^3), there is no longer a need for rounding, and the implementation is now amenable to matrices over rings, i.e. matrices whose entries are polynomials, other matrices, etc. (There is currently no known determinant algorithm in O(n^3) which does not use divisions. It's theoretically possible to get it down to O(n^3.188) but this is a lot more complicated).

This is based on the paper 'A Simple Division-Free Algorithm for Computing Determinants' (Bird 2011), which can be found at http://www.sciencedirect.com/science/article/pii/S0020019011002353
