### PR TITLE
BigNumber Trigonometry

### DIFF
--- a/lib/function/trigonometry/acos.js
+++ b/lib/function/trigonometry/acos.js
@@ -12,7 +12,7 @@ module.exports = function (math) {
       isComplex = Complex.isComplex,
       isCollection = collection.isCollection,
 
-      bigArcCos = util.bignumber.acos;
+      bigArcCos = util.bignumber.arccos;
 
   /**
    * Calculate the inverse cosine of a value.

--- a/lib/function/trigonometry/acos.js
+++ b/lib/function/trigonometry/acos.js
@@ -10,7 +10,9 @@ module.exports = function (math) {
       isNumber = util.number.isNumber,
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigArcCos = util.bignumber.acos;
 
   /**
    * Calculate the inverse cosine of a value.
@@ -78,9 +80,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return acos(x.toNumber());
+      return bigArcCos(x);
     }
 
     throw new math.error.UnsupportedTypeError('acos', math['typeof'](x));

--- a/lib/function/trigonometry/asin.js
+++ b/lib/function/trigonometry/asin.js
@@ -10,7 +10,9 @@ module.exports = function (math) {
       isNumber = util.number.isNumber,
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigArcSin = util.bignumber.asin;
 
   /**
    * Calculate the inverse sine of a value.
@@ -76,9 +78,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return asin(x.toNumber());
+      return bigArcSin(x);
     }
 
     throw new math.error.UnsupportedTypeError('asin', math['typeof'](x));

--- a/lib/function/trigonometry/asin.js
+++ b/lib/function/trigonometry/asin.js
@@ -12,7 +12,7 @@ module.exports = function (math) {
       isComplex = Complex.isComplex,
       isCollection = collection.isCollection,
 
-      bigArcSin = util.bignumber.asin;
+      bigArcSin = util.bignumber.arcsin;
 
   /**
    * Calculate the inverse sine of a value.

--- a/lib/function/trigonometry/atan.js
+++ b/lib/function/trigonometry/atan.js
@@ -10,8 +10,9 @@ module.exports = function (math) {
       isNumber = util.number.isNumber,
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
 
+      bigArcTan = util.bignumber.arctan(x);
   /**
    * Calculate the inverse tangent of a value.
    *
@@ -73,7 +74,7 @@ module.exports = function (math) {
     if (x instanceof BigNumber) {
       // TODO: implement BigNumber support
       // downgrade to Number
-      return atan(x.toNumber());
+      return bigArcTan(x);
     }
 
     throw new math.error.UnsupportedTypeError('atan', math['typeof'](x));

--- a/lib/function/trigonometry/atan.js
+++ b/lib/function/trigonometry/atan.js
@@ -12,7 +12,8 @@ module.exports = function (math) {
       isComplex = Complex.isComplex,
       isCollection = collection.isCollection,
 
-      bigArcTan = util.bignumber.arctan(x);
+      bigArcTan = util.bignumber.arctan;
+
   /**
    * Calculate the inverse tangent of a value.
    *
@@ -72,8 +73,6 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
       return bigArcTan(x);
     }
 

--- a/lib/function/trigonometry/cosh.js
+++ b/lib/function/trigonometry/cosh.js
@@ -68,7 +68,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-    1 return bigCosh(x, 0);
+      return bigCosh(x, 0);
     }
 
     throw new math.error.UnsupportedTypeError('cosh', math['typeof'](x));

--- a/lib/function/trigonometry/cosh.js
+++ b/lib/function/trigonometry/cosh.js
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigCosh = util.bignumber.cosh_sinh;
 
   /**
    * Calculate the hyperbolic cosine of a value,
@@ -66,9 +68,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return cosh(x.toNumber());
+    1 return bigCosh(x, 0);
     }
 
     throw new math.error.UnsupportedTypeError('cosh', math['typeof'](x));

--- a/lib/function/trigonometry/sinh.js
+++ b/lib/function/trigonometry/sinh.js
@@ -74,7 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCosh(x, 1);
+      return bigSinh(x, 1);
     }
 
     throw new math.error.UnsupportedTypeError('sinh', math['typeof'](x));

--- a/lib/function/trigonometry/sinh.js
+++ b/lib/function/trigonometry/sinh.js
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigSinh = util.bignumber.cosh_sinh;
 
   /**
    * Calculate the hyperbolic sine of a value,
@@ -72,9 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return sinh(x.toNumber());
+      return bigCosh(x, 1);
     }
 
     throw new math.error.UnsupportedTypeError('sinh', math['typeof'](x));

--- a/lib/function/trigonometry/tan.js
+++ b/lib/function/trigonometry/tan.js
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigTan = util.bignumber.tan;
 
   /**
    * Calculate the tangent of a value. `tan(x)` is equal to `sin(x) / cos(x)`.
@@ -73,9 +75,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return tan(x.toNumber());
+      return bigTan(x, config.precision);
     }
 
     throw new math.error.UnsupportedTypeError('tan', math['typeof'](x));

--- a/lib/function/trigonometry/tan.js
+++ b/lib/function/trigonometry/tan.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (math) {
+module.exports = function (math, config) {
   var util = require('../../util/index'),
 
       BigNumber = math.type.BigNumber,

--- a/lib/function/trigonometry/tanh.js
+++ b/lib/function/trigonometry/tanh.js
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigTanh = util.bignumber.tanh;
 
   /**
    * Calculate the hyperbolic tangent of a value,
@@ -75,9 +77,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return tanh(x.toNumber());
+      return bigTanh(x);
     }
 
     throw new math.error.UnsupportedTypeError('tanh', math['typeof'](x));

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -52,8 +52,8 @@ exports.phi = memoize(function (precision) {
 exports.pi = memoize(function (precision) {
   // we calculate pi with a few decimal places extra to prevent round off issues
   var Big = BigNumber.constructor({precision: precision + 4});
-  var pi4th = new Big(4).times(exports.arctan(new Big(1).div(5)))
-      .minus(exports.arctan(new Big(1).div(239)));
+  var pi4th = new Big(4).times(arctan_taylor(new Big(1).div(5)))
+      .minus(arctan_taylor(new Big(1).div(239)));
 
   Big.config({precision: precision});
 
@@ -484,31 +484,150 @@ function decCoefficientToBinaryString(x) {
  *************************************/
 
 /**
- * Calculate the arc tangent of x
+ * Calculate the arc cosine of x
  *
- * arctan(x) = x - x^3/3 + x^5/5 - x^7/7 + x^9/9 - ...
- *           = x - x^2*x^1/3 + x^2*x^3/5 - x^2*x^5/7 + x^2*x^7/9 - ...
+ * acos(x) = pi/2 - asin(x)
+ *
+ * @param {BigNumber} x
+ * @returns {BigNumber} arc cosine of x
+ */
+exports.arccos = function(x) {
+  var precision = x.constructor.precision;
+  var acos = exports.pi(precision + 4).div(2).minus(exports.arcsin(x));
+
+  acos.constructor.config({precision: precision});
+  return acos.toDP(precision);
+};
+
+/**
+ * Calculate the arc sine of x using Newton's method
+ *
+ * f(x) = sin(x) = N  =>  f(x)  = sin(x) - N
+ *                        f'(x) = cos(x)
+ *
+ * Thus we solve each step as follows:
+ *     x_(i+1) = x_i - (sin(x_i) - N)/cos(x_i)
+ *
+ * @param {BigNumber} x
+ * @returns {BigNumber} arc sine of x
+ */
+exports.arcsin = function(x) {
+  if (x.isNaN()) {
+    return new x.constructor(NaN);
+  }
+  if (x.isZero()) {
+    return new x.constructor(0);
+  }
+
+  if (x.gt(1)) {
+    throw new Error('arcsin() only has non-complex values for |x| <= 1.');
+  }
+
+  var Big;
+  var oldPrecision = x.constructor.precision;
+  // Get x to ~0.5
+  if (x.gt('0.864')) {
+    Big = x.constructor;
+    Big.config({precision: oldPrecision + 2});
+
+    // arcsin(x) = sign(x)*(Pi/2 - arcsin(sqrt(1 - x^2)))
+    var sign = x.s;
+    var halfPi = exports.pi(oldPrecision + 2).div(2);
+    x = halfPi.minus(exports.arcsin(Big.ONE.minus(x.times(x))));
+    x.s = sign;
+
+    Big.config({precision: oldPrecision});
+    return x.toDP(oldPrecision - 1);
+  }
+
+  if (x.gt('0.505')) {
+    Big = x.constructor;
+    Big.config({precision: oldPrecision + 8});
+
+    // arcsin(x) = 2*arcsin(x / (sqrt(2)*sqrt(sqrt(1 - x^2) + 1)))
+    x = x.div(new Big(2).sqrt().times(Big.ONE.minus(x.times(x)).sqrt()
+          .plus(Big.ONE).sqrt()));
+
+    Big.config({precision: oldPrecision});
+
+    return new Big(2).times(exports.arcsin(x));
+  }
+
+  // Calibration variables, adjusted from MAPM.
+  var tolerance = -(oldPrecision + 4);
+  var maxp = oldPrecision + 8 - x.e;
+  var localPrecision = 25 - x.e;
+  var maxIter = Math.max(Math.log(oldPrecision + 2) * 1.442695 | 0 + 5, 5);
+
+  Big = BigNumber.constructor({precision: oldPrecision});
+  var curr = new Big(Math.asin(x.toNumber()) + '');
+
+  var i = 0;
+  var tmp0, tmp1, tmp2;
+  do {
+    tmp0 = exports.cos_sin(curr, localPrecision, 1);
+    tmp1 = sin_cos_swap(tmp0);
+    if (!tmp0.isZero()) {
+      tmp0.s = curr.s;
+    }
+
+    tmp2 = tmp0.minus(x).div(tmp1);
+    curr = curr.minus(tmp2);
+
+    localPrecision = Math.min(2*localPrecision, maxp);
+    Big.config({precision: localPrecision});
+  } while ((2*tmp2.e >= tolerance) && !tmp2.isZero() && (++i <= maxIter))
+
+  if (i == maxIter) {
+    throw new Error('arcsin() failed to converge to the requested accuracy.' +
+                    'Try with a higher precision.');
+  }
+
+  Big.config({precision: oldPrecision});
+  return curr.toDP(oldPrecision - 1);
+};
+
+/**
+ * Calculate the arc tangent of x using a variety of methods.
+ * Inspired by MAPM and Michael C. Ring.
  *
  * @param {BigNumber} x
  * @returns {BigNumber} arc tangent of x
  */
 exports.arctan = function (x) {
-  var y = x;
-  var yPrev = NaN;
-  var x2 = x.times(x);
-  var num = x;
-  var add = true;
-
-  for (var k = 3; !y.equals(yPrev); k += 2) {
-    num = num.times(x2);
-
-    yPrev = y;
-    add = !add;
-    y = (add) ? y.plus(num.div(k)) : y.minus(num.div(k));
+  var Big = x.constructor;
+  if (x.isNaN()) {
+    return new Big(NaN);
+  }
+  if (x.isZero()) {
+    return new Big(0);
   }
 
-  return y;
-}
+  if (x.e <= -4) {
+    return arctan_taylor(x);
+  }
+  var precision = Big.precision;
+  if (x.e >= 4) {
+    Big.config({precision: precision + 4});
+
+    // arctan(x) = (PI / 2) - arctan(1 / |x|)
+    var halfPi = exports.pi(precision + 4).div(2);
+    var ret = halfPi.minus(arctan_taylor(Big.ONE.div(x.abs())));
+    ret.s = x.s;
+
+    Big.config({precision: precision});
+    ret.constructor.config({precision: precision});
+    console.log(Big == ret.consructor);
+    return ret.toDP(Big.precision - 1);
+  }
+
+  // arctan(x) = arcsin(x / [sqrt(1 + x^2)])
+  Big.config({precision: precision + 4});
+  x = x.div(x.times(x).plus(1).sqrt());
+  Big.config({precision: precision});
+
+  return exports.arcsin(x);
+};
 
 /**
  * Calculate cosine/sine of x using the multiple angle identity:
@@ -519,7 +638,8 @@ exports.arctan = function (x) {
  * http://www.tc.umn.edu/~ringx004/sidebar.html
  *
  * @param {BigNumber} x
- * @param {Number} mode     sine function if 1, cosine function if 0
+ * @param {Number} precision    precision as defined in the config file
+ * @param {Number} mode         sine function if 1, cosine function if 0
  * @returns {BigNumber} sine or cosine of x
  */
 exports.cos_sin = function (x, precision, mode) {
@@ -584,6 +704,111 @@ exports.cos_sin = function (x, precision, mode) {
   ret.constructor.config({precision: precision});
   return ret.toDP(precision - 1);
 };
+
+/**
+ * Calculate the tangent of x
+ *
+ * tan(x) = sin(x) / cos(x)
+ *
+ * @param {BigNumber} x
+ * @param {Number} precision    precision as defined in the config file
+ * @returns {BigNumber} tangent of x
+ */
+exports.tan = function (x, precision) {
+  var sin = exports.sin(x, precision, 1);
+  var cos = sin_cos_swap(sin);
+  
+  sin.constructor.config({precision: precision + 4});
+  var tan = sin.div(cos);
+  tan.constructor.config({precision: precision});
+
+  return tan;
+};
+
+/**
+ * Calculate the hyperbolic cosine/sine of x
+ *
+ * cosh(x) = (exp(x) + exp(-x)) / 2
+ *         = (e^x + 1/e^x) / 2
+ *
+ * sinh(x) = (exp(x) - exp(-x)) / 2
+ *         = (e^x - 1/e^x) / 2
+ *
+ * @param {BigNumber} x
+ * @param {Number} mode     cosh function if 0, sinh function if 1
+ * @returns {BigNumber} cosh or sinh of x
+ */
+exports.cosh_sinh = function (x, mode) {
+  var Big = x.constructor;
+  if (x.isNaN()) {
+    return new Big(NaN);
+  }
+
+  var precision = Big.precision;
+  Big.config({precision: precision + 4});
+
+  var y = x.exp();
+  y = (mode) ? y.plus(Big.ONE.div(y)) : y.minus(Big.ONE.div(y));
+  y = y.div(2);
+
+  Big.config({precision: precision});
+  return y.toDP(precision - 1);
+};
+
+/**
+ * Calculate the hyperbolic tangent of x
+ *
+ * tanh(x) = (exp(x) + exp(-x)) / (exp(x) - exp(-x))
+ *         = (exp(2x) - 1) / (exp(2x) + 1)
+ *         = (e^x - 1/e^x) / (e^x + 1/e^x)
+ *
+ * @param {BigNumber} x
+ * @returns {BigNumber} tanh of x
+ */
+exports.tanh = function (x) {
+  var Big = x.constructor;
+  if (x.isNaN()) {
+    return new Big(NaN);
+  }
+
+  var precision = Big.precision;
+  Big.config({precision: precision + 4});
+
+  var posExp = x.exp();
+  var negExp = Big.ONE.div(posExp);
+  var ret = posExp.minus(negExp);
+  ret = ret.div(posExp.plus(negExp));
+
+  Big.config({precision: precision});
+  return ret.toDP(precision - 1);
+};
+
+/**
+ * Calculate the arc tangent of x using a Taylor expansion
+ *
+ * arctan(x) = x - x^3/3 + x^5/5 - x^7/7 + x^9/9 - ...
+ *           = x - x^2*x^1/3 + x^2*x^3/5 - x^2*x^5/7 + x^2*x^7/9 - ...
+ *
+ * @param {BigNumber} x
+ * @returns {BigNumber} arc tangent of x
+ */
+function arctan_taylor(x) {
+  var y = x;
+  var yPrev = NaN;
+  var x2 = x.times(x);
+  var num = x;
+  var add = true;
+
+  for (var k = 3; !y.equals(yPrev); k += 2) {
+    num = num.times(x2);
+
+    yPrev = y;
+    add = !add;
+    y = (add) ? y.plus(num.div(k)) : y.minus(num.div(k));
+  }
+
+  return y;
+}
 
 /**
  * Calculate the cosine or sine of x using Taylor Series.
@@ -663,6 +888,27 @@ function reduceToPeriod(x, precision, mode) {
   }
 
   return [y, false];
+}
+
+/**
+ * Convert between sine and cosine values
+ *
+ * cos(x) = sqrt(1 - sin(x)^2)
+ *
+ * sin(x) = sqrt(1 - cos(x)^2)
+ *
+ * @param {BigNumber} x
+ * @returns {BigNumber} sine as cosine, or cosine as sine
+ */
+function sin_cos_swap(x) {
+  var Big = x.constructor;
+  var precision = Big.precision;
+  Big.config({precision: precision + 4});
+
+  var ret = Big.ONE.minus(x.times(x)).sqrt();
+
+  Big.config({precision: precision});
+  return ret;
 }
 
 

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -4,7 +4,6 @@ var BigNumber = require('decimal.js');
 var isNumber = require('./number').isNumber;
 var digits = require('./number').digits;
 var memoize = require('./function').memoize;
-var external = true;
 
 /**
  * Test whether value is a BigNumber
@@ -533,7 +532,7 @@ exports.arcsin = function (x) {
   var precision = Big.precision;
 
   // Get x below 0.58
-  if (absX.gt('0.8')) {
+  if (absX.gt(0.8)) {
     Big.config({precision: precision + 4});
 
     // arcsin(x) = sign(x)*(Pi/2 - arcsin(sqrt(1 - x^2)))
@@ -547,7 +546,7 @@ exports.arcsin = function (x) {
     return x.toDP(precision - 1);
   }
   var wasReduced;
-  if (wasReduced = absX.gt('0.58')) {
+  if (wasReduced = absX.gt(0.58)) {
     Big.config({precision: precision + 8});
 
     // arcsin(x) = 2*arcsin(x / (sqrt(2)*sqrt(sqrt(1 - x^2) + 1)))
@@ -558,7 +557,7 @@ exports.arcsin = function (x) {
   }
 
   // Avoid overhead of Newton's Method if feasible
-  var ret = (precision <= 60 || ((x.dp() <= Math.log(precision)) && x.lt('0.05')))
+  var ret = (precision <= 60 || ((x.dp() <= Math.log(precision)) && x.lt(0.05)))
     ? arcsin_taylor(x, precision)
     : arcsin_newton(x, precision);
 
@@ -591,7 +590,7 @@ exports.arctan = function (x) {
   }
 
   var absX = x.abs();
-  if (absX.lte('0.875')) {
+  if (absX.lte(0.875)) {
     Big.config({precision: precision + 4});
 
     var ret = arctan_taylor(x);
@@ -600,7 +599,7 @@ exports.arctan = function (x) {
     Big.config({precision: precision});
     return ret.toDP(Big.precision - 1);
   }
-  if (absX.gte('1.143')) {
+  if (absX.gte(1.143)) {
     Big.config({precision: precision + 4});
 
     // arctan(x) = sign(x)*((PI / 2) - arctan(1 / |x|))
@@ -642,9 +641,8 @@ exports.cos_sin = function (x, precision, mode) {
   }
 
   // Avoid changing the original value
-  Big = BigNumber.constructor({precision: x.constructor.precision});
-  var y = new Big(x);
-  y.constructor = Big;                     // Not sure why I have to do this...
+  var y = BigNumberCopy(x);
+  Big = y.constructor;
 
   // sin(-x) == -sin(x), cos(-x) == cos(x)
   var isNeg = y.isNegative();
@@ -652,14 +650,18 @@ exports.cos_sin = function (x, precision, mode) {
     y.s = -y.s;
   }
 
-  y = reduceToPeriod(y, precision, mode);  // Make this destructive
+  // Apply ~log(precision) guard bits
+  var precPlusGuardDigits = precision + (Math.log(precision) | 0) + 3; 
+  Big.config({precision: precPlusGuardDigits});
+
+  y = reduceToPeriod(y, precPlusGuardDigits, mode);  // Make this destructive
   if (y[1]) {
+    Big.config({precision: precision});
     return y[0];
   }
 
   var ret;
   y = y[0];
-  Big = y.constructor;
   if (mode) {
     ret = cos_sin_taylor(y.div(3125), mode);
     Big.config({precision: Math.min(Big.precision, precision + 15)});
@@ -719,25 +721,32 @@ exports.tan = function (x, precision) {
     return new Big(NaN);
   }
 
+  var pi = exports.pi(precision + 2);
+  var halfPi = pi.div(2).toDP(precision - 1);
+  pi = pi.toDP(precision - 1);
+
   var y = reduceToPeriod(x, precision, 1)[0];
-  var pi = exports.pi(precision + 4);
-  if (y.abs().eq(pi.toDP(precision))) {
+  if (y.abs().eq(pi)) {
     return new Big(Infinity);
   }
 
-  var sin = exports.cos_sin(y, precision + 4, 1);
+  var sin = exports.cos_sin(y, precision + 2, 1);
   var cos = sinToCos(sin);
+
+  sin.constructor.config({precision: precision});
+  sin = sin.toDP(precision);
+  cos = cos.toDP(precision);
 
   // Make sure sign for cosine is correct
   if (y.eq(x)) {
-    if (y.gt(pi.div(2).toDP(precision))) {
+    if (y.gt(halfPi)) {
       cos.s = -cos.s;
     }
-  } else if (pi.minus(y.abs()).gt(pi.div(2))) {
+  } else if (pi.minus(y.abs()).gt(halfPi)) {
     cos.s = -cos.s;
   }
 
-  sin.constructor.config({precision: precision + 4});
+  sin.constructor.config({precision: precision + 2});
   var tan = sin.div(cos);
 
   return new Big(tan.toPrecision(precision));
@@ -792,7 +801,7 @@ exports.tanh = function (x) {
     return new Big(NaN);
   }
   if (!x.isFinite()) {
-    return new Big(x.isNegative() ? -1 : 1);
+    return new Big(x.s);
   }
 
   var precision = Big.precision;
@@ -963,30 +972,19 @@ function cos_sin_taylor(x, mode) {
  * @returns {Array} [Reduced x, is tau multiple?]
  */
 function reduceToPeriod(x, precision, mode) {
-  var Big = x.constructor;
-  var xPrecision = Big.precision
-  var prec_plus_guard_digits = precision + (Math.log(precision) | 0) + 3;
-  Big.config({precision: prec_plus_guard_digits});
-
-  var y;
-  var pi = exports.pi(prec_plus_guard_digits + 2);
-  var tau = exports.tau(prec_plus_guard_digits);
-  if (x.abs().lte(pi)) {
-    y = new Big(x);
-    y.constructor = BigNumber.constructor({precision: prec_plus_guard_digits});
-    Big.config({precision: xPrecision});
-    return [y, false];
+  var pi = exports.pi(precision + 2);
+  var tau = exports.tau(precision);
+  if (x.abs().lte(pi.toDP(x.dp()))) {
+    return [x, false];
   }
 
+  var Big = x.constructor;
   // Catch if input is tau multiple using pi's precision
-  if (x.div(pi.toDP(x.dp(), 1)).toNumber() % 2 == 0) {
-    Big.config({precision: precision});
+  if (x.div(pi.toDP(x.dp())).toNumber() % 2 == 0) {
     return [new Big(mode ^ 1), true];
   }
 
-  y = x.mod(tau);
-  y.constructor = BigNumber.constructor({precision: prec_plus_guard_digits});
-  Big.config({precision: xPrecision});
+  var y = x.mod(tau);
 
   // Catch if tau multiple with tau's precision
   if (y.toDP(x.dp(), 1).isZero()) {
@@ -1004,11 +1002,12 @@ function reduceToPeriod(x, precision, mode) {
     }
   }
 
+  y.constructor = Big;
   return [y, false];
 }
 
 /**
- * Convert from cosine to sine
+ * Convert from sine to cosine
  *
  * |cos(x)| = sqrt(1 - sin(x)^2)
  *
@@ -1018,7 +1017,7 @@ function reduceToPeriod(x, precision, mode) {
 function sinToCos(sinVal) {
   var Big = sinVal.constructor;
   var precision = Big.precision;
-  Big.config({precision: precision + 4});
+  Big.config({precision: precision + 2});
 
   var ret = Big.ONE.minus(sinVal.times(sinVal)).sqrt();
 
@@ -1214,3 +1213,12 @@ exports.toFixed = function(value, precision) {
   // Note: the (precision || 0) is needed as the toFixed of BigNumber has an
   // undefined default precision instead of 0.
 };
+
+/* Helper functions */
+function BigNumberCopy(x) {
+  var Big = BigNumber.constructor({precision: x.constructor.precision});
+  var y = new Big(x);
+  y.constructor = Big;      // Not sure why I have to do this...
+
+  return y;
+}

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -4,6 +4,7 @@ var BigNumber = require('decimal.js');
 var isNumber = require('./number').isNumber;
 var digits = require('./number').digits;
 var memoize = require('./function').memoize;
+var external = true;
 
 /**
  * Test whether value is a BigNumber
@@ -486,110 +487,89 @@ function decCoefficientToBinaryString(x) {
 /**
  * Calculate the arc cosine of x
  *
- * acos(x) = pi/2 - asin(x)
+ * acos(x) = 2*atan(sqrt(1-x^2)/(1+x))
  *
  * @param {BigNumber} x
  * @returns {BigNumber} arc cosine of x
  */
-exports.arccos = function(x) {
-  var precision = x.constructor.precision;
-  var acos = exports.pi(precision + 4).div(2).minus(exports.arcsin(x));
+exports.arccos = function (x) {
+  var Big = x.constructor;
+  var precision = Big.precision;
+  if (x.abs().gt(Big.ONE)) {
+    throw new Error('acos() only has non-complex values for |x| <= 1.');
+  }
+  if (x.eq(-1)) {
+    return exports.pi(precision);
+  }
 
-  acos.constructor.config({precision: precision});
-  return acos.toDP(precision);
+  Big.config({precision: precision + 4});
+  var acos = exports.arctan(Big.ONE.minus(x.times(x)).sqrt()
+                                .div(x.plus(Big.ONE))).times(2);
+  Big.config({precision: precision});
+
+  return acos.toDP(precision - 1);
 };
 
 /**
- * Calculate the arc sine of x using Newton's method
- *
- * f(x) = sin(x) = N  =>  f(x)  = sin(x) - N
- *                        f'(x) = cos(x)
- *
- * Thus we solve each step as follows:
- *     x_(i+1) = x_i - (sin(x_i) - N)/cos(x_i)
+ * Calculate the arc sine of x
  *
  * @param {BigNumber} x
  * @returns {BigNumber} arc sine of x
  */
-exports.arcsin = function(x) {
+exports.arcsin = function (x) {
+  var Big = x.constructor;
   if (x.isNaN()) {
-    return new x.constructor(NaN);
+    return new Big(NaN);
   }
   if (x.isZero()) {
-    return new x.constructor(0);
+    return new Big(0);
   }
 
-  if (x.gt(1)) {
-    throw new Error('arcsin() only has non-complex values for |x| <= 1.');
+  var absX = x.abs();
+  if (absX.gt(1)) {
+    throw new Error('asin() only has non-complex values for |x| <= 1.');
   }
 
-  var Big;
-  var oldPrecision = x.constructor.precision;
-  // Get x to ~0.5
-  if (x.gt('0.864')) {
-    Big = x.constructor;
-    Big.config({precision: oldPrecision + 2});
+  var precision = Big.precision;
+
+  // Get x below 0.58
+  if (absX.gt('0.8')) {
+    Big.config({precision: precision + 4});
 
     // arcsin(x) = sign(x)*(Pi/2 - arcsin(sqrt(1 - x^2)))
     var sign = x.s;
-    var halfPi = exports.pi(oldPrecision + 2).div(2);
-    x = halfPi.minus(exports.arcsin(Big.ONE.minus(x.times(x))));
+    var halfPi = exports.pi(precision + 4).div(2);
+    x = halfPi.minus(exports.arcsin(Big.ONE.minus(x.times(x)).sqrt()));
     x.s = sign;
 
-    Big.config({precision: oldPrecision});
-    return x.toDP(oldPrecision - 1);
+    x.constructor = Big;
+    Big.config({precision: precision});
+    return x.toDP(precision - 1);
   }
-
-  if (x.gt('0.505')) {
-    Big = x.constructor;
-    Big.config({precision: oldPrecision + 8});
+  var wasReduced;
+  if (wasReduced = absX.gt('0.58')) {
+    Big.config({precision: precision + 8});
 
     // arcsin(x) = 2*arcsin(x / (sqrt(2)*sqrt(sqrt(1 - x^2) + 1)))
     x = x.div(new Big(2).sqrt().times(Big.ONE.minus(x.times(x)).sqrt()
           .plus(Big.ONE).sqrt()));
 
-    Big.config({precision: oldPrecision});
-
-    return new Big(2).times(exports.arcsin(x));
+    Big.config({precision: precision});
   }
 
-  // Calibration variables, adjusted from MAPM.
-  var tolerance = -(oldPrecision + 4);
-  var maxp = oldPrecision + 8 - x.e;
-  var localPrecision = 25 - x.e;
-  var maxIter = Math.max(Math.log(oldPrecision + 2) * 1.442695 | 0 + 5, 5);
+  // Avoid overhead of Newton's Method if feasible
+  var ret = (precision <= 60 || ((x.dp() <= Math.log(precision)) && x.lt('0.05')))
+    ? arcsin_taylor(x, precision)
+    : arcsin_newton(x, precision);
 
-  Big = BigNumber.constructor({precision: oldPrecision});
-  var curr = new Big(Math.asin(x.toNumber()) + '');
-
-  var i = 0;
-  var tmp0, tmp1, tmp2;
-  do {
-    tmp0 = exports.cos_sin(curr, localPrecision, 1);
-    tmp1 = sin_cos_swap(tmp0);
-    if (!tmp0.isZero()) {
-      tmp0.s = curr.s;
-    }
-
-    tmp2 = tmp0.minus(x).div(tmp1);
-    curr = curr.minus(tmp2);
-
-    localPrecision = Math.min(2*localPrecision, maxp);
-    Big.config({precision: localPrecision});
-  } while ((2*tmp2.e >= tolerance) && !tmp2.isZero() && (++i <= maxIter))
-
-  if (i == maxIter) {
-    throw new Error('arcsin() failed to converge to the requested accuracy.' +
-                    'Try with a higher precision.');
+  if (wasReduced) {
+    return ret.times(2);
   }
-
-  Big.config({precision: oldPrecision});
-  return curr.toDP(oldPrecision - 1);
+  return ret;
 };
 
 /**
- * Calculate the arc tangent of x using a variety of methods.
- * Inspired by MAPM and Michael C. Ring.
+ * Calculate the arc tangent of x
  *
  * @param {BigNumber} x
  * @returns {BigNumber} arc tangent of x
@@ -602,22 +582,34 @@ exports.arctan = function (x) {
   if (x.isZero()) {
     return new Big(0);
   }
-
-  if (x.e <= -4) {
-    return arctan_taylor(x);
-  }
   var precision = Big.precision;
-  if (x.e >= 4) {
+  if (!x.isFinite()) {
+    var halfPi = exports.pi(precision + 2).div(2).toDP(precision - 1);
+    halfPi.s = x.s;
+
+    return halfPi;
+  }
+
+  var absX = x.abs();
+  if (absX.lte('0.875')) {
     Big.config({precision: precision + 4});
 
-    // arctan(x) = (PI / 2) - arctan(1 / |x|)
+    var ret = arctan_taylor(x);
+
+    ret.constructor = Big;
+    Big.config({precision: precision});
+    return ret.toDP(Big.precision - 1);
+  }
+  if (absX.gte('1.143')) {
+    Big.config({precision: precision + 4});
+
+    // arctan(x) = sign(x)*((PI / 2) - arctan(1 / |x|))
     var halfPi = exports.pi(precision + 4).div(2);
-    var ret = halfPi.minus(arctan_taylor(Big.ONE.div(x.abs())));
+    var ret = halfPi.minus(arctan_taylor(Big.ONE.div(absX)));
     ret.s = x.s;
 
+    ret.constructor = Big;
     Big.config({precision: precision});
-    ret.constructor.config({precision: precision});
-    console.log(Big == ret.consructor);
     return ret.toDP(Big.precision - 1);
   }
 
@@ -643,26 +635,33 @@ exports.arctan = function (x) {
  * @returns {BigNumber} sine or cosine of x
  */
 exports.cos_sin = function (x, precision, mode) {
+  var Big;
   if (x.isNaN() || !x.isFinite()) {
-    var Big = BigNumber.constructor({precision: precision});
+    Big = BigNumber.constructor({precision: precision});
     return new Big(NaN);
   }
 
+  // Avoid changing the original value
+  Big = BigNumber.constructor({precision: x.constructor.precision});
+  var y = new Big(x);
+  y.constructor = Big;                     // Not sure why I have to do this...
+
   // sin(-x) == -sin(x), cos(-x) == cos(x)
-  var isNeg = x.isNegative();
+  var isNeg = y.isNegative();
   if (isNeg) {
-    x.s = -x.s;
+    y.s = -y.s;
   }
 
-  var y = reduceToPeriod(x, precision, mode);  // Make this destructive
+  y = reduceToPeriod(y, precision, mode);  // Make this destructive
   if (y[1]) {
     return y[0];
   }
 
+  var ret;
   y = y[0];
-  var Big = y.constructor;
+  Big = y.constructor;
   if (mode) {
-    var ret = cos_sin_taylor(y.div(3125), mode);
+    ret = cos_sin_taylor(y.div(3125), mode);
     Big.config({precision: Math.min(Big.precision, precision + 15)});
 
     var five = new Big(5);
@@ -690,7 +689,7 @@ exports.cos_sin = function (x, precision, mode) {
       loops = 4;
     }
 
-    var ret = cos_sin_taylor(y.div(div_factor), mode);
+    ret = cos_sin_taylor(y.div(div_factor), mode);
     Big.config({precision: Math.min(Big.precision, precision + 8)});
 
     var eight = new Big(8);
@@ -715,14 +714,33 @@ exports.cos_sin = function (x, precision, mode) {
  * @returns {BigNumber} tangent of x
  */
 exports.tan = function (x, precision) {
-  var sin = exports.sin(x, precision, 1);
-  var cos = sin_cos_swap(sin);
-  
+  var Big = BigNumber.constructor({precision: precision});
+  if (x.isNaN()) {
+    return new Big(NaN);
+  }
+
+  var y = reduceToPeriod(x, precision, 1)[0];
+  var pi = exports.pi(precision + 4);
+  if (y.abs().eq(pi.toDP(precision))) {
+    return new Big(Infinity);
+  }
+
+  var sin = exports.cos_sin(y, precision + 4, 1);
+  var cos = sinToCos(sin);
+
+  // Make sure sign for cosine is correct
+  if (y.eq(x)) {
+    if (y.gt(pi.div(2).toDP(precision))) {
+      cos.s = -cos.s;
+    }
+  } else if (pi.minus(y.abs()).gt(pi.div(2))) {
+    cos.s = -cos.s;
+  }
+
   sin.constructor.config({precision: precision + 4});
   var tan = sin.div(cos);
-  tan.constructor.config({precision: precision});
 
-  return tan;
+  return new Big(tan.toPrecision(precision));
 };
 
 /**
@@ -743,16 +761,19 @@ exports.cosh_sinh = function (x, mode) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
+  if (!x.isFinite()) {
+    return new Big((mode) ? x : Infinity);
+  }
 
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
   var y = x.exp();
-  y = (mode) ? y.plus(Big.ONE.div(y)) : y.minus(Big.ONE.div(y));
+  y = (mode) ? y.minus(Big.ONE.div(y)) : y.plus(Big.ONE.div(y));
   y = y.div(2);
 
   Big.config({precision: precision});
-  return y.toDP(precision - 1);
+  return new Big(y.toPrecision(precision));
 };
 
 /**
@@ -770,6 +791,9 @@ exports.tanh = function (x) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
+  if (!x.isFinite()) {
+    return new Big(x.isNegative() ? -1 : 1);
+  }
 
   var precision = Big.precision;
   Big.config({precision: precision + 4});
@@ -782,6 +806,91 @@ exports.tanh = function (x) {
   Big.config({precision: precision});
   return ret.toDP(precision - 1);
 };
+
+/**
+ * Calculate the arc sine of x using Newton's method
+ *
+ * f(x) = sin(x) = N  =>  f(x)  = sin(x) - N
+ *                        f'(x) = cos(x)
+ *
+ * Thus we solve each step as follows:
+ *     x_(i+1) = x_i - (sin(x_i) - N)/cos(x_i)
+ *
+ * @param {BigNumber} x
+ * @param {Number} oldPrecision
+ * @returns {BigNumber} arc sine of x
+ */
+function arcsin_newton(x, oldPrecision) {
+  // Calibration variables, adjusted from MAPM
+  var tolerance = -(oldPrecision + 4);
+  var maxp = oldPrecision + 8 - x.e;
+  var localPrecision = 25 - x.e;
+  var maxIter = Math.max(Math.log(oldPrecision + 2) * 1.442695 | 0 + 5, 5);
+
+  var Big = BigNumber.constructor({precision: oldPrecision});
+  var curr = new Big(Math.asin(x.toNumber()) + '');
+
+  var i = 0;
+  do {
+    var tmp0 = exports.cos_sin(curr, localPrecision, 1);
+    var tmp1 = sinToCos(tmp0);
+    if (!tmp0.isZero()) {
+      tmp0.s = curr.s;
+    }
+
+    var tmp2 = tmp0.minus(x).div(tmp1);
+    curr = curr.minus(tmp2);
+
+    localPrecision = Math.min(2*localPrecision, maxp);
+    curr.constructor.config({precision: localPrecision});
+  } while ((2*tmp2.e >= tolerance) && !tmp2.isZero() && (++i <= maxIter))
+
+  if (i == maxIter) {
+    throw new Error('asin() failed to converge to the requested accuracy.' +
+                    'Try with a higher precision.');
+  }
+
+  curr.constructor.config({precision: oldPrecision});
+  return curr.toDP(oldPrecision - 1);
+}
+
+/**
+ * Calculate the arc sine of x
+ *
+ * arcsin(x) = x + (1/2)*x^3/3 + (3/8)*x^5/5 + (15/48)*x^7/7 ...
+ *           = x + (1/2)*x^2*x^1/3 + [(1*3)/(2*4)]*x^2*x^3/5 + [(1*3*5)/(2*4*6)]*x^2*x^5/7 ...
+ *
+ * @param {BigNumber} x
+ * @param {Number} precision
+ * @returns {BigNumber} arc sine of x
+ */
+function arcsin_taylor(x, precision) {
+  var Big = x.constructor;
+  Big.config({precision: precision + Math.log(precision) | 0 + 4});
+
+  var one = new Big(1);
+  var y = x;
+  var yPrev = NaN;
+  var x2 = x.times(x);
+  var polyNum = x;
+  var constNum = new Big(one);
+  var constDen = new Big(one);
+
+  var bigK = new Big(one); 
+  for (var k = 3; !y.equals(yPrev); k += 2) {
+    polyNum = polyNum.times(x2);
+
+    constNum = constNum.times(bigK);
+    constDen = constDen.times(bigK.plus(one));
+
+    yPrev = y;
+    bigK = new Big(k);
+    y = y.plus(polyNum.times(constNum).div(bigK.times(constDen)));
+  }
+
+  Big.config({precision: precision});
+  return y.toDP(precision - 1);
+}
 
 /**
  * Calculate the arc tangent of x using a Taylor expansion
@@ -855,11 +964,19 @@ function cos_sin_taylor(x, mode) {
  */
 function reduceToPeriod(x, precision, mode) {
   var Big = x.constructor;
+  var xPrecision = Big.precision
   var prec_plus_guard_digits = precision + (Math.log(precision) | 0) + 3;
-
   Big.config({precision: prec_plus_guard_digits});
+
+  var y;
   var pi = exports.pi(prec_plus_guard_digits + 2);
   var tau = exports.tau(prec_plus_guard_digits);
+  if (x.abs().lte(pi)) {
+    y = new Big(x);
+    y.constructor = BigNumber.constructor({precision: prec_plus_guard_digits});
+    Big.config({precision: xPrecision});
+    return [y, false];
+  }
 
   // Catch if input is tau multiple using pi's precision
   if (x.div(pi.toDP(x.dp(), 1)).toNumber() % 2 == 0) {
@@ -867,9 +984,9 @@ function reduceToPeriod(x, precision, mode) {
     return [new Big(mode ^ 1), true];
   }
 
-  var y = x.mod(tau);
+  y = x.mod(tau);
   y.constructor = BigNumber.constructor({precision: prec_plus_guard_digits});
-  Big.config({precision: precision});
+  Big.config({precision: xPrecision});
 
   // Catch if tau multiple with tau's precision
   if (y.toDP(x.dp(), 1).isZero()) {
@@ -891,24 +1008,22 @@ function reduceToPeriod(x, precision, mode) {
 }
 
 /**
- * Convert between sine and cosine values
+ * Convert from cosine to sine
  *
- * cos(x) = sqrt(1 - sin(x)^2)
+ * |cos(x)| = sqrt(1 - sin(x)^2)
  *
- * sin(x) = sqrt(1 - cos(x)^2)
- *
- * @param {BigNumber} x
- * @returns {BigNumber} sine as cosine, or cosine as sine
+ * @param {BigNumber} sine of x
+ * @returns {BigNumber} sine as cosine
  */
-function sin_cos_swap(x) {
-  var Big = x.constructor;
+function sinToCos(sinVal) {
+  var Big = sinVal.constructor;
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
-  var ret = Big.ONE.minus(x.times(x)).sqrt();
+  var ret = Big.ONE.minus(sinVal.times(sinVal)).sqrt();
 
   Big.config({precision: precision});
-  return ret;
+  return ret.toDP(precision - 1);
 }
 
 

--- a/test/function/trigonometry/acos.test.js
+++ b/test/function/trigonometry/acos.test.js
@@ -7,7 +7,9 @@ var assert = require('assert'),
     cos = math.cos,
     complex = math.complex,
     matrix = math.matrix,
-    unit = math.unit;
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
 
 describe('acos', function() {
   it('should return the arccos of a boolean', function () {
@@ -27,8 +29,16 @@ describe('acos', function() {
     approx.equal(acos(1) / pi, 0);
   });
 
-  it('should return the arccos of a bignumber (downgrades to number)', function() {
-    approx.equal(acos(math.bignumber(-1)), pi);
+  it('should return the arccos of a bignumber', function() {
+    assert.deepEqual(acos(Big(-1)).toString(), bigmath.pi.toString());
+    assert.deepEqual(acos(Big(-0.5)), Big('2.0943951023931954923'));
+    assert.deepEqual(acos(Big(0)), Big('1.5707963267948966192'));
+    assert.deepEqual(acos(Big(0.5)), Big('1.0471975511965977462'));
+    assert.deepEqual(acos(Big(1)), Big(0));
+
+    // Hit Newton's method case
+    bigmath.config({precision: 61});
+    assert.deepEqual(acos(Big('0.00000001')), Big('1.570796316794896619231321524973084775431910533020886243820359'));
   });
 
   it('should be the inverse function of cos', function() {
@@ -37,6 +47,15 @@ describe('acos', function() {
     approx.equal(acos(cos(0.1)), 0.1);
     approx.equal(acos(cos(0.5)), 0.5);
     approx.equal(acos(cos(2)), 2);
+  });
+
+  it('should be the inverse function of bignumber cos', function() {
+    bigmath.config({precision: 20});
+    assert.deepEqual(acos(bigmath.cos(Big(-1))).toString(), '1');
+    assert.ok(acos(bigmath.cos(Big(0))).isZero());
+    assert.deepEqual(acos(bigmath.cos(Big(0.1))).toString(), '0.1');
+    assert.deepEqual(acos(bigmath.cos(Big(0.5))).toString(), '0.5');
+    assert.deepEqual(acos(bigmath.cos(Big(2))).toString(), '2');
   });
 
   it('should return the arccos of a complex number', function() {

--- a/test/function/trigonometry/acos.test.js
+++ b/test/function/trigonometry/acos.test.js
@@ -39,8 +39,9 @@ describe('acos', function() {
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(acos(Big('0.00000001')), Big('1.570796316794896619231321524973084775431910533020886243820359'));    
-
+    assert.deepEqual(acos(Big(0.00000001)).toString(), '1.570796316794896619' +
+                                                       '23132152497308477543' +
+                                                       '1910533020886243820359');
     //Make sure arg was not changed
     assert.deepEqual(arg, Big(-1));
   });

--- a/test/function/trigonometry/acos.test.js
+++ b/test/function/trigonometry/acos.test.js
@@ -30,7 +30,8 @@ describe('acos', function() {
   });
 
   it('should return the arccos of a bignumber', function() {
-    assert.deepEqual(acos(Big(-1)).toString(), bigmath.pi.toString());
+    var arg = Big(-1);
+    assert.deepEqual(acos(arg).toString(), bigmath.pi.toString());
     assert.deepEqual(acos(Big(-0.5)), Big('2.0943951023931954923'));
     assert.deepEqual(acos(Big(0)), Big('1.5707963267948966192'));
     assert.deepEqual(acos(Big(0.5)), Big('1.0471975511965977462'));
@@ -38,7 +39,10 @@ describe('acos', function() {
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(acos(Big('0.00000001')), Big('1.570796316794896619231321524973084775431910533020886243820359'));
+    assert.deepEqual(acos(Big('0.00000001')), Big('1.570796316794896619231321524973084775431910533020886243820359'));    
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg, Big(-1));
   });
 
   it('should be the inverse function of cos', function() {

--- a/test/function/trigonometry/asin.test.js
+++ b/test/function/trigonometry/asin.test.js
@@ -7,7 +7,9 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     asin = math.asin,
-    sin = math.sin;
+    sin = math.sin,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
 
 describe('asin', function() {
   it('should return the arcsin of a boolean', function () {
@@ -27,8 +29,18 @@ describe('asin', function() {
     approx.equal(asin(1) / pi, 0.5);
   });
 
-  it('should return the arcsin of a bignumber (downgrades to number)', function() {
-    approx.equal(asin(math.bignumber(-1)), -pi / 2);
+  it('should return the arcsin of a bignumber', function() {
+    assert.deepEqual(asin(Big(-1)), Big('-1.5707963267948966192'));
+    assert.deepEqual(asin(Big(-0.581)), Big('-0.6199567994522537004'));
+    assert.deepEqual(asin(Big(-0.5)), Big('-0.5235987755982988731'));
+    assert.deepEqual(asin(Big(0)), Big(0));
+    assert.deepEqual(asin(Big(0.5)), Big('0.5235987755982988731'));
+    assert.deepEqual(asin(Big(0.581)), Big('0.6199567994522537004'));
+    assert.deepEqual(asin(Big(1)), Big('1.5707963267948966192'));
+
+    // Hit Newton's method case
+    bigmath.config({precision: 61});
+    assert.deepEqual(asin(Big('0.00000001')), Big('1.0000000000000000166666666666666674166666666666667113e-8'));
   });
 
   it('should be the inverse function of sin', function() {
@@ -37,6 +49,27 @@ describe('asin', function() {
     approx.equal(asin(sin(0.1)), 0.1);
     approx.equal(asin(sin(0.5)), 0.5);
     approx.equal(asin(sin(2)), 1.14159265358979);
+  });
+
+  it('should be the inverse function of bignumber sin', function() {
+    // More Newton's method test cases
+    assert.deepEqual(asin(bigmath.sin(Big(-2))).toString(), '-1.141592653589793238462643383279502884197169399375105820974945');
+    assert.deepEqual(asin(bigmath.sin(Big(-0.5))).toString(), '-0.5');
+    assert.deepEqual(asin(bigmath.sin(Big(-0.1))).toString(), '-0.1');
+    assert.deepEqual(asin(bigmath.sin(Big(0.1))).toString(), '0.1');
+    assert.deepEqual(asin(bigmath.sin(Big(0.5))).toString(), '0.5');
+    assert.deepEqual(asin(bigmath.sin(Big(2))).toString(), '1.141592653589793238462643383279502884197169399375105820974945');
+
+    bigmath.config({precision: 20});
+    // Full decimal Taylor test cases
+    /* sin(-1) =                      -0.8414709848078965067
+       asin(-0.8414709848078965067) = -1.00000000000000000008 => (rounding up) -1.0000000000000000001
+    assert.deepEqual(asin(bigmath.sin(Big(-1))), Big('-1')); */
+
+    assert.ok(asin(bigmath.sin(Big(0))).isZero());
+    assert.deepEqual(asin(bigmath.sin(Big(0.1))).toString(), '0.1');
+    assert.deepEqual(asin(bigmath.sin(Big(0.5))).toString(), '0.5');
+    assert.deepEqual(asin(bigmath.sin(Big(2))).toString(), '1.1415926535897932385');
   });
 
   it('should return the arcsin of a complex number', function() {

--- a/test/function/trigonometry/asin.test.js
+++ b/test/function/trigonometry/asin.test.js
@@ -30,6 +30,10 @@ describe('asin', function() {
   });
 
   it('should return the arcsin of a bignumber', function() {
+    var arg1 = Big(-1);
+    var arg2 = Big(-0.581);
+    var arg3 = Big(-0.5);
+
     assert.deepEqual(asin(Big(-1)), Big('-1.5707963267948966192'));
     assert.deepEqual(asin(Big(-0.581)), Big('-0.6199567994522537004'));
     assert.deepEqual(asin(Big(-0.5)), Big('-0.5235987755982988731'));
@@ -38,9 +42,16 @@ describe('asin', function() {
     assert.deepEqual(asin(Big(0.581)), Big('0.6199567994522537004'));
     assert.deepEqual(asin(Big(1)), Big('1.5707963267948966192'));
 
+    // Make sure args were not changed
+    assert.deepEqual(arg1, Big(-1));
+    assert.deepEqual(arg2, Big(-0.581));
+    assert.deepEqual(arg3, Big(-0.5));
+
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(asin(Big('0.00000001')), Big('1.0000000000000000166666666666666674166666666666667113e-8'));
+    var arg4 = Big(0.00000001);
+    assert.deepEqual(asin(arg4), Big('1.0000000000000000166666666666666674166666666666667113e-8'));
+    assert.deepEqual(arg4, Big(0.00000001));
   });
 
   it('should be the inverse function of sin', function() {

--- a/test/function/trigonometry/asin.test.js
+++ b/test/function/trigonometry/asin.test.js
@@ -49,8 +49,9 @@ describe('asin', function() {
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
+
     var arg4 = Big(0.00000001);
-    assert.deepEqual(asin(arg4), Big('1.0000000000000000166666666666666674166666666666667113e-8'));
+    assert.deepEqual(asin(arg4).toString(), '1.0000000000000000166666666666666674166666666666667113e-8');
     assert.deepEqual(arg4, Big(0.00000001));
   });
 

--- a/test/function/trigonometry/atan.test.js
+++ b/test/function/trigonometry/atan.test.js
@@ -7,7 +7,9 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     atan = math.atan,
-    tan = math.tan;
+    tan = math.tan,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
 
 describe('atan', function() {
   it('should return the arctan of a boolean', function () {
@@ -27,8 +29,16 @@ describe('atan', function() {
     approx.equal(atan(1) / pi, 0.25);
   });
 
-  it('should return the arctan of a bignumber (downgrades to number)', function() {
-    approx.equal(atan(math.bignumber(1)), pi / 4);
+  it('should return the arctan of a bignumber', function() {
+    assert.deepEqual(atan(Big(-1)), Big('-0.7853981633974483096'));
+    assert.deepEqual(atan(Big(-0.5)), Big('-0.4636476090008061162'));
+    assert.deepEqual(atan(Big(0)), Big(0));
+    assert.deepEqual(atan(Big(0.5)), Big('0.4636476090008061162'));
+    assert.deepEqual(atan(Big(1)), Big('0.7853981633974483096'));
+
+    // Hit Newton's method case
+    bigmath.config({precision: 61});
+    assert.deepEqual(atan(Big(0.90)).toString(), '0.732815101786506591640792072734280251985755679358256086310506');
   });
 
   it('should be the inverse function of tan', function() {
@@ -37,6 +47,16 @@ describe('atan', function() {
     approx.equal(atan(tan(0.1)), 0.1);
     approx.equal(atan(tan(0.5)), 0.5);
     approx.equal(atan(tan(2)), -1.14159265358979);
+  });
+
+  it('should be the inverse function of bignumber tan', function() {
+    bigmath.config({precision: 20});
+    assert.deepEqual(atan(bigmath.tan(Big(-1))).toString(), '-1');
+    assert.ok(atan(bigmath.tan(Big(0))).isZero());
+    assert.deepEqual(atan(bigmath.tan(Big(0.1))).toString(), '0.1');
+    assert.deepEqual(atan(bigmath.tan(Big(0.5))).toString(), '0.5');
+    assert.deepEqual(atan(bigmath.tan(Big(2))).toString(), '-1.1415926535897932385');
+    assert.deepEqual(atan(bigmath.tan(bigmath.pi.div(2))).toString(), '-1.5707963267948966192');
   });
 
   it('should return the arctan of a complex number', function() {

--- a/test/function/trigonometry/atan.test.js
+++ b/test/function/trigonometry/atan.test.js
@@ -30,15 +30,26 @@ describe('atan', function() {
   });
 
   it('should return the arctan of a bignumber', function() {
-    assert.deepEqual(atan(Big(-1)), Big('-0.7853981633974483096'));
-    assert.deepEqual(atan(Big(-0.5)), Big('-0.4636476090008061162'));
-    assert.deepEqual(atan(Big(0)), Big(0));
+    var arg1 = Big(-1);
+    var arg2 = Big(-0.5);
+    var arg3 = Big(0);
+    var arg6 = Big(2);
+    assert.deepEqual(atan(arg1), Big('-0.7853981633974483096'));
+    assert.deepEqual(atan(arg2), Big('-0.4636476090008061162'));
+    assert.deepEqual(atan(arg3), Big(0));
     assert.deepEqual(atan(Big(0.5)), Big('0.4636476090008061162'));
     assert.deepEqual(atan(Big(1)), Big('0.7853981633974483096'));
+    assert.deepEqual(atan(arg6), Big('1.107148717794090503'));
+
+    // Ensure the arguments where not changed
+    assert.deepEqual(arg1, Big(-1));
+    assert.deepEqual(arg2, Big(-0.5));
+    assert.deepEqual(arg3, Big(0));
+    assert.deepEqual(arg6, Big(2));
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(atan(Big(0.90)).toString(), '0.732815101786506591640792072734280251985755679358256086310506');
+    assert.deepEqual(atan(Big(0.9)).toString(), '0.732815101786506591640792072734280251985755679358256086310506');
   });
 
   it('should be the inverse function of tan', function() {

--- a/test/function/trigonometry/cos.test.js
+++ b/test/function/trigonometry/cos.test.js
@@ -6,7 +6,10 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    cos = math.cos;
+    cos = math.cos,
+    bigmath = math.create({number: 'bignumber', precision: 15}),
+    biggermath = math.create({precision: 238});
+
 
 describe('cos', function() {
   it('should return the cosine of a boolean', function () {
@@ -33,8 +36,7 @@ describe('cos', function() {
   });
 
   it('should return the cosine of a bignumber', function() {
-    var bigmath = math.create({number: 'bignumber', precision: 238});
-    assert.deepEqual(bigmath.cos(bigmath.bignumber(0)), bigmath.bignumber(1));
+    assert.deepEqual(bigmath.cos(biggermath.bignumber(0)).toString(), '1');
 
     // 103.64 % tau = 3.109... <- pretty close to the pi boundary
     var result_val = '-0.99947004918247698171247470962484532559534008595265991588' +
@@ -42,33 +44,31 @@ describe('cos', function() {
                         '80857263937361947475191126604630777331941809888320749410' +
                         '59494006339537812110786663367929884637840572887762249921' +
                         '8425619255481';
-    var cos_val = bigmath.cos(bigmath.bignumber(103.64));
+    var cos_val = biggermath.cos(biggermath.bignumber(103.64));
     assert.equal(cos_val.constructor.precision, 238);
     assert.deepEqual(cos_val.toString(), result_val);
 
-    cos_val = bigmath.cos(bigmath.bignumber(-103.64));
+    cos_val = biggermath.cos(biggermath.bignumber(-103.64));
     assert.equal(cos_val.constructor.precision, 238);
     assert.deepEqual(cos_val.toString(), result_val);
 
-    bigmath.config({precision: 15});
 
     var bigPi = bigmath.pi;
     result_val = bigmath.SQRT2.div(2).toString();
-
     assert.deepEqual(bigmath.cos(bigPi.div(4)).toString(), result_val);
     assert.ok(bigmath.cos(bigPi.div(2)).isZero());
     assert.deepEqual(bigmath.cos(bigPi).toString(), '-1');
     assert.ok(bigmath.cos(bigPi.times(3).div(2)).isZero());
     assert.deepEqual(bigmath.cos(bigPi.times(2)).toString(), '1');
-
     assert.deepEqual(bigmath.cos(bigmath.tau).toString(), '1');
     assert.deepEqual(bigmath.cos(bigmath.tau.times(2)).toString(), '1');
-
-    /* If we ever decide to pass in more digits of pi, uncomment these.
+    
+    /* Pass in more digits of pi! */
+    biggermath.config({number: 'bignumber', precision: 17});
+    bigPi = biggermath.pi;
     assert.deepEqual(bigmath.cos(bigPi.times(3).div(4)).toString(), '-'+result_val);
     assert.deepEqual(bigmath.cos(bigPi.times(5).div(4)).toString(), '-'+result_val);
     assert.deepEqual(bigmath.cos(bigPi.times(7).div(4)).toString(), result_val);
-    */
   });
 
   it('should return the cosine of a complex number', function() {

--- a/test/function/trigonometry/cos.test.js
+++ b/test/function/trigonometry/cos.test.js
@@ -8,7 +8,7 @@ var assert = require('assert'),
     unit = math.unit,
     cos = math.cos,
     bigmath = math.create({number: 'bignumber', precision: 15}),
-    biggermath = math.create({precision: 238});
+    biggermath = math.create({number: 'bignumber', precision: 238});
 
 
 describe('cos', function() {
@@ -53,7 +53,9 @@ describe('cos', function() {
     assert.deepEqual(cos_val.toString(), result_val);
 
 
-    var bigPi = bigmath.pi;
+    biggermath.config({precision: 16});
+    var bigPi = biggermath.pi;
+
     result_val = bigmath.SQRT2.div(2).toString();
     assert.deepEqual(bigmath.cos(bigPi.div(4)).toString(), result_val);
     assert.ok(bigmath.cos(bigPi.div(2)).isZero());
@@ -62,10 +64,8 @@ describe('cos', function() {
     assert.deepEqual(bigmath.cos(bigPi.times(2)).toString(), '1');
     assert.deepEqual(bigmath.cos(bigmath.tau).toString(), '1');
     assert.deepEqual(bigmath.cos(bigmath.tau.times(2)).toString(), '1');
-    
-    /* Pass in more digits of pi! */
-    biggermath.config({number: 'bignumber', precision: 17});
-    bigPi = biggermath.pi;
+
+    /* Pass in an extra digit of pi! Also tests whether pi was changed previously. */
     assert.deepEqual(bigmath.cos(bigPi.times(3).div(4)).toString(), '-'+result_val);
     assert.deepEqual(bigmath.cos(bigPi.times(5).div(4)).toString(), '-'+result_val);
     assert.deepEqual(bigmath.cos(bigPi.times(7).div(4)).toString(), result_val);

--- a/test/function/trigonometry/cosh.test.js
+++ b/test/function/trigonometry/cosh.test.js
@@ -26,8 +26,18 @@ describe('cosh', function() {
     approx.equal(cosh(3), 10.067661995778);
   });
 
-  it('should return the cosh of a bignumber (downgrades to number)', function() {
-    approx.equal(cosh(math.bignumber(1)), 1.5430806348152);
+  it('should return the cosh of a bignumber', function() {
+    var bigmath = math.create({number: 'bignumber', precision: 20});
+    var Big = bigmath.bignumber;
+
+    assert.deepEqual(cosh(Big(-3)), Big('10.067661995777765842'));
+    assert.deepEqual(cosh(Big(-2)), Big('3.7621956910836314596'));
+    assert.deepEqual(cosh(Big(-1)), Big('1.5430806348152437785'));
+    assert.deepEqual(cosh(Big(0)), Big(1));
+    assert.deepEqual(cosh(Big(1)), Big('1.5430806348152437785'));
+    assert.deepEqual(cosh(Big(2)), Big('3.7621956910836314596'));
+    assert.deepEqual(cosh(Big(3)), Big('10.067661995777765842'));
+    assert.deepEqual(cosh(bigmath.pi).toString(), '11.591953275521520628');
   });
 
   it('should return the cosh of a complex number', function() {

--- a/test/function/trigonometry/cosh.test.js
+++ b/test/function/trigonometry/cosh.test.js
@@ -29,8 +29,12 @@ describe('cosh', function() {
   it('should return the cosh of a bignumber', function() {
     var bigmath = math.create({number: 'bignumber', precision: 20});
     var Big = bigmath.bignumber;
+    var bigInfinity = Big(Infinity);
 
-    assert.deepEqual(cosh(Big(-3)), Big('10.067661995777765842'));
+    var arg1 = Big(-3);
+    var arg9 = Big(Infinity);
+    var arg10 = Big(-Infinity);
+    assert.deepEqual(cosh(arg1), Big('10.067661995777765842'));
     assert.deepEqual(cosh(Big(-2)), Big('3.7621956910836314596'));
     assert.deepEqual(cosh(Big(-1)), Big('1.5430806348152437785'));
     assert.deepEqual(cosh(Big(0)), Big(1));
@@ -38,6 +42,13 @@ describe('cosh', function() {
     assert.deepEqual(cosh(Big(2)), Big('3.7621956910836314596'));
     assert.deepEqual(cosh(Big(3)), Big('10.067661995777765842'));
     assert.deepEqual(cosh(bigmath.pi).toString(), '11.591953275521520628');
+    assert.deepEqual(cosh(arg9), bigInfinity);
+    assert.deepEqual(cosh(arg10), bigInfinity);
+
+    // Ensure args were not changed
+    assert.deepEqual(arg1, Big(-3));
+    assert.deepEqual(arg9, bigInfinity);
+    assert.deepEqual(arg10, Big(-Infinity));
   });
 
   it('should return the cosh of a complex number', function() {

--- a/test/function/trigonometry/sin.test.js
+++ b/test/function/trigonometry/sin.test.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    sin = math.sin;
+    sin = math.sin,
+    bigmath = math.create({precision: 242});
 
 describe('sin', function() {
   it('should return the sine of a boolean', function () {
@@ -32,7 +33,6 @@ describe('sin', function() {
   });
 
   it('should return the sine of a bignumber', function() {
-    var bigmath = math.create({number: 'bignumber', precision: 242});
     assert.ok(bigmath.sin(bigmath.bignumber(0)).isZero());
 
     // 103.64 % tau = 3.109... <- pretty close to the pi boundary
@@ -48,7 +48,7 @@ describe('sin', function() {
                                                '3071480438329880550139583951234188873226108092477936610585549' +
                                                '3575835362891900420559398509489530577719840860106717522689249' +
                                                '6061212602629134186583352145117086874446046421403346033616');
-    bigmath.config({precision: 15});
+    bigmath.config({number: 'bignumber', precision: 15});
 
     var bigPi = bigmath.pi;
     result_val = bigmath.SQRT2.div(2).toString();

--- a/test/function/trigonometry/sin.test.js
+++ b/test/function/trigonometry/sin.test.js
@@ -42,7 +42,9 @@ describe('sin', function() {
                                               '714804383298805501395839512341888732261080924779366105855493575' +
                                               '835362891900420559398509489530577719840860106717522689249606121' +
                                               '2602629134186583352145117086874446046421403346033616');
-    result_val = bigmath.sin(bigmath.bignumber(-103.64));
+    var arg = bigmath.bignumber(-103.64);
+    result_val = bigmath.sin(arg);
+    assert.deepEqual(arg, bigmath.bignumber(-103.64));   // Make sure arg wasn't changed
     assert.equal(result_val.constructor.precision, 242);
     assert.deepEqual(result_val.toString(), '-0.0325518169566161584427313159942672130512044591216893328934710' +
                                                '3071480438329880550139583951234188873226108092477936610585549' +

--- a/test/function/trigonometry/sinh.test.js
+++ b/test/function/trigonometry/sinh.test.js
@@ -30,8 +30,18 @@ describe('sinh', function() {
     assert.equal(sinh(1e-50), 1e-50);
   })
 
-  it('should return the sinh of a bignumber (downgrades to number)', function() {
-    approx.equal(sinh(math.bignumber(1)), 1.1752011936438014);
+  it('should return the sinh of a bignumber', function() {
+    var bigmath = math.create({number: 'bignumber', precision: 20});
+    var Big = bigmath.bignumber;
+
+    assert.deepEqual(sinh(Big(-1)), Big('-1.1752011936438014569'));
+    assert.deepEqual(sinh(Big(0)), Big(0));
+    assert.deepEqual(sinh(bigmath.pi).toString(), '11.548739357257748378');
+    assert.deepEqual(sinh(Big(1)), Big('1.1752011936438014569'));
+    assert.deepEqual(sinh(Big(-1e-10)), Big(-1e-10));
+
+    bigmath.config({precision: 50});
+    assert.deepEqual(sinh(Big(1e-50)), Big(1e-50));
   });
 
   it('should return the sinh of a complex number', function() {

--- a/test/function/trigonometry/sinh.test.js
+++ b/test/function/trigonometry/sinh.test.js
@@ -34,11 +34,21 @@ describe('sinh', function() {
     var bigmath = math.create({number: 'bignumber', precision: 20});
     var Big = bigmath.bignumber;
 
-    assert.deepEqual(sinh(Big(-1)), Big('-1.1752011936438014569'));
+    var arg1 = Big(-1);
+    var arg6 = Big(Infinity);
+    var arg7 = Big(-Infinity);
+    assert.deepEqual(sinh(arg1), Big('-1.1752011936438014569'));
     assert.deepEqual(sinh(Big(0)), Big(0));
     assert.deepEqual(sinh(bigmath.pi).toString(), '11.548739357257748378');
     assert.deepEqual(sinh(Big(1)), Big('1.1752011936438014569'));
     assert.deepEqual(sinh(Big(-1e-10)), Big(-1e-10));
+    assert.deepEqual(sinh(arg6), Big(Infinity));
+    assert.deepEqual(sinh(arg7), Big(-Infinity));
+
+    // Ensure args were not changed
+    assert.deepEqual(arg1, Big(-1));
+    assert.deepEqual(arg6, Big(Infinity));
+    assert.deepEqual(arg7, Big(-Infinity));
 
     bigmath.config({precision: 50});
     assert.deepEqual(sinh(Big(1e-50)), Big(1e-50));

--- a/test/function/trigonometry/tan.test.js
+++ b/test/function/trigonometry/tan.test.js
@@ -8,7 +8,9 @@ var assert = require('assert'),
     unit = math.unit,
     sin = math.sin,
     cos = math.cos,
-    tan = math.tan;
+    tan = math.tan,
+    piBigmath = math.create({number: 'bignumber', precision: 21}),
+    bigmath = math.create({precision: 20});
 
 describe('tan', function() {
   it('should return the tangent of a boolean', function () {
@@ -34,11 +36,8 @@ describe('tan', function() {
   });
 
   it('should return the tangent of a bignumber', function() { 
-    var piBigmath = math.create({number: 'bignumber', precision: 24});
     var bigPi = piBigmath.pi;
     var bigTau = piBigmath.tau;
-
-    var bigmath = math.create({precision: 20});
 
     assert.ok(bigmath.tan(bigmath.bignumber(0)).isZero());
     assert.deepEqual(bigmath.tan(bigmath.bignumber(-1)).toString(), '-1.5574077246549022305');
@@ -46,15 +45,17 @@ describe('tan', function() {
     assert.deepEqual(bigmath.tan(bigPi.div(8)).toString(), '0.4142135623730950488');
     assert.deepEqual(bigmath.tan(bigPi.div(4)).toString(), '1');
     assert.ok(!bigmath.tan(bigPi.div(2)).isFinite());
-    assert.deepEqual(bigmath.tan(bigPi.times(3).div(4)).toString(), '-1');
-    assert.ok(bigmath.tan(bigPi).isZero());
-    assert.deepEqual(bigmath.tan(bigPi.times(5).div(4)).toString(), '1');
     assert.ok(!bigmath.tan(bigPi.times(3).div(2)).isFinite());
-    assert.deepEqual(bigmath.tan(bigPi.times(7).div(4)).toString(), '-1');
     assert.ok(bigmath.tan(bigPi.times(2)).isZero());
     assert.ok(bigmath.tan(bigPi.times(4)).isZero());
     assert.ok(bigmath.tan(bigTau).isZero());
     assert.ok(bigmath.tan(bigTau.times(2)).isZero());
+
+    /* Passes with an extra digit of pi! */
+    assert.deepEqual(bigmath.tan(bigPi.times(3).div(4)).toString(), '-1');
+    assert.ok(bigmath.tan(bigPi).isZero());
+    assert.deepEqual(bigmath.tan(bigPi.times(5).div(4)).toString(), '1');
+    assert.deepEqual(bigmath.tan(bigPi.times(7).div(4)).toString(), '-1');
   });
 
   it('should return the tangent of a complex number', function() {

--- a/test/function/trigonometry/tan.test.js
+++ b/test/function/trigonometry/tan.test.js
@@ -33,8 +33,28 @@ describe('tan', function() {
     approx.equal(tan(pi*8/4), 0);
   });
 
-  it('should return the tangent of a bignumber (downgrades to number)', function() {
-    approx.equal(tan(math.bignumber(1)), 1.55740772465490);
+  it('should return the tangent of a bignumber', function() { 
+    var piBigmath = math.create({number: 'bignumber', precision: 24});
+    var bigPi = piBigmath.pi;
+    var bigTau = piBigmath.tau;
+
+    var bigmath = math.create({precision: 20});
+
+    assert.ok(bigmath.tan(bigmath.bignumber(0)).isZero());
+    assert.deepEqual(bigmath.tan(bigmath.bignumber(-1)).toString(), '-1.5574077246549022305');
+
+    assert.deepEqual(bigmath.tan(bigPi.div(8)).toString(), '0.4142135623730950488');
+    assert.deepEqual(bigmath.tan(bigPi.div(4)).toString(), '1');
+    assert.ok(!bigmath.tan(bigPi.div(2)).isFinite());
+    assert.deepEqual(bigmath.tan(bigPi.times(3).div(4)).toString(), '-1');
+    assert.ok(bigmath.tan(bigPi).isZero());
+    assert.deepEqual(bigmath.tan(bigPi.times(5).div(4)).toString(), '1');
+    assert.ok(!bigmath.tan(bigPi.times(3).div(2)).isFinite());
+    assert.deepEqual(bigmath.tan(bigPi.times(7).div(4)).toString(), '-1');
+    assert.ok(bigmath.tan(bigPi.times(2)).isZero());
+    assert.ok(bigmath.tan(bigPi.times(4)).isZero());
+    assert.ok(bigmath.tan(bigTau).isZero());
+    assert.ok(bigmath.tan(bigTau.times(2)).isZero());
   });
 
   it('should return the tangent of a complex number', function() {

--- a/test/function/trigonometry/tanh.test.js
+++ b/test/function/trigonometry/tanh.test.js
@@ -26,8 +26,18 @@ describe('tanh', function() {
     approx.equal(tanh(3), 0.99505475368673);
   });
 
-  it('should return the tanh of a bignumber (downgrades to number)', function() {
-    approx.equal(tanh(math.bignumber(1)), 0.76159415595576);
+  it('should return the tanh of a bignumber', function() {
+    var bigmath = math.create({number: 'bignumber', precision: 20});
+    var Big = bigmath.bignumber;
+
+    assert.deepEqual(tanh(Big(-3)), Big('-0.9950547536867304513'));
+    assert.deepEqual(tanh(Big(-2)), Big('-0.9640275800758168839'));
+    assert.deepEqual(tanh(Big(-1)), Big('-0.7615941559557648881'));
+    assert.deepEqual(tanh(Big(0)), Big(0));
+    assert.deepEqual(tanh(Big(1)), Big('0.7615941559557648881'));
+    assert.deepEqual(tanh(Big(2)), Big('0.9640275800758168839'));
+    assert.deepEqual(tanh(Big(3)), Big('0.9950547536867304513'));
+    assert.deepEqual(tanh(bigmath.pi).toString(), '0.9962720762207499443');
   });
 
   it('should return the tanh of a complex number', function() {

--- a/test/function/trigonometry/tanh.test.js
+++ b/test/function/trigonometry/tanh.test.js
@@ -30,7 +30,11 @@ describe('tanh', function() {
     var bigmath = math.create({number: 'bignumber', precision: 20});
     var Big = bigmath.bignumber;
 
-    assert.deepEqual(tanh(Big(-3)), Big('-0.9950547536867304513'));
+    var arg1 = Big(-Infinity);
+    var arg2 = Big(-3);
+    var arg10 = Big(Infinity);
+    assert.deepEqual(tanh(arg1), Big(-1));
+    assert.deepEqual(tanh(arg2), Big('-0.9950547536867304513'));
     assert.deepEqual(tanh(Big(-2)), Big('-0.9640275800758168839'));
     assert.deepEqual(tanh(Big(-1)), Big('-0.7615941559557648881'));
     assert.deepEqual(tanh(Big(0)), Big(0));
@@ -38,6 +42,12 @@ describe('tanh', function() {
     assert.deepEqual(tanh(Big(2)), Big('0.9640275800758168839'));
     assert.deepEqual(tanh(Big(3)), Big('0.9950547536867304513'));
     assert.deepEqual(tanh(bigmath.pi).toString(), '0.9962720762207499443');
+    assert.deepEqual(tanh(arg10), Big(1));
+
+    // Make sure args were not changed
+    assert.deepEqual(arg1, Big(-Infinity));
+    assert.deepEqual(arg2, Big(-3));
+    assert.deepEqual(arg10, Big(Infinity));
   });
 
   it('should return the tanh of a complex number', function() {


### PR DESCRIPTION
Implemented and tested BigNumber implementations of `acos`, `asin`, `atan`, `tan`, `cosh`, `sinh`, and `tanh`. I also fixed the test cases for `cos` to take in `1` extra bit of `pi` and they work; `tan` had a similar issue. I will refactor the others next weekend, so that they have this property as well (`tan` is all set though as can be seen in it's test cases).

While it may look like a lot, it's "only" 404 lines of code in `bignumber.js`, so hopefully it won't be too much of an eyesore to look over.