### PR TITLE
Fix missing brackets in LaTeX output (bug #273)

### DIFF
--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -166,10 +166,7 @@ OperatorNode.prototype.toTex = function() {
           }
 
           if (rp instanceof OperatorNode) {
-            if (rp.op === '+' || rp.op === '-') {
-              rhb = true;
-            }
-            else if (rp.op === '*') {
+            if (rp.op === '+' || rp.op === '-' || rp.op === '*') {
               rhb = true;
             }
           }

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -175,6 +175,14 @@ OperatorNode.prototype.toTex = function() {
 
           break;
 
+		case '-':
+			if (rp instanceof OperatorNode) {
+				if (rp.op === '+' | rp.op === '-' ) {
+					rhb = true;
+				}
+			}
+			break;
+
         case '^':
           if (lp instanceof OperatorNode || lp instanceof FunctionNode) {
             lhb = true;

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -127,12 +127,21 @@ OperatorNode.prototype.toTex = function() {
 
   switch (args.length) {
     case 1:
-      if (this.op === '-' || this.op === '+') {
-        // special case: unary minus
-        return this.op + lp.toTex();
+      var operand = lp.toTex();
+      switch (this.op) {
+        case '-': //unary minus needs brackets around '-' and '+'
+          if (lp instanceof OperatorNode && (lp.op === '-' || lp.op === '+')) {
+            return this.op + latex.addBraces(operand, true);
+          }
+        case '+':
+          return this.op + operand;
+          break;
+        default: // fox example '5!'
+          if (lp instanceof OperatorNode) {
+            return latex.addBraces(operand, true) + this.op;
+          }
+          return operand + this.op;
       }
-      // for example '5!'
-      return lp.toTex() + this.op;
 
     case 2: // for example '2+3'
       var lhs = lp.toTex(),

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -175,13 +175,13 @@ OperatorNode.prototype.toTex = function() {
 
           break;
 
-		case '-':
-			if (rp instanceof OperatorNode) {
-				if (rp.op === '+' | rp.op === '-' ) {
-					rhb = true;
-				}
-			}
-			break;
+        case '-':
+          if (rp instanceof OperatorNode) {
+            if (rp.op === '+' | rp.op === '-' ) {
+              rhb = true;
+            }
+          }
+          break;
 
         case '^':
           if (lp instanceof OperatorNode || lp instanceof FunctionNode) {

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -242,10 +242,54 @@ describe('OperatorNode', function() {
     assert.equal(n.toTex(), '2!');
   });
 
+  it ('should LaTeX an OperatorNode with factorial of an OperatorNode', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+
+    var sub = new OperatorNode('-', 'subtract', [a, b]);
+    var add = new OperatorNode('+', 'add', [a, b]);
+    var mult = new OperatorNode('*', 'multiply', [a, b]);
+    var div = new OperatorNode('/', 'divide', [a, b]);
+
+    var n1= new OperatorNode('!', 'factorial', [sub] );
+    var n2= new OperatorNode('!', 'factorial', [add] );
+    var n3= new OperatorNode('!', 'factorial', [mult] );
+    var n4= new OperatorNode('!', 'factorial', [div] );
+    assert.equal(n1.toTex(), '\\left({{2}-{3}}\\right)!');
+    assert.equal(n2.toTex(), '\\left({{2}+{3}}\\right)!');
+    assert.equal(n3.toTex(), '\\left({{2} \\cdot {3}}\\right)!');
+    assert.equal(n4.toTex(), '\\left({\\frac{2}{3}}\\right)!');
+  });
+
   it ('should LaTeX an OperatorNode with unary minus', function () {
     var a = new ConstantNode(2);
-    var n = new OperatorNode('-', 'unaryMinus', [a]);
-    assert.equal(n.toTex(), '-2');
+    var b = new ConstantNode(3);
+
+    var sub = new OperatorNode('-', 'subtract', [a, b]);
+    var add = new OperatorNode('+', 'add', [a, b]);
+
+    var n1 = new OperatorNode('-', 'unaryMinus', [a]);
+    var n2 = new OperatorNode('-', 'unaryMinus', [sub]);
+    var n3 = new OperatorNode('-', 'unaryMinus', [add]);
+
+    assert.equal(n1.toTex(), '-2');
+    assert.equal(n2.toTex(), '-\\left({{2}-{3}}\\right)');
+    assert.equal(n3.toTex(), '-\\left({{2}+{3}}\\right)');
+  });
+
+  it ('should LaTeX an OperatorNode that subtracts an OperatorNode', function() {
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(3);
+
+    var sub = new OperatorNode('-', 'subtract', [b, c]);
+    var add = new OperatorNode('+', 'add', [b, c]);
+
+    var n1 = new OperatorNode('-', 'subtract', [a, sub]);
+    var n2 = new OperatorNode('-', 'subtract', [a, add]);
+
+    assert.equal(n1.toTex(), '{1}-\\left({{2}-{3}}\\right)');
+    assert.equal(n2.toTex(), '{1}-\\left({{2}+{3}}\\right)');
   });
 
   it ('should LaTeX an OperatorNode with zero arguments', function () {


### PR DESCRIPTION
When creating the LaTeX output for expressions like 1-(1+1) or 1-(1-1),
the bracket's where missing.