### PR TITLE
Fix sech example

### DIFF
--- a/lib/function/trigonometry/sech.js
+++ b/lib/function/trigonometry/sech.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    *    // sech(x) = 1/ cosh(x)
    *    math.sech(0.5);       // returns 0.886818883970074
-   *    1 / math.cosh(0.5);   // returns 1.9190347513349437
+   *    1 / math.cosh(0.5);   // returns 0.886818883970074
    *
    * See also:
    *


### PR DESCRIPTION
Since:

```
sech(x) = 1 / cosh(x)
```

Surely these two expressions should both return `0.886818883970074`.

I'm not sure if I should rebuild `docs/`.