### PR TITLE
Missing separator in error message when multiplying

### DIFF
--- a/lib/function/arithmetic/multiply.js
+++ b/lib/function/arithmetic/multiply.js
@@ -135,7 +135,7 @@ module.exports = function(math) {
               throw new RangeError('Dimension mismatch in multiplication. ' +
                   'Length of A must match length of B ' +
                   '(A is ' + sizeX[0] +
-                  ', B is ' + sizeY[0] +
+                  ', B is ' + sizeY[0] + ', ' +
                   sizeX[0] + ' != ' + sizeY[0] + ')');
             }
 


### PR DESCRIPTION
```
[1,2,3]*[4,5]
RangeError: Dimension mismatch in multiplication. Length of A must match length of B (A is 3, B is 23 != 2)
```

The error message is missing a comma.
