### PR TITLE
Inverse hyperbolic trigonometric functions, and reciprocal BigNumber trigonometric functions.

### DIFF
--- a/lib/function/trigonometry/acosh.js
+++ b/lib/function/trigonometry/acosh.js
@@ -73,7 +73,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAcosh(x, 0, false);
+      return bigAcosh(x, false, false);
     }
 
     throw new math.error.UnsupportedTypeError('acosh', math['typeof'](x));

--- a/lib/function/trigonometry/acosh.js
+++ b/lib/function/trigonometry/acosh.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    * Examples:
    *
-   *    math.acosh(1.5);       // returns 0.962423650119206
+   *    math.acosh(1.5);       // returns 0.9624236501192069
    *
    * See also:
    *

--- a/lib/function/trigonometry/acosh.js
+++ b/lib/function/trigonometry/acosh.js
@@ -47,17 +47,21 @@ module.exports = function (math) {
     }
 
     if (isComplex(x)) {
-      return new Complex(
-        Math.log(x.re + Math.sqrt(x.re*x.re - 1)),
-        Math.log(x.im + Math.sqrt(x.im + 1)*Math.sqrt(x.im - 1))
-      );
-    }
-
-    if (isUnit(x)) {
-      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function acosh is no angle');
+      // acosh(z) = (-acos(z).im,  acos(z).re)   for acos(z).im <= 0
+      //            ( acos(z).im, -acos(z).re)   otherwise
+      var temp;
+      var acos = math.acos(x);
+      if (acos.im <= 0) {
+        temp = acos.re;
+        acos.re = -acos.im;
+        acos.im = temp;
+      } else {
+        temp = acos.im;
+        acos.im = -acos.re;
+        acos.re = temp;
       }
-      return acosh(x.value);
+
+      return acos;
     }
 
     if (isCollection(x)) {
@@ -65,7 +69,7 @@ module.exports = function (math) {
     }
 
     if (isBoolean(x) || x === null) {
-      return 0;
+      return (x) ? 0 : NaN;
     }
 
     if (x instanceof BigNumber) {

--- a/lib/function/trigonometry/acosh.js
+++ b/lib/function/trigonometry/acosh.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      BigNumber = math.type.BigNumber,
+      Complex = require('../../type/Complex'),
+      Unit = require('../../type/Unit'),
+      collection = require('../../type/collection'),
+
+      isNumber = util.number.isNumber,
+      isBoolean = util['boolean'].isBoolean,
+      isComplex = Complex.isComplex,
+      isUnit = Unit.isUnit,
+      isCollection = collection.isCollection,
+
+      bigAcosh = util.bignumber.acosh_asinh_asech_acsch;
+
+  /**
+   * Calculate the hyperbolic arccos of a value,
+   * defined as `acosh(x) = ln(x + sqrt(x^2 - 1))`.
+   *
+   * For matrices, the function is evaluated element wise.
+   *
+   * Syntax:
+   *
+   *    math.acosh(x)
+   *
+   * Examples:
+   *
+   *    math.acosh(1.5);       // returns 0.962423650119206
+   *
+   * See also:
+   *
+   *    asinh, atanh
+   *
+   * @param {Number | Boolean | Complex | Unit | Array | Matrix | null} x  Function input
+   * @return {Number | Complex | Array | Matrix} Hyperbolic arccosine of x
+   */
+  math.acosh = function acosh(x) {
+    if (arguments.length != 1) {
+      throw new math.error.ArgumentsError('acosh', arguments.length, 1);
+    }
+
+    if (isNumber(x)) {
+      return Math.log(x + Math.sqrt(x*x - 1));
+    }
+
+    if (isComplex(x)) {
+      return new Complex(
+        Math.log(x.re + Math.sqrt(x.re*x.re - 1)),
+        Math.log(x.im + Math.sqrt(x.im + 1)*Math.sqrt(x.im - 1))
+      );
+    }
+
+    if (isUnit(x)) {
+      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
+        throw new TypeError('Unit in function acosh is no angle');
+      }
+      return acosh(x.value);
+    }
+
+    if (isCollection(x)) {
+      return collection.deepMap(x, acosh);
+    }
+
+    if (isBoolean(x) || x === null) {
+      return 0;
+    }
+
+    if (x instanceof BigNumber) {
+      return bigAcosh(x, 0, false);
+    }
+
+    throw new math.error.UnsupportedTypeError('acosh', math['typeof'](x));
+  };
+};

--- a/lib/function/trigonometry/acoth.js
+++ b/lib/function/trigonometry/acoth.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      BigNumber = math.type.BigNumber,
+      Complex = require('../../type/Complex'),
+      Unit = require('../../type/Unit'),
+      collection = require('../../type/collection'),
+
+      isNumber = util.number.isNumber,
+      isBoolean = util['boolean'].isBoolean,
+      isComplex = Complex.isComplex,
+      isUnit = Unit.isUnit,
+      isCollection = collection.isCollection,
+
+      bigAcoth = util.bignumber.atanh_acoth;
+
+  /**
+   * Calculate the hyperbolic arccotangent of a value,
+   * defined as `acoth(x) = 2 / ln((1 + x)/(1 - x))`.
+   *
+   * For matrices, the function is evaluated element wise.
+   *
+   * Syntax:
+   *
+   *    math.acoth(x)
+   *
+   * Examples:
+   *
+   *    math.acoth(0.5);       // returns 0.4812118250596
+   *
+   * See also:
+   *
+   *    acsch, asech
+   *
+   * @param {Number | Boolean | Complex | Unit | Array | Matrix | null} x  Function input
+   * @return {Number | Complex | Array | Matrix} Hyperbolic arccotangent of x
+   */
+  math.acoth = function acoth(x) {
+    if (arguments.length != 1) {
+      throw new math.error.ArgumentsError('acoth', arguments.length, 1);
+    }
+
+    if (isNumber(x)) {
+      return 2 / Math.log((1 + x)/(1 - x));
+    }
+
+    if (isComplex(x)) {
+      return new Complex(
+        2 / Math.log((1 + x.re)/(1 - x.re)),
+        2 / (Math.log(1 + x.im) - Math.log(1 - x.im))
+      );
+    }
+
+    if (isUnit(x)) {
+      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
+        throw new TypeError('Unit in function acoth is no angle');
+      }
+      return acoth(x.value);
+    }
+
+    if (isCollection(x)) {
+      return collection.deepMap(x, acoth);
+    }
+
+    if (isBoolean(x) || x === null) {
+      return (x) ? Infinity : 0;
+    }
+
+    if (x instanceof BigNumber) {
+      return bigAcoth(x, true);
+    }
+
+    throw new math.error.UnsupportedTypeError('acoth', math['typeof'](x));
+  };
+};

--- a/lib/function/trigonometry/acoth.js
+++ b/lib/function/trigonometry/acoth.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    * Examples:
    *
-   *    math.acoth(0.5);       // returns 0.4812118250596
+   *    math.acoth(0.5);       // returns 0.8047189562170503
    *
    * See also:
    *

--- a/lib/function/trigonometry/acoth.js
+++ b/lib/function/trigonometry/acoth.js
@@ -18,7 +18,7 @@ module.exports = function (math) {
 
   /**
    * Calculate the hyperbolic arccotangent of a value,
-   * defined as `acoth(x) = 2 / ln((1 + x)/(1 - x))`.
+   * defined as `acoth(x) = (ln((x+1)/x) + ln(x/(x-1))) / 2`.
    *
    * For matrices, the function is evaluated element wise.
    *
@@ -43,21 +43,25 @@ module.exports = function (math) {
     }
 
     if (isNumber(x)) {
-      return 2 / Math.log((1 + x)/(1 - x));
+      return isFinite(x) ? (Math.log((x+1)/x) + Math.log(x/(x-1))) / 2 : 0;
     }
 
     if (isComplex(x)) {
-      return new Complex(
-        2 / Math.log((1 + x.re)/(1 - x.re)),
-        2 / (Math.log(1 + x.im) - Math.log(1 - x.im))
-      );
-    }
-
-    if (isUnit(x)) {
-      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function acoth is no angle');
+      if (x.re == 0 && x.im == 0) {
+        return new Complex(0, Math.PI / 2);
       }
-      return acoth(x.value);
+
+      // acoth(z) = -i*atanh(1/z)
+      var den = x.re*x.re + x.im*x.im;
+      if (den != 0) {
+        x.re =  x.re / den;
+        x.im = -x.im / den;
+      } else {
+        x.re = (x.re != 0) ?  (x.re / 0) : 0;
+        x.im = (x.im != 0) ? -(x.im / 0) : 0;
+      }
+
+      return math.atanh(x);
     }
 
     if (isCollection(x)) {
@@ -65,7 +69,7 @@ module.exports = function (math) {
     }
 
     if (isBoolean(x) || x === null) {
-      return (x) ? Infinity : 0;
+      return (x) ? Infinity : NaN;
     }
 
     if (x instanceof BigNumber) {

--- a/lib/function/trigonometry/acoth.js
+++ b/lib/function/trigonometry/acoth.js
@@ -48,7 +48,7 @@ module.exports = function (math) {
 
     if (isComplex(x)) {
       if (x.re == 0 && x.im == 0) {
-        return new Complex(0, Math.PI / 2);
+        return new Complex(0, 1.5707963267948966);
       }
 
       // acoth(z) = -i*atanh(1/z)

--- a/lib/function/trigonometry/acsch.js
+++ b/lib/function/trigonometry/acsch.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    * Examples:
    *
-   *    math.acsch(0.5);       // returns 0.4812118250596
+   *    math.acsch(0.5);       // returns 1.4436354751788103
    *
    * See also:
    *

--- a/lib/function/trigonometry/acsch.js
+++ b/lib/function/trigonometry/acsch.js
@@ -18,7 +18,7 @@ module.exports = function (math) {
 
   /**
    * Calculate the hyperbolic arccosecant of a value,
-   * defined as `acsch(x) = 1 / ln(x + sqrt(x^2 + 1))`.
+   * defined as `acsch(x) = ln(1/x + sqrt(1/x^2 + 1))`.
    *
    * For matrices, the function is evaluated element wise.
    *
@@ -43,21 +43,27 @@ module.exports = function (math) {
     }
 
     if (isNumber(x)) {
-      return 1 / Math.log(x + Math.sqrt(x*x + 1));
+      x = 1 / x;
+      return Math.log(x + Math.sqrt(x*x + 1));
     }
 
     if (isComplex(x)) {
-      return new Complex(
-        1 / Math.log(x.re + Math.sqrt(x.re*x.re + 1)),
-        1 / Math.log(x.im + Math.sqrt(x.im*x.im + 1))
-      );
-    }
-
-    if (isUnit(x)) {
-      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function acsch is no angle');
+      // acsch(z) = -i*asinh(1/z)
+      var den = x.re*x.re + x.im*x.im;
+      if (den != 0) {
+        x.re =  x.re / den;
+        x.im = -x.im / den;
+      } else {
+        x.re = (x.re != 0) ?  (x.re / 0) : 0;
+        x.im = (x.im != 0) ? -(x.im / 0) : 0;
       }
-      return acsch(x.value);
+
+      if (x.im) {
+        return math.asinh(x);
+      }
+
+      x = 1 / x.re;
+      return new Complex(Math.log(x + Math.sqrt(x*x + 1)), 0);
     }
 
     if (isCollection(x)) {
@@ -65,7 +71,7 @@ module.exports = function (math) {
     }
 
     if (isBoolean(x) || x === null) {
-      return (x) ? Math.log(1 + Math.SQRT1_2) : Infinity;
+      return (x) ? 0.881373587019543 : Infinity;
     }
 
     if (x instanceof BigNumber) {

--- a/lib/function/trigonometry/acsch.js
+++ b/lib/function/trigonometry/acsch.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      BigNumber = math.type.BigNumber,
+      Complex = require('../../type/Complex'),
+      Unit = require('../../type/Unit'),
+      collection = require('../../type/collection'),
+
+      isNumber = util.number.isNumber,
+      isBoolean = util['boolean'].isBoolean,
+      isComplex = Complex.isComplex,
+      isUnit = Unit.isUnit,
+      isCollection = collection.isCollection,
+
+      bigAcsch = util.bignumber.acosh_asinh_asech_acsch;
+
+  /**
+   * Calculate the hyperbolic arccosecant of a value,
+   * defined as `acsch(x) = 1 / ln(x + sqrt(x^2 + 1))`.
+   *
+   * For matrices, the function is evaluated element wise.
+   *
+   * Syntax:
+   *
+   *    math.acsch(x)
+   *
+   * Examples:
+   *
+   *    math.acsch(0.5);       // returns 0.4812118250596
+   *
+   * See also:
+   *
+   *    asech, acoth
+   *
+   * @param {Number | Boolean | Complex | Unit | Array | Matrix | null} x  Function input
+   * @return {Number | Complex | Array | Matrix} Hyperbolic arccosecant of x
+   */
+  math.acsch = function acsch(x) {
+    if (arguments.length != 1) {
+      throw new math.error.ArgumentsError('acsch', arguments.length, 1);
+    }
+
+    if (isNumber(x)) {
+      return 1 / Math.log(x + Math.sqrt(x*x + 1));
+    }
+
+    if (isComplex(x)) {
+      return new Complex(
+        1 / Math.log(x.re + Math.sqrt(x.re*x.re + 1)),
+        1 / Math.log(x.im + Math.sqrt(x.im*x.im + 1))
+      );
+    }
+
+    if (isUnit(x)) {
+      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
+        throw new TypeError('Unit in function acsch is no angle');
+      }
+      return acsch(x.value);
+    }
+
+    if (isCollection(x)) {
+      return collection.deepMap(x, acsch);
+    }
+
+    if (isBoolean(x) || x === null) {
+      return (x) ? Math.log(1 + Math.SQRT1_2) : Infinity;
+    }
+
+    if (x instanceof BigNumber) {
+      return bigAcsch(x, 1, true);
+    }
+
+    throw new math.error.UnsupportedTypeError('acsch', math['typeof'](x));
+  };
+};

--- a/lib/function/trigonometry/acsch.js
+++ b/lib/function/trigonometry/acsch.js
@@ -75,7 +75,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAcsch(x, 1, true);
+      return bigAcsch(x, true, true);
     }
 
     throw new math.error.UnsupportedTypeError('acsch', math['typeof'](x));

--- a/lib/function/trigonometry/asech.js
+++ b/lib/function/trigonometry/asech.js
@@ -74,7 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAsech(x, 0, true);
+      return bigAsech(x, false, true);
     }
 
     throw new math.error.UnsupportedTypeError('asech', math['typeof'](x));

--- a/lib/function/trigonometry/asech.js
+++ b/lib/function/trigonometry/asech.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      BigNumber = math.type.BigNumber,
+      Complex = require('../../type/Complex'),
+      Unit = require('../../type/Unit'),
+      collection = require('../../type/collection'),
+
+      isNumber = util.number.isNumber,
+      isBoolean = util['boolean'].isBoolean,
+      isComplex = Complex.isComplex,
+      isUnit = Unit.isUnit,
+      isCollection = collection.isCollection,
+
+      bigAsech = util.bignumber.acosh_asinh_asech_acsch;
+
+  /**
+   * Calculate the hyperbolic arccos of a value,
+   * defined as `asech(x) = 1 / ln(x + sqrt(x^2 - 1))`.
+   *
+   * For matrices, the function is evaluated element wise.
+   *
+   * Syntax:
+   *
+   *    math.asech(x)
+   *
+   * Examples:
+   *
+   *    math.asech(0.5);       // returns 0.4812118250596
+   *
+   * See also:
+   *
+   *    acsch, acoth
+   *
+   * @param {Number | Boolean | Complex | Unit | Array | Matrix | null} x  Function input
+   * @return {Number | Complex | Array | Matrix} Hyperbolic arcsecant of x
+   */
+  math.asech = function asech(x) {
+    if (arguments.length != 1) {
+      throw new math.error.ArgumentsError('asech', arguments.length, 1);
+    }
+
+    if (isNumber(x)) {
+      return 1 / Math.log(x + Math.sqrt(x*x - 1));
+    }
+
+    if (isComplex(x)) {
+      return new Complex(
+        1 / Math.log(x.re + Math.sqrt(x.re*x.re - 1)),
+        1 / Math.log(x.im + Math.sqrt(x.im + 1)*Math.sqrt(x.im - 1))
+      );
+    }
+
+    if (isUnit(x)) {
+      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
+        throw new TypeError('Unit in function asech is no angle');
+      }
+      return asech(x.value);
+    }
+
+    if (isCollection(x)) {
+      return collection.deepMap(x, asech);
+    }
+
+    if (isBoolean(x) || x === null) {
+      return (x) ? 0 : Infinity;
+    }
+
+    if (x instanceof BigNumber) {
+      return bigAsech(x, 0, true);
+    }
+
+    throw new math.error.UnsupportedTypeError('asech', math['typeof'](x));
+  };
+};

--- a/lib/function/trigonometry/asech.js
+++ b/lib/function/trigonometry/asech.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    * Examples:
    *
-   *    math.asech(0.5);       // returns 0.4812118250596
+   *    math.asech(0.5);       // returns 1.3169578969248166
    *
    * See also:
    *

--- a/lib/function/trigonometry/asech.js
+++ b/lib/function/trigonometry/asech.js
@@ -18,7 +18,7 @@ module.exports = function (math) {
 
   /**
    * Calculate the hyperbolic arccos of a value,
-   * defined as `asech(x) = 1 / ln(x + sqrt(x^2 - 1))`.
+   * defined as `asech(x) = ln(1/x + sqrt(1/x^2 - 1))`.
    *
    * For matrices, the function is evaluated element wise.
    *
@@ -43,21 +43,26 @@ module.exports = function (math) {
     }
 
     if (isNumber(x)) {
-      return 1 / Math.log(x + Math.sqrt(x*x - 1));
+      x = 1 / x;
+      return Math.log(x + Math.sqrt(x*x - 1));
     }
 
     if (isComplex(x)) {
-      return new Complex(
-        1 / Math.log(x.re + Math.sqrt(x.re*x.re - 1)),
-        1 / Math.log(x.im + Math.sqrt(x.im + 1)*Math.sqrt(x.im - 1))
-      );
-    }
-
-    if (isUnit(x)) {
-      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function asech is no angle');
+      if (x.re == 0 && x.im == 0) {
+        return new Complex(Infinity, 0);
       }
-      return asech(x.value);
+
+      // acsch(z) = -i*asinh(1/z)
+      var den = x.re*x.re + x.im*x.im;
+      if (den != 0) {
+        x.re =  x.re / den;
+        x.im = -x.im / den;
+      } else {
+        x.re = (x.re != 0) ?  (x.re / 0) : 0;
+        x.im = (x.im != 0) ? -(x.im / 0) : 0;
+      }
+
+      return math.acosh(x);
     }
 
     if (isCollection(x)) {

--- a/lib/function/trigonometry/asinh.js
+++ b/lib/function/trigonometry/asinh.js
@@ -47,17 +47,17 @@ module.exports = function (math) {
     }
 
     if (isComplex(x)) {
-      return new Complex(
-        Math.log(x.re + Math.sqrt(x.re*x.re + 1)),
-        Math.log(x.im + Math.sqrt(x.im*x.im + 1))
-      );
-    }
+      // asinh(z) = (-asin((z.im, -z.re)).im, asin((z.im, -z.re)).re)
+      var temp = x.im;
+      x.im = -x.re;
+      x.re = temp;
 
-    if (isUnit(x)) {
-      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function asinh is no angle');
-      }
-      return asinh(x.value);
+      var asin = math.asin(x);
+      temp = asin.re;
+      asin.re = -asin.im;
+      asin.im = temp;
+
+      return asin;
     }
 
     if (isCollection(x)) {

--- a/lib/function/trigonometry/asinh.js
+++ b/lib/function/trigonometry/asinh.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      BigNumber = math.type.BigNumber,
+      Complex = require('../../type/Complex'),
+      Unit = require('../../type/Unit'),
+      collection = require('../../type/collection'),
+
+      isNumber = util.number.isNumber,
+      isBoolean = util['boolean'].isBoolean,
+      isComplex = Complex.isComplex,
+      isUnit = Unit.isUnit,
+      isCollection = collection.isCollection,
+
+      bigAsinh = util.bignumber.acosh_asinh_asech_acsch;
+
+  /**
+   * Calculate the hyperbolic arcsine of a value,
+   * defined as `asinh(x) = ln(x + sqrt(x^2 + 1))`.
+   *
+   * For matrices, the function is evaluated element wise.
+   *
+   * Syntax:
+   *
+   *    math.asinh(x)
+   *
+   * Examples:
+   *
+   *    math.asinh(0.5);       // returns 0.4812118250596
+   *
+   * See also:
+   *
+   *    acosh, atanh
+   *
+   * @param {Number | Boolean | Complex | Unit | Array | Matrix | null} x  Function input
+   * @return {Number | Complex | Array | Matrix} Hyperbolic arcsine of x
+   */
+  math.asinh = function asinh(x) {
+    if (arguments.length != 1) {
+      throw new math.error.ArgumentsError('asinh', arguments.length, 1);
+    }
+
+    if (isNumber(x)) {
+      return Math.log(x + Math.sqrt(x*x + 1));
+    }
+
+    if (isComplex(x)) {
+      return new Complex(
+        Math.log(x.re + Math.sqrt(x.re*x.re + 1)),
+        Math.log(x.im + Math.sqrt(x.im*x.im + 1))
+      );
+    }
+
+    if (isUnit(x)) {
+      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
+        throw new TypeError('Unit in function asinh is no angle');
+      }
+      return asinh(x.value);
+    }
+
+    if (isCollection(x)) {
+      return collection.deepMap(x, asinh);
+    }
+
+    if (isBoolean(x) || x === null) {
+      return (x) ? Math.log(1 + Math.SQRT2) : 0;
+    }
+
+    if (x instanceof BigNumber) {
+      return bigAsinh(x, 1, false);
+    }
+
+    throw new math.error.UnsupportedTypeError('asinh', math['typeof'](x));
+  };
+};

--- a/lib/function/trigonometry/asinh.js
+++ b/lib/function/trigonometry/asinh.js
@@ -65,11 +65,11 @@ module.exports = function (math) {
     }
 
     if (isBoolean(x) || x === null) {
-      return (x) ? Math.log(1 + Math.SQRT2) : 0;
+      return (x) ? 0.881373587019543 : 0;
     }
 
     if (x instanceof BigNumber) {
-      return bigAsinh(x, 1, false);
+      return bigAsinh(x, true, false);
     }
 
     throw new math.error.UnsupportedTypeError('asinh', math['typeof'](x));

--- a/lib/function/trigonometry/asinh.js
+++ b/lib/function/trigonometry/asinh.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    * Examples:
    *
-   *    math.asinh(0.5);       // returns 0.4812118250596
+   *    math.asinh(0.5);       // returns 0.48121182505960347
    *
    * See also:
    *

--- a/lib/function/trigonometry/atanh.js
+++ b/lib/function/trigonometry/atanh.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = function (math) {
+  var util = require('../../util/index'),
+
+      BigNumber = math.type.BigNumber,
+      Complex = require('../../type/Complex'),
+      Unit = require('../../type/Unit'),
+      collection = require('../../type/collection'),
+
+      isNumber = util.number.isNumber,
+      isBoolean = util['boolean'].isBoolean,
+      isComplex = Complex.isComplex,
+      isUnit = Unit.isUnit,
+      isCollection = collection.isCollection,
+
+      bigAtanh = util.bignumber.atanh_acoth;
+
+  /**
+   * Calculate the hyperbolic arctangent of a value,
+   * defined as `atanh(x) = ln((1 + x)/(1 - x)) / 2`.
+   *
+   * For matrices, the function is evaluated element wise.
+   *
+   * Syntax:
+   *
+   *    math.atanh(x)
+   *
+   * Examples:
+   *
+   *    math.atanh(0.5);       // returns 0.4812118250596
+   *
+   * See also:
+   *
+   *    acosh, asinh
+   *
+   * @param {Number | Boolean | Complex | Unit | Array | Matrix | null} x  Function input
+   * @return {Number | Complex | Array | Matrix} Hyperbolic arctangent of x
+   */
+  math.atanh = function atanh(x) {
+    if (arguments.length != 1) {
+      throw new math.error.ArgumentsError('atanh', arguments.length, 1);
+    }
+
+    if (isNumber(x)) {
+      return Math.log((1 + x)/(1 - x)) / 2;
+    }
+
+    if (isComplex(x)) {
+      return new Complex(
+        Math.log((1 + x.re)/(1 - x.re)) / 2,
+        (Math.log(1 + x.im) - Math.log(1 - x.im)) / 2
+      );
+    }
+
+    if (isUnit(x)) {
+      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
+        throw new TypeError('Unit in function atanh is no angle');
+      }
+      return atanh(x.value);
+    }
+
+    if (isCollection(x)) {
+      return collection.deepMap(x, atanh);
+    }
+
+    if (isBoolean(x) || x === null) {
+      return (x) ? Infinity : 0;
+    }
+
+    if (x instanceof BigNumber) {
+      return bigAtanh(x, false);
+    }
+
+    throw new math.error.UnsupportedTypeError('atanh', math['typeof'](x));
+  };
+};

--- a/lib/function/trigonometry/atanh.js
+++ b/lib/function/trigonometry/atanh.js
@@ -28,7 +28,7 @@ module.exports = function (math) {
    *
    * Examples:
    *
-   *    math.atanh(0.5);       // returns 0.4812118250596
+   *    math.atanh(0.5);       // returns 0.5493061443340549
    *
    * See also:
    *

--- a/lib/function/trigonometry/atanh.js
+++ b/lib/function/trigonometry/atanh.js
@@ -47,17 +47,30 @@ module.exports = function (math) {
     }
 
     if (isComplex(x)) {
-      return new Complex(
-        Math.log((1 + x.re)/(1 - x.re)) / 2,
-        (Math.log(1 + x.im) - Math.log(1 - x.im)) / 2
-      );
-    }
+      // x.im should equal -pi / 2 in this case
+      var noIM = x.re > 1 && x.im == 0;
 
-    if (isUnit(x)) {
-      if (!x.hasBase(Unit.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function atanh is no angle');
+      var oneMinus = 1 - x.re;
+      var onePlus = 1 + x.re;
+      var den = oneMinus*oneMinus + x.im*x.im;
+      x = (den != 0)
+        ? new Complex(
+            (onePlus*oneMinus - x.im*x.im) / den,
+            (x.im*oneMinus + onePlus*x.im) / den
+          )
+        : new Complex(
+            (x.re != -1) ? (x.re / 0) : 0,
+            (x.im != 0) ? (x.im / 0) : 0
+          );
+
+      var temp = x.re;
+      x.re = Math.log(Math.sqrt(x.re*x.re + x.im*x.im)) / 2;
+      x.im = Math.atan2(x.im, temp) / 2;
+
+      if (noIM) {
+        x.im = -x.im;
       }
-      return atanh(x.value);
+      return x;
     }
 
     if (isCollection(x)) {

--- a/lib/function/trigonometry/cos.js
+++ b/lib/function/trigonometry/cos.js
@@ -14,7 +14,7 @@ module.exports = function (math, config) {
       isUnit = Unit.isUnit,
       isCollection = collection.isCollection,
 
-      bigCos = util.bignumber.cos_sin;
+      bigCos = util.bignumber.cos_sin_sec_csc;
 
   /**
    * Calculate the cosine of a value.
@@ -75,7 +75,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCos(x, config.precision, 0);
+      return bigCos(x, config.precision, 0, false);
     }
 
     throw new math.error.UnsupportedTypeError('cos', math['typeof'](x));

--- a/lib/function/trigonometry/cosh.js
+++ b/lib/function/trigonometry/cosh.js
@@ -14,7 +14,7 @@ module.exports = function (math) {
       isUnit = Unit.isUnit,
       isCollection = collection.isCollection,
 
-      bigCosh = util.bignumber.cosh_sinh;
+      bigCosh = util.bignumber.cosh_sinh_csch_sech;
 
   /**
    * Calculate the hyperbolic cosine of a value,
@@ -68,7 +68,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCosh(x, 0);
+      return bigCosh(x, 0, false);
     }
 
     throw new math.error.UnsupportedTypeError('cosh', math['typeof'](x));

--- a/lib/function/trigonometry/cosh.js
+++ b/lib/function/trigonometry/cosh.js
@@ -68,7 +68,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCosh(x, 0, false);
+      return bigCosh(x, false, false);
     }
 
     throw new math.error.UnsupportedTypeError('cosh', math['typeof'](x));

--- a/lib/function/trigonometry/cot.js
+++ b/lib/function/trigonometry/cot.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (math) {
+module.exports = function (math, config) {
   var util = require('../../util/index'),
 
       BigNumber = math.type.BigNumber,
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigCot = util.bignumber.tan_cot;
 
   /**
    * Calculate the cotangent of a value. `cot(x)` is defined as `1 / tan(x)`.
@@ -70,9 +72,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return cot(x.toNumber());
+      return bigCot(x, config.precision, true);
     }
 
     throw new math.error.UnsupportedTypeError('cot', math['typeof'](x));

--- a/lib/function/trigonometry/coth.js
+++ b/lib/function/trigonometry/coth.js
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigCoth = util.bignumber.tanh_coth;
 
   /**
    * Calculate the hyperbolic cotangent of a value,
@@ -74,9 +76,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return coth(x.toNumber());
+      return bigCoth(x, true);
     }
 
     throw new math.error.UnsupportedTypeError('coth', math['typeof'](x));

--- a/lib/function/trigonometry/csc.js
+++ b/lib/function/trigonometry/csc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (math) {
+module.exports = function (math, config) {
   var util = require('../../util/index'),
 
       BigNumber = math.type.BigNumber,
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigCsc = util.bignumber.cos_sin_sec_csc;
 
   /**
    * Calculate the cosecant of a value, defined as `csc(x) = 1/sin(x)`.
@@ -71,9 +73,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return csc(x.toNumber());
+      return bigCsc(x, config.precision, 1, true);
     }
 
     throw new math.error.UnsupportedTypeError('csc', math['typeof'](x));

--- a/lib/function/trigonometry/csch.js
+++ b/lib/function/trigonometry/csch.js
@@ -13,7 +13,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigCsch = util.bignumber.cosh_sinh_csch_sech;
 
   /**
    * Calculate the hyperbolic cosecant of a value,
@@ -45,7 +47,7 @@ module.exports = function (math) {
 
     if (isNumber(x)) {
       // x == 0
-      if (x == 0) return Number.NaN;
+      if (x == 0) return Number.POSITIVE_INFINITY;
       // consider values close to zero (+/-)
       return Math.abs(2 / (Math.exp(x) - Math.exp(-x))) * number.sign(x);
     }
@@ -75,9 +77,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return csch(x.toNumber());
+      return bigCsch(x, 1, true);
     }
 
     throw new math.error.UnsupportedTypeError('csch', math['typeof'](x));

--- a/lib/function/trigonometry/csch.js
+++ b/lib/function/trigonometry/csch.js
@@ -77,7 +77,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCsch(x, 1, true);
+      return bigCsch(x, true, true);
     }
 
     throw new math.error.UnsupportedTypeError('csch', math['typeof'](x));

--- a/lib/function/trigonometry/sec.js
+++ b/lib/function/trigonometry/sec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (math) {
+module.exports = function (math, config) {
   var util = require('../../util/index'),
 
       BigNumber = math.type.BigNumber,
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigSec = util.bignumber.cos_sin_sec_csc;
 
   /**
    * Calculate the secant of a value, defined as `sec(x) = 1/cos(x)`.
@@ -71,9 +73,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return sec(x.toNumber());
+      return bigSec(x, config.precision, 0, true);
     }
 
     throw new math.error.UnsupportedTypeError('sec', math['typeof'](x));

--- a/lib/function/trigonometry/sech.js
+++ b/lib/function/trigonometry/sech.js
@@ -73,7 +73,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSech(x, 0, true);
+      return bigSech(x, false, true);
     }
 
     throw new math.error.UnsupportedTypeError('sech', math['typeof'](x));

--- a/lib/function/trigonometry/sech.js
+++ b/lib/function/trigonometry/sech.js
@@ -12,7 +12,9 @@ module.exports = function (math) {
       isBoolean = util['boolean'].isBoolean,
       isComplex = Complex.isComplex,
       isUnit = Unit.isUnit,
-      isCollection = collection.isCollection;
+      isCollection = collection.isCollection,
+
+      bigSech = util.bignumber.cosh_sinh_csch_sech;
 
   /**
    * Calculate the hyperbolic secant of a value,
@@ -71,9 +73,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      // TODO: implement BigNumber support
-      // downgrade to Number
-      return sech(x.toNumber());
+      return bigSech(x, 0, true);
     }
 
     throw new math.error.UnsupportedTypeError('sech', math['typeof'](x));

--- a/lib/function/trigonometry/sin.js
+++ b/lib/function/trigonometry/sin.js
@@ -14,7 +14,7 @@ module.exports = function (math, config) {
       isUnit = Unit.isUnit,
       isCollection = collection.isCollection,
 
-      bigSin = util.bignumber.cos_sin;
+      bigSin = util.bignumber.cos_sin_sec_csc;
 
   /**
    * Calculate the sine of a value.
@@ -74,7 +74,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSin(x, config.precision, 1);
+      return bigSin(x, config.precision, 1, false);
     }
 
     throw new math.error.UnsupportedTypeError('sin', math['typeof'](x));

--- a/lib/function/trigonometry/sinh.js
+++ b/lib/function/trigonometry/sinh.js
@@ -14,7 +14,7 @@ module.exports = function (math) {
       isUnit = Unit.isUnit,
       isCollection = collection.isCollection,
 
-      bigSinh = util.bignumber.cosh_sinh;
+      bigSinh = util.bignumber.cosh_sinh_csch_sech;
 
   /**
    * Calculate the hyperbolic sine of a value,
@@ -74,7 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSinh(x, 1);
+      return bigSinh(x, 1, false);
     }
 
     throw new math.error.UnsupportedTypeError('sinh', math['typeof'](x));

--- a/lib/function/trigonometry/sinh.js
+++ b/lib/function/trigonometry/sinh.js
@@ -74,7 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSinh(x, 1, false);
+      return bigSinh(x, true, false);
     }
 
     throw new math.error.UnsupportedTypeError('sinh', math['typeof'](x));

--- a/lib/function/trigonometry/tan.js
+++ b/lib/function/trigonometry/tan.js
@@ -14,7 +14,7 @@ module.exports = function (math, config) {
       isUnit = Unit.isUnit,
       isCollection = collection.isCollection,
 
-      bigTan = util.bignumber.tan;
+      bigTan = util.bignumber.tan_cot;
 
   /**
    * Calculate the tangent of a value. `tan(x)` is equal to `sin(x) / cos(x)`.
@@ -75,7 +75,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigTan(x, config.precision);
+      return bigTan(x, config.precision, false);
     }
 
     throw new math.error.UnsupportedTypeError('tan', math['typeof'](x));

--- a/lib/function/trigonometry/tanh.js
+++ b/lib/function/trigonometry/tanh.js
@@ -14,7 +14,7 @@ module.exports = function (math) {
       isUnit = Unit.isUnit,
       isCollection = collection.isCollection,
 
-      bigTanh = util.bignumber.tanh;
+      bigTanh = util.bignumber.tanh_coth;
 
   /**
    * Calculate the hyperbolic tangent of a value,
@@ -77,7 +77,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigTanh(x);
+      return bigTanh(x, false);
     }
 
     throw new math.error.UnsupportedTypeError('tanh', math['typeof'](x));

--- a/lib/math.js
+++ b/lib/math.js
@@ -291,9 +291,15 @@ function create (config) {
 
   // functions - trigonometry
   require('./function/trigonometry/acos')(math, _config);
+  require('./function/trigonometry/acosh')(math, _config);
+  require('./function/trigonometry/acoth')(math, _config);
+  require('./function/trigonometry/acsch')(math, _config);
+  require('./function/trigonometry/asech')(math, _config);
   require('./function/trigonometry/asin')(math, _config);
+  require('./function/trigonometry/asinh')(math, _config);
   require('./function/trigonometry/atan')(math, _config);
   require('./function/trigonometry/atan2')(math, _config);
+  require('./function/trigonometry/atanh')(math, _config);
   require('./function/trigonometry/cos')(math, _config);
   require('./function/trigonometry/cosh')(math, _config);
   require('./function/trigonometry/cot')(math, _config);

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -646,21 +646,20 @@ exports.acosh_asinh_asech_acsch = function (x, mode, reciprocal) {
       if (x.isNegative() || x.gt(Big.ONE)) {
         throw new Error('asech() only has non-complex values for 0 <= x <= 1.');
       }
-    } else {
-      if (x.lt(Big.ONE)) {
-        throw new Error('acosh() only has non-complex values for x >= 1.');
-      }
+    } else if (x.lt(Big.ONE)) {
+      throw new Error('acosh() only has non-complex values for x >= 1.');
     }
   }
 
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
-  var plusOrMinus = (mode) ? x.plus : x.minus;
-  var ret = x.plus(x.times(x).plusOrMinus(Big.ONE).sqrt()).ln();
   if (reciprocal) {
-    ret = Big.ONE.div(ret);
+    x = Big.ONE.div(x);
   }
+
+  var x2PlusOrMinus = (mode) ? x.times(x).plus(Big.ONE) : x.times(x).minus(Big.ONE);
+  var ret = x.plus(x2PlusOrMinus.sqrt()).ln();
 
   Big.config({precision: precision});
   return new Big(ret.toPrecision(precision));
@@ -671,6 +670,8 @@ exports.acosh_asinh_asech_acsch = function (x, mode, reciprocal) {
  *
  * atanh(x) = ln((1 + x)/(1 - x)) / 2
  *
+ * acoth(x) = atanh(1 / x)
+ *
  * @param {BigNumber} x
  * @param {Boolean} reciprocal  is sec or csc
  * @returns {BigNumber} hyperbolic arctangent or arccotangent of x
@@ -680,27 +681,30 @@ exports.atanh_acoth = function (x, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
-  if (x.isZero()) {
-    return new Big(0);
-  }
 
   var absX = x.abs();
   if (absX.eq(Big.ONE)) {
     return new Big(x.isNegative() ? -Infinity : Infinity);
   }
-  if (abs.gt(Big.ONE)) {
+  if (absX.gt(Big.ONE)) {
     if (!reciprocal) {
       throw new Error('atanh() only has non-complex values for |x| <= 1.');
     }
   } else if (reciprocal) {
-    throw new Error('acoth() has complex values for |x| < 1, except x = 0.');
+    throw new Error('acoth() has complex values for |x| < 1.');
+  }
+
+  if (x.isZero()) {
+    return new Big(0);
   }
 
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
-  var ret = Big.ONE.plus(x).div(Big.ONE.minus(x)).ln();
-  ret = (reciprocal) ? new Big(2).div(ret) : ret.div(2);
+  if (reciprocal) {
+    x = Big.ONE.div(x);
+  }
+  var ret = Big.ONE.plus(x).div(Big.ONE.minus(x)).ln().div(2);
 
   Big.config({precision: precision});
   return new Big(ret.toPrecision(precision));

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -484,12 +484,12 @@ function decCoefficientToBinaryString(x) {
  *************************************/
 
 /**
- * Calculate the arc cosine of x
+ * Calculate the arccosine of x
  *
  * acos(x) = 2*atan(sqrt(1-x^2)/(1+x))
  *
  * @param {BigNumber} x
- * @returns {BigNumber} arc cosine of x
+ * @returns {BigNumber} arccosine of x
  */
 exports.arccos = function (x) {
   var Big = x.constructor;
@@ -510,10 +510,10 @@ exports.arccos = function (x) {
 };
 
 /**
- * Calculate the arc sine of x
+ * Calculate the arcsine of x
  *
  * @param {BigNumber} x
- * @returns {BigNumber} arc sine of x
+ * @returns {BigNumber} arcsine of x
  */
 exports.arcsin = function (x) {
   var Big = x.constructor;
@@ -568,10 +568,10 @@ exports.arcsin = function (x) {
 };
 
 /**
- * Calculate the arc tangent of x
+ * Calculate the arctangent of x
  *
  * @param {BigNumber} x
- * @returns {BigNumber} arc tangent of x
+ * @returns {BigNumber} arctangent of x
  */
 exports.arctan = function (x) {
   var Big = x.constructor;
@@ -589,10 +589,10 @@ exports.arctan = function (x) {
     return halfPi;
   }
 
+  Big.config({precision: precision + 4});
+
   var absX = x.abs();
   if (absX.lte(0.875)) {
-    Big.config({precision: precision + 4});
-
     var ret = arctan_taylor(x);
 
     ret.constructor = Big;
@@ -600,8 +600,6 @@ exports.arctan = function (x) {
     return ret.toDP(Big.precision - 1);
   }
   if (absX.gte(1.143)) {
-    Big.config({precision: precision + 4});
-
     // arctan(x) = sign(x)*((PI / 2) - arctan(1 / |x|))
     var halfPi = exports.pi(precision + 4).div(2);
     var ret = halfPi.minus(arctan_taylor(Big.ONE.div(absX)));
@@ -613,15 +611,103 @@ exports.arctan = function (x) {
   }
 
   // arctan(x) = arcsin(x / [sqrt(1 + x^2)])
-  Big.config({precision: precision + 4});
   x = x.div(x.times(x).plus(1).sqrt());
-  Big.config({precision: precision});
 
+  Big.config({precision: precision});
   return exports.arcsin(x);
 };
 
 /**
- * Calculate cosine/sine of x using the multiple angle identity:
+ * Calculate the hyperbolic arccosine, arcsine, arcsecant, or arccosecant of x
+ *
+ * acosh(x) = ln(x + sqrt(x^2 - 1))
+ *
+ * asinh(x) = ln(x + sqrt(x^2 + 1))
+ *
+ * asech(x) = 1 / ln(x + sqrt(x^2 - 1))
+ *
+ * acsch(x) = 1 / ln(x + sqrt(x^2 + 1))
+ *
+ * @param {BigNumber} x
+ * @param {Number} mode         cosine function if 0, sine function if 1
+ * @param {Boolean} reciprocal  is sec or csc
+ * @returns {BigNumber} hyperbolic arccosine, arcsine, arcsecant, or arccosecant of x
+ */
+exports.acosh_asinh_asech_acsch = function (x, mode, reciprocal) {
+  var Big = x.constructor;
+  if (x.isNaN()) {
+    return new Big(NaN);
+  }
+  if (reciprocal && x.isZero()) {
+    return new Big(Infinity);
+  }
+  if (!mode) {
+    if (reciprocal) {
+      if (x.isNegative() || x.gt(Big.ONE)) {
+        throw new Error('asech() only has non-complex values for 0 <= x <= 1.');
+      }
+    } else {
+      if (x.lt(Big.ONE)) {
+        throw new Error('acosh() only has non-complex values for x >= 1.');
+      }
+    }
+  }
+
+  var precision = Big.precision;
+  Big.config({precision: precision + 4});
+
+  var plusOrMinus = (mode) ? x.plus : x.minus;
+  var ret = x.plus(x.times(x).plusOrMinus(Big.ONE).sqrt()).ln();
+  if (reciprocal) {
+    ret = Big.ONE.div(ret);
+  }
+
+  Big.config({precision: precision});
+  return new Big(ret.toPrecision(precision));
+};
+
+/**
+ * Calculate the hyperbolic arctangent or arccotangent of x
+ *
+ * atanh(x) = ln((1 + x)/(1 - x)) / 2
+ *
+ * @param {BigNumber} x
+ * @param {Boolean} reciprocal  is sec or csc
+ * @returns {BigNumber} hyperbolic arctangent or arccotangent of x
+ */
+exports.atanh_acoth = function (x, reciprocal) {
+  var Big = x.constructor;
+  if (x.isNaN()) {
+    return new Big(NaN);
+  }
+  if (x.isZero()) {
+    return new Big(0);
+  }
+
+  var absX = x.abs();
+  if (absX.eq(Big.ONE)) {
+    return new Big(x.isNegative() ? -Infinity : Infinity);
+  }
+  if (abs.gt(Big.ONE)) {
+    if (!reciprocal) {
+      throw new Error('atanh() only has non-complex values for |x| <= 1.');
+    }
+  } else if (reciprocal) {
+    throw new Error('acoth() has complex values for |x| < 1, except x = 0.');
+  }
+
+  var precision = Big.precision;
+  Big.config({precision: precision + 4});
+
+  var ret = Big.ONE.plus(x).div(Big.ONE.minus(x)).ln();
+  ret = (reciprocal) ? new Big(2).div(ret) : ret.div(2);
+
+  Big.config({precision: precision});
+  return new Big(ret.toPrecision(precision));
+};
+
+/**
+ * Calculate the cosine/sine of x using the multiple angle identity:
  *
  * cos(4x) = 8[cos(x)^4 - cos(x)^2] + 1
  *
@@ -630,10 +716,11 @@ exports.arctan = function (x) {
  *
  * @param {BigNumber} x
  * @param {Number} precision    precision as defined in the config file
- * @param {Number} mode         sine function if 1, cosine function if 0
- * @returns {BigNumber} sine or cosine of x
+ * @param {Number} mode         cosine function if 0, sine function if 1
+ * @param {Boolean} reciprocal  is sec or csc
+ * @returns {BigNumber} cosine, sine, secant, or cosecant of x
  */
-exports.cos_sin = function (x, precision, mode) {
+exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
   var Big;
   if (x.isNaN() || !x.isFinite()) {
     Big = BigNumber.constructor({precision: precision});
@@ -651,13 +738,18 @@ exports.cos_sin = function (x, precision, mode) {
   }
 
   // Apply ~log(precision) guard bits
-  var precPlusGuardDigits = precision + (Math.log(precision) | 0) + 3; 
+  var precPlusGuardDigits = precision + (Math.log(precision) | 0) + 3;
   Big.config({precision: precPlusGuardDigits});
 
   y = reduceToPeriod(y, precPlusGuardDigits, mode);  // Make this destructive
   if (y[1]) {
+    y = y[0];
+    if (reciprocal && y.isZero()) {
+      y = new Big(Infinity);
+    }
+
     Big.config({precision: precision});
-    return y[0];
+    return y;
   }
 
   var ret;
@@ -702,6 +794,12 @@ exports.cos_sin = function (x, precision, mode) {
     }
   }
 
+  if (reciprocal) {
+    ret = (ret.e <= -precision)
+      ? new Big(Infinity)
+      : Big.ONE.div(ret);
+  }
+
   ret.constructor.config({precision: precision});
   return ret.toDP(precision - 1);
 };
@@ -711,11 +809,14 @@ exports.cos_sin = function (x, precision, mode) {
  *
  * tan(x) = sin(x) / cos(x)
  *
+ * cot(x) = cos(x) / sin(x)
+ *
  * @param {BigNumber} x
  * @param {Number} precision    precision as defined in the config file
- * @returns {BigNumber} tangent of x
+ * @param {Boolean} reciprocal  is cot
+ * @returns {BigNumber} tangent or cotangent of x
  */
-exports.tan = function (x, precision) {
+exports.tan_cot = function (x, precision, reciprocal) {
   var Big = BigNumber.constructor({precision: precision});
   if (x.isNaN()) {
     return new Big(NaN);
@@ -730,7 +831,7 @@ exports.tan = function (x, precision) {
     return new Big(Infinity);
   }
 
-  var sin = exports.cos_sin(y, precision + 2, 1);
+  var sin = exports.cos_sin_sec_csc(y, precision + 2, 1, false);
   var cos = sinToCos(sin);
 
   sin.constructor.config({precision: precision});
@@ -747,13 +848,13 @@ exports.tan = function (x, precision) {
   }
 
   sin.constructor.config({precision: precision + 2});
-  var tan = sin.div(cos);
+  var tan = (reciprocal) ? cos.div(sin) : sin.div(cos);
 
   return new Big(tan.toPrecision(precision));
 };
 
 /**
- * Calculate the hyperbolic cosine/sine of x
+ * Calculate the hyperbolic sine, cosine, secant, or cosecant of x
  *
  * cosh(x) = (exp(x) + exp(-x)) / 2
  *         = (e^x + 1/e^x) / 2
@@ -761,16 +862,26 @@ exports.tan = function (x, precision) {
  * sinh(x) = (exp(x) - exp(-x)) / 2
  *         = (e^x - 1/e^x) / 2
  *
+ * sech(x) = 2 / (exp(x) + exp(-x))
+ *         = 2 / (e^x + 1/e^x)
+ *
+ * csch(x) = 2 / (exp(x) - exp(-x))
+ *         = 2 / (e^x - 1/e^x)
+ *
  * @param {BigNumber} x
- * @param {Number} mode     cosh function if 0, sinh function if 1
- * @returns {BigNumber} cosh or sinh of x
+ * @param {Number} mode         cosh function if 0, sinh function if 1
+ * @param {Boolean} reciprocal  is sech or csch
+ * @returns {BigNumber} hyperbolic cosine, sine, secant. or cosecant of x
  */
-exports.cosh_sinh = function (x, mode) {
+exports.cosh_sinh_csch_sech = function (x, mode, reciprocal) {
   var Big = x.constructor;
   if (x.isNaN()) {
     return new Big(NaN);
   }
   if (!x.isFinite()) {
+    if (reciprocal) {
+      return new Big(0);
+    }
     return new Big((mode) ? x : Infinity);
   }
 
@@ -779,7 +890,7 @@ exports.cosh_sinh = function (x, mode) {
 
   var y = x.exp();
   y = (mode) ? y.minus(Big.ONE.div(y)) : y.plus(Big.ONE.div(y));
-  y = y.div(2);
+  y = (reciprocal) ? new Big(2).div(y) : y.div(2);
 
   Big.config({precision: precision});
   return new Big(y.toPrecision(precision));
@@ -792,10 +903,15 @@ exports.cosh_sinh = function (x, mode) {
  *         = (exp(2x) - 1) / (exp(2x) + 1)
  *         = (e^x - 1/e^x) / (e^x + 1/e^x)
  *
+ * coth(x) = (exp(x) - exp(-x)) / (exp(x) + exp(-x))
+ *         = (exp(2x) + 1) / (exp(2x) - 1)
+ *         = (e^x + 1/e^x) / (e^x - 1/e^x)
+ *
  * @param {BigNumber} x
- * @returns {BigNumber} tanh of x
+ * @param {Boolean} reciprocal  is coth
+ * @returns {BigNumber} hyperbolic tangent or cotangent of x
  */
-exports.tanh = function (x) {
+exports.tanh_coth = function (x, reciprocal) {
   var Big = x.constructor;
   if (x.isNaN()) {
     return new Big(NaN);
@@ -810,7 +926,7 @@ exports.tanh = function (x) {
   var posExp = x.exp();
   var negExp = Big.ONE.div(posExp);
   var ret = posExp.minus(negExp);
-  ret = ret.div(posExp.plus(negExp));
+  ret = (reciprocal) ? posExp.plus(negExp).div(ret) : ret.div(posExp.plus(negExp));
 
   Big.config({precision: precision});
   return ret.toDP(precision - 1);
@@ -841,7 +957,7 @@ function arcsin_newton(x, oldPrecision) {
 
   var i = 0;
   do {
-    var tmp0 = exports.cos_sin(curr, localPrecision, 1);
+    var tmp0 = exports.cos_sin_sec_csc(curr, localPrecision, 1, false);
     var tmp1 = sinToCos(tmp0);
     if (!tmp0.isZero()) {
       tmp0.s = curr.s;

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -247,10 +247,10 @@ exports.or = function (x, y) {
   if (!x.isFinite() || !y.isFinite()) {
     if ((!x.isFinite() && !x.isNegative() && y.isNegative()) ||
            (x.isNegative() && !y.isNegative() && !y.isFinite())) {
-        return negOne;
+      return negOne;
     }
     if (x.isNegative() && y.isNegative()) {
-        return x.isFinite() ? x : y;
+      return x.isFinite() ? x : y;
     }
     return x.isFinite() ? y : x;
   }
@@ -545,8 +545,8 @@ exports.arcsin = function (x) {
     Big.config({precision: precision});
     return x.toDP(precision - 1);
   }
-  var wasReduced;
-  if (wasReduced = absX.gt(0.58)) {
+  var wasReduced = absX.gt(0.58);
+  if (wasReduced) {
     Big.config({precision: precision + 8});
 
     // arcsin(x) = 2*arcsin(x / (sqrt(2)*sqrt(sqrt(1 - x^2) + 1)))
@@ -624,12 +624,12 @@ exports.arctan = function (x) {
  *
  * asinh(x) = ln(x + sqrt(x^2 + 1))
  *
- * asech(x) = 1 / ln(x + sqrt(x^2 - 1))
+ * asech(x) = acosh(1 / x)
  *
- * acsch(x) = 1 / ln(x + sqrt(x^2 + 1))
+ * acsch(x) = asinh(1 / x)
  *
  * @param {BigNumber} x
- * @param {Number} mode         cosine function if 0, sine function if 1
+ * @param {Boolean} mode        sine function if true, cosine function if false
  * @param {Boolean} reciprocal  is sec or csc
  * @returns {BigNumber} hyperbolic arccosine, arcsine, arcsecant, or arccosecant of x
  */
@@ -873,7 +873,7 @@ exports.tan_cot = function (x, precision, reciprocal) {
  *         = 2 / (e^x - 1/e^x)
  *
  * @param {BigNumber} x
- * @param {Number} mode         cosh function if 0, sinh function if 1
+ * @param {Boolean} mode        sinh function if true, cosh function if false
  * @param {Boolean} reciprocal  is sech or csch
  * @returns {BigNumber} hyperbolic cosine, sine, secant. or cosecant of x
  */

--- a/test/function/trigonometry/acos.test.js
+++ b/test/function/trigonometry/acos.test.js
@@ -63,6 +63,15 @@ describe('acos', function() {
     assert.deepEqual(acos(bigmath.cos(Big(2))).toString(), '2');
   });
 
+  it('should throw an error if the bignumber result is complex', function() {
+    assert.throws(function () {
+      acos(Big(1.1));
+    }, /acos() only has non-complex values for |x| <= 1./);
+    assert.throws(function () {
+      acos(Big(-1.1));
+    }, /acos() only has non-complex values for |x| <= 1./);
+  });
+
   it('should return the arccos of a complex number', function() {
     approx.deepEqual(acos(complex('2+3i')), complex(1.00014354247380, -1.98338702991654));
     approx.deepEqual(acos(complex('2-3i')), complex(1.00014354247380, 1.98338702991654));

--- a/test/function/trigonometry/acosh.test.js
+++ b/test/function/trigonometry/acosh.test.js
@@ -1,0 +1,100 @@
+var assert = require('assert'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    approx = require('../../../tools/approx'),
+    pi = math.pi,
+    acosh = math.acosh,
+    cosh = math.cosh,
+    complex = math.complex,
+    matrix = math.matrix,
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
+
+describe('acosh', function() {
+  it('should return the hyperbolic arccos of a boolean', function () {
+    assert.equal(acosh(true), 0);
+    assert.ok(isNaN(acosh(false)));
+  });
+
+  it('should return the hyperbolic arccos of null', function () {
+    assert.ok(isNaN(acosh(null)));
+  });
+
+  it('should return the hyperbolic arccos of a number', function() {
+    assert.ok(isNaN(acosh(-1.5)));
+    assert.ok(isNaN(acosh(0)));
+    approx.equal(acosh(1), 0);
+    approx.equal(acosh(2), 1.31695789692481670862504634730797);
+    approx.equal(acosh(3), 1.7627471740390860504652186499595);
+    approx.equal(acosh(pi), 1.811526272460853107021852049305);
+  });
+
+  it('should return the hyperbolic arccos of a bignumber', function() {
+    var arg = Big(1);
+    assert.deepEqual(acosh(arg), Big(0));
+    assert.deepEqual(acosh(Big(2)), Big('1.3169578969248167086'));
+    assert.deepEqual(acosh(Big(3)), Big('1.7627471740390860505'));
+    assert.deepEqual(acosh(bigmath.pi).toString(), '1.811526272460853107');
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg, Big(1));
+  });
+
+  it('should be the inverse function of hyperbolic cos', function() {
+    approx.equal(acosh(cosh(-1)), 1);
+    approx.equal(acosh(cosh(0)), 0);
+    approx.equal(acosh(cosh(0.1)), 0.1);
+    approx.equal(acosh(cosh(0.5)), 0.5);
+    approx.equal(acosh(cosh(2)), 2);
+  });
+
+  it('should be the inverse function of bignumber cosh', function() {
+    assert.deepEqual(acosh(bigmath.cosh(Big(-1))), Big(1));
+    assert.deepEqual(acosh(bigmath.cosh(Big(0))), Big(0));
+    assert.deepEqual(acosh(bigmath.cosh(Big(2))), Big(2));
+
+    /* Pass in more digits to pi. */
+    //bigmath.config({precision: 21});
+    //assert.deepEqual(acosh(bigmath.cosh(Big(0.1))), Big(0.1));
+    //assert.deepEqual(acosh(bigmath.cosh(Big(0.5))), Big(0.5));
+  });
+
+/*it('should throw an error if the bignumber result is complex', function() {
+    assert.throws(function () {
+      acosh(Big(0.5));
+    }, /acosh() only has non-complex values for x >= 1./);
+  });*/
+
+  it('should return the arccosh of a complex number', function() {
+    approx.deepEqual(acosh(complex('2+3i')), complex(1.9833870299165, 1.000143542473797));
+    approx.deepEqual(acosh(complex('2-3i')), complex(1.9833870299165, -1.000143542473797));
+    approx.deepEqual(acosh(complex('-2+3i')), complex(1.9833870299165, 2.14144911111600));
+    approx.deepEqual(acosh(complex('-2-3i')), complex(1.9833870299165, -2.14144911111600));
+    approx.deepEqual(acosh(complex('1+i')), complex(1.061275061905036, 0.904556894302381));
+    approx.deepEqual(acosh(complex('i')), complex(0.881373587019543, 1.570796326794897));
+    assert.deepEqual(acosh(complex('1')), complex(0, 0));
+    approx.deepEqual(acosh(complex('0')), complex(0, pi / 2));
+  });
+
+  it('should throw an error if called with a unit', function() {
+    assert.throws(function () {acosh(unit('45deg'))});
+    assert.throws(function () {acosh(unit('5 celsius'))});
+  });
+
+  it('should throw an error if called with a string', function() {
+    assert.throws(function () {acosh('string')});
+  });
+
+  it('should calculate the arccos element-wise for arrays and matrices', function() {
+    var acosh123 = [0, 1.3169578969248167, 1.7627471740390860504];
+    approx.deepEqual(acosh([1,2,3]), acosh123);
+    approx.deepEqual(acosh(matrix([1,2,3])), matrix(acosh123));
+  });
+
+  it('should throw an error in case of invalid number of arguments', function() {
+    assert.throws(function () {acosh()}, error.ArgumentsError);
+    assert.throws(function () {acosh(1, 2)}, error.ArgumentsError);
+  });
+
+});

--- a/test/function/trigonometry/acoth.test.js
+++ b/test/function/trigonometry/acoth.test.js
@@ -1,0 +1,114 @@
+var assert = require('assert'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    approx = require('../../../tools/approx'),
+    pi = math.pi,
+    acoth = math.acoth,
+    coth = math.coth,
+    complex = math.complex,
+    matrix = math.matrix,
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
+
+describe('acoth', function() {
+  it('should return the hyperbolic arccot of a boolean', function () {
+    assert.equal(acoth(true), Infinity);
+    assert.ok(isNaN(acoth(false)));
+  });
+
+  it('should return the hyperbolic arccot of null', function () {
+    assert.ok(isNaN(acoth(null)));
+  });
+
+  it('should return the hyperbolic arccot of a number', function() {
+    assert.ok(isNaN(acoth(-0.5)));
+    assert.ok(isNaN(acoth(0)));
+    assert.ok(isNaN(acoth(0.5)));
+
+    approx.equal(acoth(-2), -0.54930614433405484569762261846);
+    assert.equal(acoth(-1), -Infinity);
+    assert.equal(acoth(1), Infinity);
+    approx.equal(acoth(2), 0.54930614433405484569762261846);
+    assert.equal(acoth(Infinity), 0);
+  });
+
+  it('should return the hyperbolic arccot of a bignumber', function() {
+    var arg2 = Big(-2);
+    var arg3 = Big(-1);
+    assert.deepEqual(acoth(Big(-Infinity)), Big(0));
+    assert.deepEqual(acoth(arg2), Big('-0.5493061443340548457'));
+    assert.deepEqual(acoth(arg3), Big(-Infinity));
+    assert.deepEqual(acoth(Big(1)), Big(Infinity));
+    assert.deepEqual(acoth(Big(2)), Big('0.5493061443340548457'));
+    assert.deepEqual(acoth(Big(Infinity)), Big(0));
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg2, Big(-2));
+    assert.deepEqual(arg3, Big(-1));
+  });
+
+  it('should be the inverse function of hyperbolic cot', function() {
+    approx.equal(acoth(coth(-2)), -2);
+    approx.equal(acoth(coth(-1)), -1);
+    approx.equal(acoth(coth(0)), 0);
+    approx.equal(acoth(coth(1)), 1);
+    approx.equal(acoth(coth(2)), 2);
+  });
+
+  it('should be the inverse function of bignumber coth', function() {
+    assert.deepEqual(acoth(bigmath.coth(Big(-1))), Big(-1));
+    assert.deepEqual(acoth(bigmath.coth(Big(0))), Big(0));
+    assert.deepEqual(acoth(bigmath.coth(Big(1))), Big(1));
+
+    /* Pass in more digits to pi. */
+    //bigmath.config({precision: 21});
+    //assert.deepEqual(acoth(bigmath.coth(Big(-2))), Big(-2));
+    //assert.deepEqual(acoth(bigmath.coth(Big(2))), Big(2));
+  });
+
+  it('should throw an error if the bignumber result is complex', function() {
+    assert.throws(function () {
+      acoth(Big(-0.5));
+    }, /acoth() has complex values for |x| < 1./);
+    assert.throws(function () {
+      acoth(Big(0.5));
+    }, /acoth() has complex values for |x| < 1./);
+    assert.throws(function () {
+      acoth(Big(0));
+    }, /acoth() has complex values for |x| < 1./);
+  });
+
+  it('should return the arccoth of a complex number', function() {
+    approx.deepEqual(acoth(complex('2+3i')), complex(0.1469466662255, -0.2318238045004));
+    approx.deepEqual(acoth(complex('2-3i')), complex(0.1469466662255, 0.2318238045004));
+    approx.deepEqual(acoth(complex('-2+3i')), complex(-0.1469466662255, -0.2318238045004));
+    approx.deepEqual(acoth(complex('-2-3i')), complex(-0.1469466662255, 0.2318238045004));
+    approx.deepEqual(acoth(complex('1+i')), complex(0.4023594781085251, -0.55357435889705));
+    approx.deepEqual(acoth(complex('i')), complex(0, -pi / 4));
+    assert.deepEqual(acoth(complex('1')), complex(Infinity, 0));
+    approx.deepEqual(acoth(complex('0.5')), complex(0.5493061443340548, -1.5707963267949));
+    approx.deepEqual(acoth(complex('0')), complex(0, pi / 2));
+  });
+
+  it('should throw an error if called with a unit', function() {
+    assert.throws(function () {acoth(unit('45deg'))});
+    assert.throws(function () {acoth(unit('5 celsius'))});
+  });
+
+  it('should throw an error if called with a string', function() {
+    assert.throws(function () {acoth('string')});
+  });
+
+  it('should calculate the arccot element-wise for arrays and matrices', function() {
+    var acoth123 = [Infinity, 0.54930614433405, 0.34657359027997];
+    approx.deepEqual(acoth([1,2,3]), acoth123);
+    approx.deepEqual(acoth(matrix([1,2,3])), matrix(acoth123));
+  });
+
+  it('should throw an error in case of invalid number of arguments', function() {
+    assert.throws(function () {acoth()}, error.ArgumentsError);
+    assert.throws(function () {acoth(1, 2)}, error.ArgumentsError);
+  });
+
+});

--- a/test/function/trigonometry/acsch.test.js
+++ b/test/function/trigonometry/acsch.test.js
@@ -1,0 +1,95 @@
+var assert = require('assert'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    approx = require('../../../tools/approx'),
+    pi = math.pi,
+    acsch = math.acsch,
+    csch = math.csch,
+    complex = math.complex,
+    matrix = math.matrix,
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
+
+describe('acsch', function() {
+  it('should return the hyperbolic arccsc of a boolean', function () {
+    approx.equal(acsch(true), 0.8813735870195430);
+    assert.equal(acsch(false), Infinity);
+  });
+
+  it('should return the hyperbolic arccsc of null', function () {
+    assert.equal(acsch(null), Infinity);
+  });
+
+  it('should return the hyperbolic arccsc of a number', function() {
+    approx.equal(acsch(-2), -0.48121182505960344749775891342437);
+    approx.equal(acsch(-1), -0.88137358701954302523260932497979);
+    assert.equal(acsch(0), Infinity);
+    approx.equal(acsch(1), 0.88137358701954302523260932497979);
+    approx.equal(acsch(2), 0.48121182505960344749775891342437);
+    approx.equal(acsch(pi), 0.3131658804508683758718693082657);
+  });
+
+  it('should return the hyperbolic arccsc of a bignumber', function() {
+    var arg = Big(-2);
+    assert.deepEqual(acsch(arg), Big('-0.4812118250596034475'));
+    assert.deepEqual(acsch(Big(-1)), Big('-0.88137358701954302523'));
+    assert.deepEqual(acsch(Big(0)), Big(Infinity));
+    assert.deepEqual(acsch(Big(1)), Big('0.88137358701954302523'));
+    assert.deepEqual(acsch(Big(2)), Big('0.4812118250596034475'));
+    assert.deepEqual(acsch(bigmath.pi).toString(), '0.31316588045086837587');
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg, Big(-2));
+  });
+
+  it('should be the inverse function of hyperbolic csc', function() {
+    approx.equal(acsch(csch(-1)), -1);
+    approx.equal(acsch(csch(0)), 0);
+    approx.equal(acsch(csch(0.1)), 0.1);
+    approx.equal(acsch(csch(0.5)), 0.5);
+    approx.equal(acsch(csch(2)), 2);
+  });
+
+  it('should be the inverse function of bignumber csch', function() {
+    assert.deepEqual(acsch(bigmath.csch(Big(-2))), Big(-2));
+    assert.deepEqual(acsch(bigmath.csch(Big(-0.5))), Big(-0.5));
+    assert.deepEqual(acsch(bigmath.csch(Big(-0.1))), Big(-0.1));
+    assert.deepEqual(acsch(bigmath.csch(Big(0))), Big(0));
+    assert.deepEqual(acsch(bigmath.csch(Big(0.1))), Big(0.1));
+    assert.deepEqual(acsch(bigmath.csch(Big(0.5))), Big(0.5));
+    assert.deepEqual(acsch(bigmath.csch(Big(2))), Big(2));
+  });
+
+  it('should return the arccsch of a complex number', function() {
+    approx.deepEqual(acsch(complex('2+3i')), complex(0.157355498844985, -0.229962902377208));
+    approx.deepEqual(acsch(complex('2-3i')), complex(0.157355498844985, 0.229962902377208));
+    approx.deepEqual(acsch(complex('-2+3i')), complex(-0.157355498844985, -0.229962902377208));
+    approx.deepEqual(acsch(complex('-2-3i')), complex(-0.157355498844985, 0.229962902377208));
+    approx.deepEqual(acsch(complex('1+i')), complex(0.530637530952517826, -0.45227844715119068));
+    approx.deepEqual(acsch(complex('i')), complex(0, -pi / 2));
+    approx.deepEqual(acsch(complex('1')), complex(0.881373587019543025, 0));
+    assert.deepEqual(acsch(complex('0')), complex(Infinity, 0));
+  });
+
+  it('should throw an error if called with a unit', function() {
+    assert.throws(function () {acsch(unit('45deg'))});
+    assert.throws(function () {acsch(unit('5 celsius'))});
+  });
+
+  it('should throw an error if called with a string', function() {
+    assert.throws(function () {acsch('string')});
+  });
+
+  it('should calculate the arccsc element-wise for arrays and matrices', function() {
+    var acsch123 = [0.881373587019543025, 0.481211825059603447, 0.32745015023725844];
+    approx.deepEqual(acsch([1,2,3]), acsch123);
+    approx.deepEqual(acsch(matrix([1,2,3])), matrix(acsch123));
+  });
+
+  it('should throw an error in case of invalid number of arguments', function() {
+    assert.throws(function () {acsch()}, error.ArgumentsError);
+    assert.throws(function () {acsch(1, 2)}, error.ArgumentsError);
+  });
+
+});

--- a/test/function/trigonometry/asech.test.js
+++ b/test/function/trigonometry/asech.test.js
@@ -1,0 +1,111 @@
+var assert = require('assert'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    approx = require('../../../tools/approx'),
+    asech = math.asech,
+    sech = math.sech,
+    complex = math.complex,
+    matrix = math.matrix,
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
+
+describe('asech', function() {
+  it('should return the hyperbolic arcsec of a boolean', function () {
+    assert.equal(asech(true), 0);
+    assert.equal(asech(false), Infinity);
+  });
+
+  it('should return the hyperbolic arcsec of null', function () {
+    assert.equal(asech(null), Infinity);
+  });
+
+  it('should return the hyperbolic arcsec of a number', function() {
+    assert.ok(isNaN(asech(-1)));
+    assert.ok(isNaN(asech(1.1)));
+
+    assert.equal(asech(0), Infinity);
+    approx.equal(asech(0.25), 2.0634370688955605467272811726201);
+    approx.equal(asech(0.5), 1.31695789692481670862504634730797);
+    approx.equal(asech(0.75), 0.7953654612239056305278909331478);
+    assert.equal(asech(1), 0);
+  });
+
+  it('should return the hyperbolic arcsec of a bignumber', function() {
+    var arg1 = Big(0);
+    var arg2 = Big(0.25);
+    assert.deepEqual(asech(arg1), Big(Infinity));
+    assert.deepEqual(asech(arg2), Big('2.0634370688955605467'));
+    assert.deepEqual(asech(Big(0.5)), Big('1.3169578969248167086'));
+    assert.deepEqual(asech(Big(0.75)), Big('0.79536546122390563053'));
+    assert.deepEqual(asech(Big(1)), Big(0));
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg1, Big(0));
+    assert.deepEqual(arg2, Big(0.25));
+  });
+
+  it('should be the inverse function of hyperbolic sec', function() {
+    approx.equal(asech(sech(-1)), 1);
+    approx.equal(asech(sech(0)), 0);
+    approx.equal(asech(sech(0.1)), 0.1);
+    approx.equal(asech(sech(0.5)), 0.5);
+    approx.equal(asech(sech(2)), 2);
+  });
+
+  it('should be the inverse function of bignumber sech', function() {
+    assert.deepEqual(asech(bigmath.sech(Big(-1))), Big(1));
+    assert.deepEqual(asech(bigmath.sech(Big(0))), Big(0));
+    assert.deepEqual(asech(bigmath.sech(Big(0.5))), Big(0.5));
+    assert.deepEqual(asech(bigmath.sech(Big(2))), Big(2));
+
+    /* Pass in more digits to pi. */
+    //bigmath.config({precision: 21});
+    //assert.deepEqual(asech(bigmath.sech(Big(0.1))), Big(0.1));
+  });
+
+/*it('should throw an error if the bignumber result is complex', function() {
+    assert.throws(function () {
+      asech(Big(-1));
+    }, /asech() only has non-complex values for 0 <= x <= 1./);
+    assert.throws(function () {
+      asech(Big(2));
+    }, /asech() only has non-complex values for 0 <= x <= 1./);
+  });*/
+
+  it('should return the arcsech of a complex number', function() {
+    approx.deepEqual(asech(complex('2+3i')), complex(0.23133469857397, -1.420410722467035));
+    approx.deepEqual(asech(complex('2-3i')), complex(0.23133469857397, 1.420410722467035));
+    approx.deepEqual(asech(complex('-2+3i')), complex(0.23133469857397, -1.72118193112275858));
+    approx.deepEqual(asech(complex('-2-3i')), complex(0.23133469857397, 1.72118193112275858));
+    approx.deepEqual(asech(complex('1+i')), complex(0.5306375309525178, -1.11851787964370594));
+    approx.deepEqual(asech(complex('i')), complex(0.881373587019543, -1.570796326794897));
+    approx.deepEqual(asech(complex('2')), complex(0, math.pi / 3));
+    assert.deepEqual(asech(complex('1')), complex(0, 0));
+    approx.deepEqual(asech(complex('0.5')), complex(1.3169578969248, 0));
+    assert.deepEqual(asech(complex('0')), complex(Infinity, 0));
+    approx.deepEqual(asech(complex('-0.5')), complex(1.3169578969248, math.pi));
+    approx.deepEqual(asech(complex('-1')), complex(0, math.pi));
+  });
+
+  it('should throw an error if called with a unit', function() {
+    assert.throws(function () {asech(unit('45deg'))});
+    assert.throws(function () {asech(unit('5 celsius'))});
+  });
+
+  it('should throw an error if called with a string', function() {
+    assert.throws(function () {asech('string')});
+  });
+
+  it('should calculate the arcsec element-wise for arrays and matrices', function() {
+    var asech01 = [Infinity, 0];
+    assert.deepEqual(asech([0,1]), asech01);
+    assert.deepEqual(asech(matrix([0,1])), matrix(asech01));
+  });
+
+  it('should throw an error in case of invalid number of arguments', function() {
+    assert.throws(function () {asech()}, error.ArgumentsError);
+    assert.throws(function () {asech(1, 2)}, error.ArgumentsError);
+  });
+
+});

--- a/test/function/trigonometry/asin.test.js
+++ b/test/function/trigonometry/asin.test.js
@@ -84,6 +84,15 @@ describe('asin', function() {
     assert.deepEqual(asin(bigmath.sin(Big(2))).toString(), '1.1415926535897932385');
   });
 
+  it('should throw an error if the bignumber result is complex', function() {
+    assert.throws(function () {
+      asin(Big(1.1));
+    }, /asin() only has non-complex values for |x| <= 1./);
+    assert.throws(function () {
+      asin(Big(-1.1));
+    }, /asin() only has non-complex values for |x| <= 1./);
+  });
+
   it('should return the arcsin of a complex number', function() {
     var re = 0.570652784321099;
     var im = 1.983387029916536;

--- a/test/function/trigonometry/asinh.test.js
+++ b/test/function/trigonometry/asinh.test.js
@@ -1,0 +1,96 @@
+var assert = require('assert'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    approx = require('../../../tools/approx'),
+    pi = math.pi,
+    asinh = math.asinh,
+    sinh = math.sinh,
+    complex = math.complex,
+    matrix = math.matrix,
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
+
+describe('asinh', function() {
+  it('should return the hyperbolic arcsin of a boolean', function () {
+    approx.equal(asinh(true), 0.8813735870195430);
+    assert.equal(asinh(false), 0);
+  });
+
+  it('should return the hyperbolic arcsin of null', function () {
+    assert.equal(asinh(null), 0);
+  });
+
+  it('should return the hyperbolic arcsin of a number', function() {
+    approx.equal(asinh(-2), -1.44363547517881034249327674027311);
+    approx.equal(asinh(-1), -0.88137358701954302523260932497979);
+    approx.equal(asinh(0), 0);
+    approx.equal(asinh(1), 0.88137358701954302523260932497979);
+    approx.equal(asinh(2), 1.44363547517881034249327674027311);
+    approx.equal(asinh(pi), 1.8622957433108482198883613251826);
+  });
+
+  it('should return the hyperbolic arcsin of a bignumber', function() {
+    var arg = Big(-2);
+    assert.deepEqual(asinh(arg), Big('-1.4436354751788103425'));
+    assert.deepEqual(asinh(Big(-1)), Big('-0.88137358701954302523'));
+    assert.deepEqual(asinh(Big(0)), Big(0));
+    assert.deepEqual(asinh(Big(1)), Big('0.88137358701954302523'));
+    assert.deepEqual(asinh(Big(2)), Big('1.4436354751788103425'));
+    assert.deepEqual(asinh(bigmath.pi).toString(), '1.8622957433108482199');
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg, Big(-2));
+  });
+
+  it('should be the inverse function of hyperbolic sin', function() {
+    approx.equal(asinh(sinh(-1)), -1);
+    approx.equal(asinh(sinh(0)), 0);
+    approx.equal(asinh(sinh(0.1)), 0.1);
+    approx.equal(asinh(sinh(0.5)), 0.5);
+    approx.equal(asinh(sinh(2)), 2);
+  });
+
+  it('should be the inverse function of bignumber sinh', function() {
+    assert.deepEqual(asinh(bigmath.sinh(Big(-1))), Big(-1));
+    assert.deepEqual(asinh(bigmath.sinh(Big(0))), Big(0));
+    assert.deepEqual(asinh(bigmath.sinh(Big(0.5))), Big(0.5));
+    assert.deepEqual(asinh(bigmath.sinh(Big(2))), Big(2));
+
+    /* Pass in more digits to pi. */
+    //bigmath.config({precision: 21});
+    //assert.deepEqual(asinh(bigmath.sinh(Big(0.1))), Big(0.1));
+  });
+
+  it('should return the arcsinh of a complex number', function() {
+    approx.deepEqual(asinh(complex('2+3i')), complex(1.9686379257931, 0.9646585044076028));
+    approx.deepEqual(asinh(complex('2-3i')), complex(1.9686379257931, -0.9646585044076028));
+    approx.deepEqual(asinh(complex('-2+3i')), complex(-1.9686379257931, 0.9646585044076028));
+    approx.deepEqual(asinh(complex('-2-3i')), complex(-1.9686379257931, -0.9646585044076028));
+    approx.deepEqual(asinh(complex('1+i')), complex(1.0612750619050357, 0.6662394324925153));
+    approx.deepEqual(asinh(complex('i')), complex(0, pi / 2));
+    approx.deepEqual(asinh(complex('1')), complex(0.881373587019543025, 0));
+    assert.deepEqual(asinh(complex('0')), complex(0, 0));
+  });
+
+  it('should throw an error if called with a unit', function() {
+    assert.throws(function () {asinh(unit('45deg'))});
+    assert.throws(function () {asinh(unit('5 celsius'))});
+  });
+
+  it('should throw an error if called with a string', function() {
+    assert.throws(function () {asinh('string')});
+  });
+
+  it('should calculate the arcsin element-wise for arrays and matrices', function() {
+    var asinh123 = [0.881373587019543025, 1.4436354751788103, 1.8184464592320668];
+    approx.deepEqual(asinh([1,2,3]), asinh123);
+    approx.deepEqual(asinh(matrix([1,2,3])), matrix(asinh123));
+  });
+
+  it('should throw an error in case of invalid number of arguments', function() {
+    assert.throws(function () {asinh()}, error.ArgumentsError);
+    assert.throws(function () {asinh(1, 2)}, error.ArgumentsError);
+  });
+
+});

--- a/test/function/trigonometry/atanh.test.js
+++ b/test/function/trigonometry/atanh.test.js
@@ -1,0 +1,108 @@
+var assert = require('assert'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    approx = require('../../../tools/approx'),
+    pi = math.pi,
+    atanh = math.atanh,
+    tanh = math.tanh,
+    complex = math.complex,
+    matrix = math.matrix,
+    unit = math.unit,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    Big = bigmath.bignumber;
+
+describe('atanh', function() {
+  it('should return the hyperbolic arctan of a boolean', function () {
+    assert.equal(atanh(true), Infinity);
+    assert.equal(atanh(false), 0);
+  });
+
+  it('should return the hyperbolic arctan of null', function () {
+    assert.equal(atanh(null), 0);
+  });
+
+  it('should return the hyperbolic arctan of a number', function() {
+    assert.ok(isNaN(atanh(-1.1)));
+    assert.ok(isNaN(atanh(1.1)));
+
+    approx.equal(atanh(-1), -Infinity);
+    approx.equal(atanh(-0.5), -0.54930614433405484569762261846);
+    approx.equal(atanh(0), 0);
+    approx.equal(atanh(0.5), 0.54930614433405484569762261846);
+    approx.equal(atanh(1), Infinity);
+  });
+
+  it('should return the hyperbolic arctan of a bignumber', function() {
+    var arg1 = Big(-1);
+    var arg2 = Big(-0.5);
+    assert.deepEqual(atanh(arg1), Big(-Infinity));
+    assert.deepEqual(atanh(arg2), Big('-0.5493061443340548457')); 
+    assert.deepEqual(atanh(Big(0)), Big(0));
+    assert.deepEqual(atanh(Big(0.5)), Big('0.5493061443340548457')); 
+    assert.deepEqual(atanh(Big(1)), Big(Infinity));
+
+    //Make sure arg was not changed
+    assert.deepEqual(arg1, Big(-1));
+    assert.deepEqual(arg2, Big(-0.5));
+  });
+
+  it('should be the inverse function of hyperbolic tan', function() {
+    approx.equal(atanh(tanh(-1)), -1);
+    approx.equal(atanh(tanh(0)), 0);
+    approx.equal(atanh(tanh(0.1)), 0.1);
+    approx.equal(atanh(tanh(0.5)), 0.5);
+  });
+
+  it('should be the inverse function of bignumber tanh', function() {
+    assert.deepEqual(atanh(bigmath.tanh(Big(-0.5))), Big(-0.5));
+    assert.deepEqual(atanh(bigmath.tanh(Big(0))), Big(0));
+    assert.deepEqual(atanh(bigmath.tanh(Big(0.5))), Big(0.5));
+
+    /* Pass in more digits to pi. */
+    //bigmath.config({precision: 21});
+    //assert.deepEqual(atanh(bigmath.tanh(Big(-1))), Big(-1));
+    //assert.deepEqual(atanh(bigmath.tanh(Big(0.1))), Big(0.1));
+  });
+
+  it('should throw an error if the bignumber result is complex', function() {
+    assert.throws(function () {
+      atanh(Big(1.1));
+    }, /atanh() only has non-complex values for |x| <= 1./);
+    assert.throws(function () {
+      atanh(Big(-1.1));
+    }, /atanh() only has non-complex values for |x| <= 1./);
+  });
+
+  it('should return the arctanh of a complex number', function() {
+    approx.deepEqual(atanh(complex('2+3i')), complex(0.1469466662255, 1.33897252229449));
+    approx.deepEqual(atanh(complex('2-3i')), complex(0.1469466662255, -1.33897252229449));
+    approx.deepEqual(atanh(complex('-2+3i')), complex(-0.1469466662255, 1.33897252229449));
+    approx.deepEqual(atanh(complex('-2-3i')), complex(-0.1469466662255, -1.33897252229449));
+    approx.deepEqual(atanh(complex('1+i')), complex(0.402359478108525, 1.01722196789785137));
+    approx.deepEqual(atanh(complex('i')), complex(0, pi / 4));
+    approx.deepEqual(atanh(complex('2')), complex(0.54930614433405485, -1.5707963267948966));
+    assert.deepEqual(atanh(complex('1')), complex(Infinity, 0));
+    assert.deepEqual(atanh(complex('0')), complex(0, 0));
+  });
+
+  it('should throw an error if called with a unit', function() {
+    assert.throws(function () {atanh(unit('45deg'))});
+    assert.throws(function () {atanh(unit('5 celsius'))});
+  });
+
+  it('should throw an error if called with a string', function() {
+    assert.throws(function () {atanh('string')});
+  });
+
+  it('should calculate the arctan element-wise for arrays and matrices', function() {
+    var atanh101 = [-Infinity, 0, Infinity];
+    assert.deepEqual(atanh([-1,0,1]), atanh101);
+    assert.deepEqual(atanh(matrix([-1,0,1])), matrix(atanh101));
+  });
+
+  it('should throw an error in case of invalid number of arguments', function() {
+    assert.throws(function () {atanh()}, error.ArgumentsError);
+    assert.throws(function () {atanh(1, 2)}, error.ArgumentsError);
+  });
+
+});

--- a/test/function/trigonometry/cot.test.js
+++ b/test/function/trigonometry/cot.test.js
@@ -6,7 +6,9 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    cot = math.cot;
+    cot = math.cot,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({number: 'bignumber', precision: 22});
 
 describe('cot', function() {
   it('should return the cotan of a boolean', function () {
@@ -20,8 +22,8 @@ describe('cot', function() {
 
   it('should return the cotan of a number', function() {
     approx.equal(cot(0), Infinity);
-    approx.equal(1 / cot(pi*1/4), 1);
     approx.equal(1 / cot(pi*1/8), 0.414213562373095);
+    approx.equal(1 / cot(pi*1/4), 1);
     approx.equal(cot(pi*2/4), 0);
     approx.equal(1 / cot(pi*3/4), -1);
     approx.equal(1 / cot(pi*4/4), 0);
@@ -31,8 +33,34 @@ describe('cot', function() {
     approx.equal(1 / cot(pi*8/4), 0);
   });
 
-  it('should return the cotan of a bignumber (downgrades to number)', function() {
-    approx.equal(cot(math.bignumber(1)), 0.642092615934331);
+  it('should return the cotan of a bignumber', function() {
+    var Big = bigmath.bignumber;
+    var bigPi = bigmath.pi;
+    var sqrt2 = bigmath.SQRT2.toString();
+
+    var arg1 = Big(0);
+    var result1 = bigmath.cot(arg1);
+    assert.ok(!result1.isFinite());
+    assert.equal(result1.constructor.precision, 20);
+    assert.deepEqual(arg1, Big(0));
+
+    var result2 = bigmath.cot(bigPi.div(8));
+    assert.deepEqual(result2.toString(), '2.4142135623730950488');
+    assert.equal(result2.constructor.precision, 20);
+    assert.equal(bigPi.constructor.precision, 20);
+
+    assert.ok(bigmath.cot(bigPi.div(2)).isZero());
+    assert.ok(!bigmath.cot(bigPi).isFinite());
+    assert.ok(bigmath.cot(bigPi.times(3).div(2)).isZero());
+    assert.ok(!bigmath.cot(bigPi.times(2)).isFinite());
+    assert.ok(!bigmath.cot(bigmath.tau).isFinite());
+
+    /* Pass in more digits of pi. */
+    bigPi = biggermath.pi;
+    assert.deepEqual(bigmath.cot(bigPi.div(4)).toString(), '1');
+    assert.deepEqual(bigmath.cot(bigPi.times(3).div(4)).toString(), '-1');
+    assert.deepEqual(bigmath.cot(bigPi.times(5).div(4)).toString(), '1');
+    assert.deepEqual(bigmath.cot(bigPi.times(7).div(4)).toString(), '-1');
   });
 
   it('should return the cotan of a complex number', function() {

--- a/test/function/trigonometry/coth.test.js
+++ b/test/function/trigonometry/coth.test.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    coth = math.coth;
+    coth = math.coth,
+    bigmath = math.create({number: 'bignumber', precision: 20});
 
 describe('coth', function() {
   it('should return the coth of a boolean', function () {
@@ -26,8 +27,15 @@ describe('coth', function() {
     approx.equal(coth(3), 1.0049698233137);
   });
 
-  it('should return the coth of a bignumber (downgrades to number)', function() {
-    approx.equal(coth(math.bignumber(1)), 1.3130352854993);
+  it('should return the coth of a bignumber', function() {
+    var Big = bigmath.bignumber;
+    assert.deepEqual(coth(Big(0)), Big(Number.POSITIVE_INFINITY));
+    assert.deepEqual(coth(Big(1)), Big('1.3130352854993313036'));
+    assert.deepEqual(coth(Big(2)), Big('1.0373147207275480959'));
+    assert.deepEqual(coth(Big(3)), Big('1.0049698233136891711'));
+
+    /* Pass in extra digits to pi. */
+    //assert.deepEqual(coth(bigmath.pi), Big('0.0862667383340544147'));
   });
 
   it('should return the coth of a complex number', function() {

--- a/test/function/trigonometry/csc.test.js
+++ b/test/function/trigonometry/csc.test.js
@@ -6,7 +6,9 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    csc = math.csc;
+    csc = math.csc,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({number: 'bignumber', precision: 21});
 
 describe('csc', function() {
   it('should return the cosecant of a boolean', function () {
@@ -32,8 +34,25 @@ describe('csc', function() {
     approx.equal(1 / csc(pi/4), math.sqrt(2)/2);
   });
 
-  it('should return the cosecant of a bignumber (downgrades to number)', function() {
-    approx.equal(csc(math.bignumber(1)), 1.18839510577812);
+  it('should return the cosecant of a bignumber', function() {
+    var Big = bigmath.bignumber;
+    var bigPi = bigmath.pi;
+    var sqrt2 = bigmath.SQRT2.toString();
+
+    assert.ok(!bigmath.csc(Big(0)).isFinite());
+    assert.deepEqual(bigmath.csc(bigPi.div(8)).toString(), '2.6131259297527530557');
+    assert.deepEqual(bigmath.csc(bigPi.div(4)).toString(), sqrt2);
+    assert.deepEqual(bigmath.csc(bigPi.div(2)).toString(), '1');
+    assert.ok(!bigmath.csc(bigPi).isFinite());
+    assert.deepEqual(bigmath.csc(bigPi.times(3).div(2)).toString(), '-1');
+    assert.ok(!bigmath.csc(bigPi.times(2)).isFinite());
+    assert.ok(!bigmath.csc(bigmath.tau).isFinite());
+
+    /* Pass in more digits of pi. */
+    bigPi = biggermath.pi;
+    assert.deepEqual(bigmath.csc(bigPi.times(3).div(4)).toString(), sqrt2);
+    assert.deepEqual(bigmath.csc(bigPi.times(5).div(4)).toString(), '-'+sqrt2);
+    assert.deepEqual(bigmath.csc(bigPi.times(7).div(4)).toString(), '-'+sqrt2);
   });
 
   it('should return the cosecant of a complex number', function() {

--- a/test/function/trigonometry/csch.test.js
+++ b/test/function/trigonometry/csch.test.js
@@ -6,31 +6,39 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    csch = math.csch;
+    csch = math.csch,
+    bigmath = math.create({number: 'bignumber', precision: 20});
 
 describe('csch', function() {
   it('should return the csch of a boolean', function () {
     approx.equal(csch(true), 0.85091812823932);
-    approx.equal(csch(false), Number.NaN);
+    approx.equal(csch(false), Number.POSITIVE_INFINITY);
   });
 
   it('should return the csch of null', function () {
-    approx.equal(csch(null), Number.NaN);
+    approx.equal(csch(null), Number.POSITIVE_INFINITY);
   });
 
   it('should return the csch of a number', function() {
-    approx.equal(csch(0), Number.NaN);
+    approx.equal(csch(0), Number.POSITIVE_INFINITY);
     approx.equal(csch(pi), 0.086589537530047);
     approx.equal(csch(1), 0.85091812823932);
     approx.equal(csch(2), 0.27572056477178);
-    approx.equal(csch(3), 0.099821569668823);
     approx.equal(csch(3), 0.099821569668823);
     approx.equal(csch(1e-22), Number.POSITIVE_INFINITY);
     approx.equal(csch(-1e-22), Number.NEGATIVE_INFINITY);
   });
 
-  it('should return the csch of a bignumber (downgrades to number)', function() {
-    approx.equal(csch(math.bignumber(1)), 0.85091812823932);
+  it('should return the csch of a bignumber', function() {
+    var Big = bigmath.bignumber;
+
+    assert.deepEqual(csch(Big(0)), Big(Infinity));
+    assert.deepEqual(csch(Big(1)), Big('0.85091812823932154513'));
+    assert.deepEqual(csch(Big(2)), Big('0.27572056477178320776'));
+    assert.deepEqual(csch(Big(3)), Big('0.099821569668822732851'));
+
+    /* Pass in extra digits to pi. */
+    //assert.deepEqual(csch(bigmath.pi).toString(), '0.086589537530046941828');
   });
 
   it('should return the csch of a complex number', function() {

--- a/test/function/trigonometry/sec.test.js
+++ b/test/function/trigonometry/sec.test.js
@@ -6,7 +6,9 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    sec = math.sec;
+    sec = math.sec,
+    bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({number: 'bignumber', precision: 21});
 
 describe('sec', function() {
   it('should return the secant of a boolean', function () {
@@ -40,8 +42,26 @@ describe('sec', function() {
     approx.equal(sec(-2*pi), 1);
   });
 
-  it('should return the secant of a bignumber (downgrades to number)', function() {
-    approx.equal(sec(math.bignumber(1)), 1.85081571768093);
+  it('should return the secant of a bignumber', function() {
+    var Big = bigmath.bignumber;
+    var bigPi = bigmath.pi;
+    var sqrt2 = bigmath.SQRT2.toString();
+
+    assert.deepEqual(bigmath.sec(Big(0)).toString(), '1');
+    assert.deepEqual(bigmath.sec(bigPi.div(8)).toString(), '1.0823922002923939688');
+    assert.deepEqual(bigmath.sec(bigPi.div(4)).toString(), sqrt2);
+    assert.deepEqual(bigmath.sec(bigPi).toString(), '-1');
+    assert.deepEqual(bigmath.sec(bigPi.times(2)).toString(), '1');
+    assert.deepEqual(bigmath.sec(bigmath.tau).toString(), '1');
+    assert.deepEqual(bigmath.sec(bigmath.tau.times(-2)).toString(), '1');
+
+    /* Pass in one more digit of pi. */
+    bigPi = biggermath.pi;
+    assert.ok(!bigmath.sec(bigPi.div(2)).isFinite());
+    assert.deepEqual(bigmath.sec(bigPi.times(3).div(4)).toString(), '-'+sqrt2);
+    assert.deepEqual(bigmath.sec(bigPi.times(5).div(4)).toString(), '-'+sqrt2);
+    assert.ok(!bigmath.sec(bigPi.times(3).div(2)).isFinite());
+    assert.deepEqual(bigmath.sec(bigPi.times(7).div(4)).toString(), sqrt2);
   });
 
   it('should return the secant of a complex number', function() {

--- a/test/function/trigonometry/sech.test.js
+++ b/test/function/trigonometry/sech.test.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    sech = math.sech;
+    sech = math.sech,
+    bigmath = math.create({number: 'bignumber', precision: 20});
 
 describe('sech', function() {
   it('should return the sech of a boolean', function () {
@@ -26,8 +27,16 @@ describe('sech', function() {
     approx.equal(sech(3), 0.099327927419433);
   });
 
-  it('should return the sech of a bignumber (downgrades to number)', function() {
-    approx.equal(sech(math.bignumber(1)), 0.64805427366389);
+  it('should return the sech of a bignumber', function() {
+    var Big = bigmath.bignumber;
+
+    assert.deepEqual(sech(Big(0)), Big(1));
+    assert.deepEqual(sech(Big(1)), Big('0.64805427366388539957'));
+    assert.deepEqual(sech(Big(2)), Big('0.26580222883407969212'));
+    assert.deepEqual(sech(Big(3)), Big('0.099327927419433207829'));
+
+    /* Pass in extra digits to pi. */
+    //assert.deepEqual(sech(bigmath.pi), Big('0.0862667383340544147'));
   });
 
   it('should return the sech of a complex number', function() {


### PR DESCRIPTION
Added BigNumber functionality to the reciprocal ilk of trig functions (`csc`, `sec`, `cot`, etc), and added inverse hyperbolic functions in full (`asinh`, `acosh`, `atanh`, `acsch`, etc.).

The basic reciprocal trig functions can have higher precision values passed in, however the others can't. I will improve this, and I will also try to pass in the constructor in order to minimize the space used. I will also try to add the inverse reciprocal functions (I didn't notice they weren't here until I was almost done with this).