### PR TITLE
Now numbers from BigNumber trig calls use the default constructor rather...

### DIFF
--- a/lib/function/trigonometry/acos.js
+++ b/lib/function/trigonometry/acos.js
@@ -80,7 +80,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigArcCos(x, false);
+      return bigArcCos(x, BigNumber, false);
     }
 
     throw new math.error.UnsupportedTypeError('acos', math['typeof'](x));

--- a/lib/function/trigonometry/acosh.js
+++ b/lib/function/trigonometry/acosh.js
@@ -79,7 +79,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAcosh(x, false, false);
+      return bigAcosh(x, BigNumber, false, false);
     }
 
     throw new math.error.UnsupportedTypeError('acosh', math['typeof'](x));

--- a/lib/function/trigonometry/acot.js
+++ b/lib/function/trigonometry/acot.js
@@ -72,7 +72,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigArcCot(x, true);
+      return bigArcCot(x, BigNumber, true);
     }
 
     throw new math.error.UnsupportedTypeError('acot', math['typeof'](x));

--- a/lib/function/trigonometry/acoth.js
+++ b/lib/function/trigonometry/acoth.js
@@ -78,7 +78,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAcoth(x, true);
+      return bigAcoth(x, BigNumber, true);
     }
 
     throw new math.error.UnsupportedTypeError('acoth', math['typeof'](x));

--- a/lib/function/trigonometry/acsc.js
+++ b/lib/function/trigonometry/acsc.js
@@ -38,7 +38,6 @@ module.exports = function (math) {
    * @return {Number | Complex | Array | Matrix} The arc cosecant of x
    */
   math.acsc = function acsc(x) {
-
     if (arguments.length != 1) {
       throw new math.error.ArgumentsError('acsc', arguments.length, 1);
     }
@@ -76,7 +75,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigArcCsc(x, true);
+      return bigArcCsc(x, BigNumber, true);
     }
 
     throw new math.error.UnsupportedTypeError('acsc', math['typeof'](x));

--- a/lib/function/trigonometry/acsch.js
+++ b/lib/function/trigonometry/acsch.js
@@ -79,7 +79,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAcsch(x, true, true);
+      return bigAcsch(x, BigNumber, true, true);
     }
 
     throw new math.error.UnsupportedTypeError('acsch', math['typeof'](x));

--- a/lib/function/trigonometry/asec.js
+++ b/lib/function/trigonometry/asec.js
@@ -75,7 +75,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigArcSec(x, true);
+      return bigArcSec(x, BigNumber, true);
     }
 
     throw new math.error.UnsupportedTypeError('asec', math['typeof'](x));

--- a/lib/function/trigonometry/asech.js
+++ b/lib/function/trigonometry/asech.js
@@ -86,7 +86,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAsech(x, false, true);
+      return bigAsech(x, BigNumber, false, true);
     }
 
     throw new math.error.UnsupportedTypeError('asech', math['typeof'](x));

--- a/lib/function/trigonometry/asin.js
+++ b/lib/function/trigonometry/asin.js
@@ -78,7 +78,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigArcSin(x, false);
+      return bigArcSin(x, BigNumber, false);
     }
 
     throw new math.error.UnsupportedTypeError('asin', math['typeof'](x));

--- a/lib/function/trigonometry/asinh.js
+++ b/lib/function/trigonometry/asinh.js
@@ -74,7 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAsinh(x, true, false);
+      return bigAsinh(x, BigNumber, true, false);
     }
 
     throw new math.error.UnsupportedTypeError('asinh', math['typeof'](x));

--- a/lib/function/trigonometry/atan.js
+++ b/lib/function/trigonometry/atan.js
@@ -82,7 +82,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigArcTan(x, false);
+      return bigArcTan(x, BigNumber, false);
     }
 
     throw new math.error.UnsupportedTypeError('atan', math['typeof'](x));

--- a/lib/function/trigonometry/atanh.js
+++ b/lib/function/trigonometry/atanh.js
@@ -85,7 +85,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigAtanh(x, false);
+      return bigAtanh(x, BigNumber, false);
     }
 
     throw new math.error.UnsupportedTypeError('atanh', math['typeof'](x));

--- a/lib/function/trigonometry/cos.js
+++ b/lib/function/trigonometry/cos.js
@@ -75,7 +75,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCos(x, config.precision, 0, false);
+      return bigCos(x, BigNumber, 0, false);
     }
 
     throw new math.error.UnsupportedTypeError('cos', math['typeof'](x));

--- a/lib/function/trigonometry/cosh.js
+++ b/lib/function/trigonometry/cosh.js
@@ -68,7 +68,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCosh(x, false, false);
+      return bigCosh(x, BigNumber, false, false);
     }
 
     throw new math.error.UnsupportedTypeError('cosh', math['typeof'](x));

--- a/lib/function/trigonometry/cot.js
+++ b/lib/function/trigonometry/cot.js
@@ -72,7 +72,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCot(x, config.precision, true);
+      return bigCot(x, BigNumber, true);
     }
 
     throw new math.error.UnsupportedTypeError('cot', math['typeof'](x));

--- a/lib/function/trigonometry/coth.js
+++ b/lib/function/trigonometry/coth.js
@@ -76,7 +76,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCoth(x, true);
+      return bigCoth(x, BigNumber, true);
     }
 
     throw new math.error.UnsupportedTypeError('coth', math['typeof'](x));

--- a/lib/function/trigonometry/csc.js
+++ b/lib/function/trigonometry/csc.js
@@ -73,7 +73,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCsc(x, config.precision, 1, true);
+      return bigCsc(x, BigNumber, 1, true);
     }
 
     throw new math.error.UnsupportedTypeError('csc', math['typeof'](x));

--- a/lib/function/trigonometry/csch.js
+++ b/lib/function/trigonometry/csch.js
@@ -77,7 +77,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigCsch(x, true, true);
+      return bigCsch(x, BigNumber, true, true);
     }
 
     throw new math.error.UnsupportedTypeError('csch', math['typeof'](x));

--- a/lib/function/trigonometry/sec.js
+++ b/lib/function/trigonometry/sec.js
@@ -73,7 +73,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSec(x, config.precision, 0, true);
+      return bigSec(x, BigNumber, 0, true);
     }
 
     throw new math.error.UnsupportedTypeError('sec', math['typeof'](x));

--- a/lib/function/trigonometry/sech.js
+++ b/lib/function/trigonometry/sech.js
@@ -73,7 +73,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSech(x, false, true);
+      return bigSech(x, BigNumber, false, true);
     }
 
     throw new math.error.UnsupportedTypeError('sech', math['typeof'](x));

--- a/lib/function/trigonometry/sin.js
+++ b/lib/function/trigonometry/sin.js
@@ -74,7 +74,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSin(x, config.precision, 1, false);
+      return bigSin(x, BigNumber, 1, false);
     }
 
     throw new math.error.UnsupportedTypeError('sin', math['typeof'](x));

--- a/lib/function/trigonometry/sinh.js
+++ b/lib/function/trigonometry/sinh.js
@@ -74,7 +74,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigSinh(x, true, false);
+      return bigSinh(x, BigNumber, true, false);
     }
 
     throw new math.error.UnsupportedTypeError('sinh', math['typeof'](x));

--- a/lib/function/trigonometry/tan.js
+++ b/lib/function/trigonometry/tan.js
@@ -75,7 +75,7 @@ module.exports = function (math, config) {
     }
 
     if (x instanceof BigNumber) {
-      return bigTan(x, config.precision, false);
+      return bigTan(x, BigNumber, false);
     }
 
     throw new math.error.UnsupportedTypeError('tan', math['typeof'](x));

--- a/lib/function/trigonometry/tanh.js
+++ b/lib/function/trigonometry/tanh.js
@@ -77,7 +77,7 @@ module.exports = function (math) {
     }
 
     if (x instanceof BigNumber) {
-      return bigTanh(x, false);
+      return bigTanh(x, BigNumber, false);
     }
 
     throw new math.error.UnsupportedTypeError('tanh', math['typeof'](x));

--- a/lib/util/bignumber.js
+++ b/lib/util/bignumber.js
@@ -491,11 +491,11 @@ function decCoefficientToBinaryString(x) {
  * asec(x) = acos(1/x)
  *
  * @param {BigNumber} x
- * @param {Boolean} reciprocal  is sec
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} reciprocal   is sec
  * @returns {BigNumber} arccosine or arcsecant of x
  */
-exports.arccos_arcsec = function (x, reciprocal) {
-  var Big = x.constructor;
+exports.arccos_arcsec = function (x, Big, reciprocal) {
   var precision = Big.precision;
   if (reciprocal) {
     if (x.abs().lt(Big.ONE)) {
@@ -515,7 +515,7 @@ exports.arccos_arcsec = function (x, reciprocal) {
   }
 
   var acos = exports.arctan_arccot(Big.ONE.minus(x.times(x)).sqrt()
-                                      .div(x.plus(Big.ONE))).times(2);
+                                      .div(x.plus(Big.ONE)), Big).times(2);
 
   Big.config({precision: precision});
   return acos.toDP(precision - 1);
@@ -525,16 +525,16 @@ exports.arccos_arcsec = function (x, reciprocal) {
  * Calculate the arcsine or arccosecant of x
  *
  * @param {BigNumber} x
- * @param {Boolean} reciprocal  is csc
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} reciprocal   is csc
  * @returns {BigNumber} arcsine or arccosecant of x
  */
-exports.arcsin_arccsc = function (x, reciprocal) {
-  var Big = x.constructor;
-  var precision = Big.precision;
+exports.arcsin_arccsc = function (x, Big, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
 
+  var precision = Big.precision;
   var absX = x.abs();
   if (reciprocal) {
     if (absX.lt(Big.ONE)) {
@@ -557,7 +557,7 @@ exports.arcsin_arccsc = function (x, reciprocal) {
     // arcsin(x) = sign(x)*(Pi/2 - arcsin(sqrt(1 - x^2)))
     var sign = x.s;
     var halfPi = exports.pi(precision + 4).div(2);
-    x = halfPi.minus(exports.arcsin_arccsc(Big.ONE.minus(x.times(x)).sqrt()));
+    x = halfPi.minus(exports.arcsin_arccsc(Big.ONE.minus(x.times(x)).sqrt(), Big));
     x.s = sign;
 
     x.constructor = Big;
@@ -578,7 +578,7 @@ exports.arcsin_arccsc = function (x, reciprocal) {
   // Avoid overhead of Newton's Method if feasible
   var ret = (precision <= 60 || ((x.dp() <= Math.log(precision)) && x.lt(0.05)))
     ? arcsin_taylor(x, precision)
-    : arcsin_newton(x, precision);
+    : arcsin_newton(x, Big);
 
   if (wasReduced) {
     return ret.times(2);
@@ -590,17 +590,18 @@ exports.arcsin_arccsc = function (x, reciprocal) {
  * Calculate the arctangent or arccotangent of x
  *
  * @param {BigNumber} x
- * @param {Boolean} reciprocal  is cot
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} reciprocal   is cot
  * @returns {BigNumber} arctangent or arccotangent of x
  */
-exports.arctan_arccot = function (x, reciprocal) {
-  var Big = x.constructor;
+exports.arctan_arccot = function (x, Big, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
   if ((!reciprocal && x.isZero()) || (reciprocal && !x.isFinite())) {
     return new Big(0);
   }
+
   var precision = Big.precision;
   if ((!reciprocal && !x.isFinite()) || (reciprocal && x.isZero())) {
     var halfPi = exports.pi(precision + 2).div(2).toDP(precision - 1);
@@ -638,7 +639,7 @@ exports.arctan_arccot = function (x, reciprocal) {
   x = x.div(x.times(x).plus(1).sqrt());
 
   Big.config({precision: precision});
-  return exports.arcsin_arccsc(x, false);
+  return exports.arcsin_arccsc(x, Big);
 };
 
 /**
@@ -653,12 +654,12 @@ exports.arctan_arccot = function (x, reciprocal) {
  * acsch(x) = asinh(1 / x)
  *
  * @param {BigNumber} x
- * @param {Boolean} mode        sine function if true, cosine function if false
- * @param {Boolean} reciprocal  is sec or csc
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} mode         sine function if true, cosine function if false
+ * @param {Boolean} reciprocal   is sec or csc
  * @returns {BigNumber} hyperbolic arccosine, arcsine, arcsecant, or arccosecant of x
  */
-exports.acosh_asinh_asech_acsch = function (x, mode, reciprocal) {
-  var Big = x.constructor;
+exports.acosh_asinh_asech_acsch = function (x, Big, mode, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
@@ -678,12 +679,15 @@ exports.acosh_asinh_asech_acsch = function (x, mode, reciprocal) {
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
+  var y = new Big(x);
+  y.constructor = Big;
+
   if (reciprocal) {
-    x = Big.ONE.div(x);
+    y = Big.ONE.div(y);
   }
 
-  var x2PlusOrMinus = (mode) ? x.times(x).plus(Big.ONE) : x.times(x).minus(Big.ONE);
-  var ret = x.plus(x2PlusOrMinus.sqrt()).ln();
+  var x2PlusOrMinus = (mode) ? y.times(y).plus(Big.ONE) : y.times(y).minus(Big.ONE);
+  var ret = y.plus(x2PlusOrMinus.sqrt()).ln();
 
   Big.config({precision: precision});
   return new Big(ret.toPrecision(precision));
@@ -697,11 +701,11 @@ exports.acosh_asinh_asech_acsch = function (x, mode, reciprocal) {
  * acoth(x) = atanh(1 / x)
  *
  * @param {BigNumber} x
- * @param {Boolean} reciprocal  is sec or csc
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} reciprocal   is sec or csc
  * @returns {BigNumber} hyperbolic arctangent or arccotangent of x
  */
-exports.atanh_acoth = function (x, reciprocal) {
-  var Big = x.constructor;
+exports.atanh_acoth = function (x, Big, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
@@ -725,10 +729,13 @@ exports.atanh_acoth = function (x, reciprocal) {
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
+  var y = new Big(x);
+  y.constructor = Big;
+
   if (reciprocal) {
-    x = Big.ONE.div(x);
+    y = Big.ONE.div(y);
   }
-  var ret = Big.ONE.plus(x).div(Big.ONE.minus(x)).ln().div(2);
+  var ret = Big.ONE.plus(y).div(Big.ONE.minus(y)).ln().div(2);
 
   Big.config({precision: precision});
   return new Big(ret.toPrecision(precision));
@@ -743,21 +750,19 @@ exports.atanh_acoth = function (x, reciprocal) {
  * http://www.tc.umn.edu/~ringx004/sidebar.html
  *
  * @param {BigNumber} x
- * @param {Number} precision    precision as defined in the config file
- * @param {Number} mode         cosine function if 0, sine function if 1
- * @param {Boolean} reciprocal  is sec or csc
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Number} mode          cosine function if 0, sine function if 1
+ * @param {Boolean} reciprocal   is sec or csc
  * @returns {BigNumber} cosine, sine, secant, or cosecant of x
  */
-exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
-  var Big;
+exports.cos_sin_sec_csc = function (x, Big, mode, reciprocal) {
   if (x.isNaN() || !x.isFinite()) {
-    Big = BigNumber.constructor({precision: precision});
     return new Big(NaN);
   }
+  var precision = Big.precision;
 
   // Avoid changing the original value
-  var y = BigNumberCopy(x);
-  Big = y.constructor;
+  var y = new Big(x);
 
   // sin(-x) == -sin(x), cos(-x) == cos(x)
   var isNeg = y.isNegative();
@@ -770,6 +775,7 @@ exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
   Big.config({precision: precPlusGuardDigits});
 
   y = reduceToPeriod(y, precPlusGuardDigits, mode);  // Make this destructive
+  y[0].constructor = Big;
   if (y[1]) {
     y = y[0];
     if (reciprocal && y.isZero()) {
@@ -784,7 +790,7 @@ exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
   y = y[0];
   if (mode) {
     ret = cos_sin_taylor(y.div(3125), mode);
-    Big.config({precision: Math.min(Big.precision, precision + 15)});
+    Big.config({precision: Math.min(precPlusGuardDigits, precision + 15)});
 
     var five = new Big(5);
     var sixteen = new Big(16);
@@ -812,7 +818,7 @@ exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
     }
 
     ret = cos_sin_taylor(y.div(div_factor), mode);
-    Big.config({precision: Math.min(Big.precision, precision + 8)});
+    Big.config({precision: Math.min(precPlusGuardDigits, precision + 8)});
 
     var eight = new Big(8);
     for (; loops > 0; --loops) {
@@ -828,7 +834,7 @@ exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
       : Big.ONE.div(ret);
   }
 
-  ret.constructor.config({precision: precision});
+  Big.config({precision: precision});
   return ret.toDP(precision - 1);
 };
 
@@ -840,16 +846,16 @@ exports.cos_sin_sec_csc = function (x, precision, mode, reciprocal) {
  * cot(x) = cos(x) / sin(x)
  *
  * @param {BigNumber} x
- * @param {Number} precision    precision as defined in the config file
- * @param {Boolean} reciprocal  is cot
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} reciprocal   is cot
  * @returns {BigNumber} tangent or cotangent of x
  */
-exports.tan_cot = function (x, precision, reciprocal) {
-  var Big = BigNumber.constructor({precision: precision});
+exports.tan_cot = function (x, Big, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
 
+  var precision = Big.precision;
   var pi = exports.pi(precision + 2);
   var halfPi = pi.div(2).toDP(precision - 1);
   pi = pi.toDP(precision - 1);
@@ -859,10 +865,10 @@ exports.tan_cot = function (x, precision, reciprocal) {
     return new Big(Infinity);
   }
 
-  var sin = exports.cos_sin_sec_csc(y, precision + 2, 1, false);
+  Big.config({precision: precision + 2});
+  var sin = exports.cos_sin_sec_csc(y, Big, 1, false);
   var cos = sinToCos(sin);
 
-  sin.constructor.config({precision: precision});
   sin = sin.toDP(precision);
   cos = cos.toDP(precision);
 
@@ -875,9 +881,9 @@ exports.tan_cot = function (x, precision, reciprocal) {
     cos.s = -cos.s;
   }
 
-  sin.constructor.config({precision: precision + 2});
   var tan = (reciprocal) ? cos.div(sin) : sin.div(cos);
 
+  Big.config({precision: precision});
   return new Big(tan.toPrecision(precision));
 };
 
@@ -897,12 +903,12 @@ exports.tan_cot = function (x, precision, reciprocal) {
  *         = 2 / (e^x - 1/e^x)
  *
  * @param {BigNumber} x
- * @param {Boolean} mode        sinh function if true, cosh function if false
- * @param {Boolean} reciprocal  is sech or csch
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} mode         sinh function if true, cosh function if false
+ * @param {Boolean} reciprocal   is sech or csch
  * @returns {BigNumber} hyperbolic cosine, sine, secant. or cosecant of x
  */
-exports.cosh_sinh_csch_sech = function (x, mode, reciprocal) {
-  var Big = x.constructor;
+exports.cosh_sinh_csch_sech = function (x, Big, mode, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
@@ -916,7 +922,10 @@ exports.cosh_sinh_csch_sech = function (x, mode, reciprocal) {
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
-  var y = x.exp();
+  var y = new Big(x);
+  y.constructor = Big;
+
+  y = y.exp();
   y = (mode) ? y.minus(Big.ONE.div(y)) : y.plus(Big.ONE.div(y));
   y = (reciprocal) ? new Big(2).div(y) : y.div(2);
 
@@ -936,11 +945,11 @@ exports.cosh_sinh_csch_sech = function (x, mode, reciprocal) {
  *         = (e^x + 1/e^x) / (e^x - 1/e^x)
  *
  * @param {BigNumber} x
- * @param {Boolean} reciprocal  is coth
+ * @param {DecimalFactory} Big   current BigNumber constructor
+ * @param {Boolean} reciprocal   is coth
  * @returns {BigNumber} hyperbolic tangent or cotangent of x
  */
-exports.tanh_coth = function (x, reciprocal) {
-  var Big = x.constructor;
+exports.tanh_coth = function (x, Big, reciprocal) {
   if (x.isNaN()) {
     return new Big(NaN);
   }
@@ -951,7 +960,10 @@ exports.tanh_coth = function (x, reciprocal) {
   var precision = Big.precision;
   Big.config({precision: precision + 4});
 
-  var posExp = x.exp();
+  var y = new Big(x);
+  y.constructor = Big;
+
+  var posExp = y.exp();
   var negExp = Big.ONE.div(posExp);
   var ret = posExp.minus(negExp);
   ret = (reciprocal) ? posExp.plus(negExp).div(ret) : ret.div(posExp.plus(negExp));
@@ -970,22 +982,23 @@ exports.tanh_coth = function (x, reciprocal) {
  *     x_(i+1) = x_i - (sin(x_i) - N)/cos(x_i)
  *
  * @param {BigNumber} x
- * @param {Number} oldPrecision
+ * @param {DecimalFactory} Big   current BigNumber constructor
  * @returns {BigNumber} arc sine of x
  */
-function arcsin_newton(x, oldPrecision) {
+function arcsin_newton(x, Big) {
+  var oldPrecision = Big.precision;
+
   // Calibration variables, adjusted from MAPM
   var tolerance = -(oldPrecision + 4);
   var maxp = oldPrecision + 8 - x.e;
   var localPrecision = 25 - x.e;
   var maxIter = Math.max(Math.log(oldPrecision + 2) * 1.442695 | 0 + 5, 5);
-
-  var Big = BigNumber.constructor({precision: oldPrecision});
-  var curr = new Big(Math.asin(x.toNumber()) + '');
+  Big.config({precision: localPrecision});
 
   var i = 0;
+  var curr = new Big(Math.asin(x.toNumber()) + '');
   do {
-    var tmp0 = exports.cos_sin_sec_csc(curr, localPrecision, 1, false);
+    var tmp0 = exports.cos_sin_sec_csc(curr, Big, 1, false);
     var tmp1 = sinToCos(tmp0);
     if (!tmp0.isZero()) {
       tmp0.s = curr.s;
@@ -995,7 +1008,7 @@ function arcsin_newton(x, oldPrecision) {
     curr = curr.minus(tmp2);
 
     localPrecision = Math.min(2*localPrecision, maxp);
-    curr.constructor.config({precision: localPrecision});
+    Big.config({precision: localPrecision});
   } while ((2*tmp2.e >= tolerance) && !tmp2.isZero() && (++i <= maxIter))
 
   if (i == maxIter) {
@@ -1003,7 +1016,7 @@ function arcsin_newton(x, oldPrecision) {
                     'Try with a higher precision.');
   }
 
-  curr.constructor.config({precision: oldPrecision});
+  Big.config({precision: oldPrecision});
   return curr.toDP(oldPrecision - 1);
 }
 

--- a/test/function/trigonometry/acos.test.js
+++ b/test/function/trigonometry/acos.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    acosBig = bigmath.acos,
+    cosBig = bigmath.cos,
     Big = bigmath.bignumber;
 
 describe('acos', function() {
@@ -31,17 +33,17 @@ describe('acos', function() {
 
   it('should return the arccos of a bignumber', function() {
     var arg = Big(-1);
-    assert.deepEqual(acos(arg).toString(), bigmath.pi.toString());
-    assert.deepEqual(acos(Big(-0.5)), Big('2.0943951023931954923'));
-    assert.deepEqual(acos(Big(0)), Big('1.5707963267948966192'));
-    assert.deepEqual(acos(Big(0.5)), Big('1.0471975511965977462'));
-    assert.deepEqual(acos(Big(1)), Big(0));
+    assert.deepEqual(acosBig(arg).toString(), bigmath.pi.toString());
+    assert.deepEqual(acosBig(Big(-0.5)), Big('2.0943951023931954923'));
+    assert.deepEqual(acosBig(Big(0)), Big('1.5707963267948966192'));
+    assert.deepEqual(acosBig(Big(0.5)), Big('1.0471975511965977462'));
+    assert.deepEqual(acosBig(Big(1)), Big(0));
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(acos(Big(0.00000001)).toString(), '1.570796316794896619' +
-                                                       '23132152497308477543' +
-                                                       '1910533020886243820359');
+    assert.deepEqual(acosBig(Big(0.00000001)), Big('1.5707963167948966192313' +
+                                                     '2152497308477543191053' +
+                                                     '3020886243820359'));
     //Make sure arg was not changed
     assert.deepEqual(arg, Big(-1));
   });
@@ -56,11 +58,11 @@ describe('acos', function() {
 
   it('should be the inverse function of bignumber cos', function() {
     bigmath.config({precision: 20});
-    assert.deepEqual(acos(bigmath.cos(Big(-1))).toString(), '1');
-    assert.ok(acos(bigmath.cos(Big(0))).isZero());
-    assert.deepEqual(acos(bigmath.cos(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(acos(bigmath.cos(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(acos(bigmath.cos(Big(2))).toString(), '2');
+    assert.deepEqual(acosBig(cosBig(Big(-1))), Big(1));
+    assert.deepEqual(acosBig(cosBig(Big(0))), Big(0));
+    assert.deepEqual(acosBig(cosBig(Big(0.1))), Big(0.1));
+    assert.deepEqual(acosBig(cosBig(Big(0.5))), Big(0.5));
+    assert.deepEqual(acosBig(cosBig(Big(2))), Big(2));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/acosh.test.js
+++ b/test/function/trigonometry/acosh.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 22}),
+    acoshBig = bigmath.acosh,
     Big = bigmath.bignumber;
 
 describe('acosh', function() {
@@ -37,10 +39,10 @@ describe('acosh', function() {
 
   it('should return the hyperbolic arccos of a bignumber', function() {
     var arg = Big(1);
-    assert.deepEqual(acosh(arg), Big(0));
-    assert.deepEqual(acosh(Big(2)), Big('1.3169578969248167086'));
-    assert.deepEqual(acosh(Big(3)), Big('1.7627471740390860505'));
-    assert.deepEqual(acosh(bigmath.pi).toString(), '1.811526272460853107');
+    assert.deepEqual(acosh(arg), math.bignumber(0));
+    assert.deepEqual(acoshBig(Big(2)), Big('1.3169578969248167086'));
+    assert.deepEqual(acoshBig(Big(3)), Big('1.7627471740390860505'));
+    assert.deepEqual(acoshBig(bigmath.pi).toString(), '1.811526272460853107');
 
     //Make sure arg was not changed
     assert.deepEqual(arg, Big(1));
@@ -55,14 +57,15 @@ describe('acosh', function() {
   });
 
   it('should be the inverse function of bignumber cosh', function() {
-    assert.deepEqual(acosh(bigmath.cosh(Big(-1))), Big(1));
-    assert.deepEqual(acosh(bigmath.cosh(Big(0))), Big(0));
-    assert.deepEqual(acosh(bigmath.cosh(Big(2))), Big(2));
+    assert.deepEqual(acoshBig(bigmath.cosh(Big(-1))), Big(1));
+    assert.deepEqual(acoshBig(bigmath.cosh(Big(0))), Big(0));
+    assert.deepEqual(acoshBig(bigmath.cosh(Big(2))), Big(2));
 
-    /* Pass in more digits to pi. */
-    //bigmath.config({precision: 21});
-    //assert.deepEqual(acosh(bigmath.cosh(Big(0.1))), Big(0.1));
-    //assert.deepEqual(acosh(bigmath.cosh(Big(0.5))), Big(0.5));
+    // Pass in extra digit
+    var arg = Big(0.1);
+    assert.deepEqual(acoshBig(biggermath.cosh(arg)), Big(0.1));
+    assert.deepEqual(acoshBig(biggermath.cosh(Big(0.5))), Big(0.5));
+    assert.deepEqual(arg, Big(0.1));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/acot.test.js
+++ b/test/function/trigonometry/acot.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     acot = math.acot,
     cot = math.cot,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    acotBig = bigmath.acot,
+    cotBig = bigmath.cot,
     Big = bigmath.bignumber;
 
 describe('acot', function() {
@@ -39,13 +41,13 @@ describe('acot', function() {
     var arg7 = Big(2);
     var arg8 = Big(Infinity);
 
-    assert.deepEqual(acot(Big(-2)), Big('-0.4636476090008061162'));
-    assert.deepEqual(acot(arg2), Big('-0.7853981633974483096'));
-    assert.deepEqual(acot(arg3), Big('-1.107148717794090503'));
-    assert.deepEqual(acot(arg4).toString(), '1.5707963267948966192');
-    assert.deepEqual(acot(Big(1)), Big('0.7853981633974483096'));
-    assert.deepEqual(acot(arg7), Big('0.4636476090008061162'));
-    assert.deepEqual(acot(arg8), Big(0));
+    assert.deepEqual(acotBig(Big(-2)), Big('-0.4636476090008061162'));
+    assert.deepEqual(acotBig(arg2), Big('-0.7853981633974483096'));
+    assert.deepEqual(acotBig(arg3), Big('-1.107148717794090503'));
+    assert.deepEqual(acotBig(arg4).toString(), '1.5707963267948966192');
+    assert.deepEqual(acotBig(Big(1)), Big('0.7853981633974483096'));
+    assert.deepEqual(acotBig(arg7), Big('0.4636476090008061162'));
+    assert.deepEqual(acotBig(arg8), Big(0));
 
     // Ensure the arguments where not changed
     assert.deepEqual(arg2, Big(-1));
@@ -56,7 +58,7 @@ describe('acot', function() {
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(acot(Big(1.1)).toString(), '0.73781506012046491381362812980339020358273335525044448963405');
+    assert.deepEqual(acotBig(Big(1.1)), Big('0.73781506012046491381362812980339020358273335525044448963405'));
   });
 
   it('should be the inverse function of cot', function() {
@@ -69,12 +71,12 @@ describe('acot', function() {
 
   it('should be the inverse function of bignumber cot', function() {
     bigmath.config({precision: 20});
-    assert.deepEqual(acot(bigmath.cot(Big(-1))).toString(), '-1');
-    assert.ok(acot(bigmath.cot(Big(0))).isZero());
-    assert.deepEqual(acot(bigmath.cot(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(acot(bigmath.cot(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(acot(bigmath.cot(Big(2))).toString(), '-1.1415926535897932385');
-    assert.deepEqual(acot(bigmath.cot(bigmath.pi.div(2))).toString(), '1.5707963267948966192');
+    assert.deepEqual(acotBig(cotBig(Big(-1))), Big(-1));
+    assert.deepEqual(acotBig(cotBig(Big(0))), Big(0));
+    assert.deepEqual(acotBig(cotBig(Big(0.1))), Big(0.1));
+    assert.deepEqual(acotBig(cotBig(Big(0.5))), Big(0.5));
+    assert.deepEqual(acotBig(cotBig(Big(2))), Big('-1.1415926535897932385'));
+    assert.deepEqual(acotBig(cotBig(bigmath.pi.div(2))).toString(), '1.5707963267948966192');
   });
 
   it('should return the arccot of a complex number', function() {
@@ -84,7 +86,7 @@ describe('acot', function() {
     approx.deepEqual(acot(complex('2-3i')), complex(re, im));
     approx.deepEqual(acot(complex('-2+3i')), complex(-re, -im));
     approx.deepEqual(acot(complex('-2-3i')), complex(-re, im));
-    approx.deepEqual(acot(complex('i')), complex(0, -Infinity));
+    assert.deepEqual(acot(complex('i')), complex(0, -Infinity));
     approx.deepEqual(acot(complex('1')), complex(pi / 4, 0));
     approx.deepEqual(acot(complex('1+i')), complex(0.553574358897, -0.4023594781085));
   });

--- a/test/function/trigonometry/acoth.test.js
+++ b/test/function/trigonometry/acoth.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 21}),
+    acothBig = bigmath.acoth,
     Big = bigmath.bignumber;
 
 describe('acoth', function() {
@@ -39,12 +41,12 @@ describe('acoth', function() {
   it('should return the hyperbolic arccot of a bignumber', function() {
     var arg2 = Big(-2);
     var arg3 = Big(-1);
-    assert.deepEqual(acoth(Big(-Infinity)), Big(0));
-    assert.deepEqual(acoth(arg2), Big('-0.5493061443340548457'));
-    assert.deepEqual(acoth(arg3), Big(-Infinity));
-    assert.deepEqual(acoth(Big(1)), Big(Infinity));
-    assert.deepEqual(acoth(Big(2)), Big('0.5493061443340548457'));
-    assert.deepEqual(acoth(Big(Infinity)), Big(0));
+    assert.deepEqual(acothBig(Big(-Infinity)), Big(0));
+    assert.deepEqual(acothBig(arg2), Big('-0.5493061443340548457'));
+    assert.deepEqual(acothBig(arg3), Big(-Infinity));
+    assert.deepEqual(acothBig(Big(1)), Big(Infinity));
+    assert.deepEqual(acothBig(Big(2)), Big('0.5493061443340548457'));
+    assert.deepEqual(acothBig(Big(Infinity)), Big(0));
 
     //Make sure arg was not changed
     assert.deepEqual(arg2, Big(-2));
@@ -60,14 +62,13 @@ describe('acoth', function() {
   });
 
   it('should be the inverse function of bignumber coth', function() {
-    assert.deepEqual(acoth(bigmath.coth(Big(-1))), Big(-1));
-    assert.deepEqual(acoth(bigmath.coth(Big(0))), Big(0));
-    assert.deepEqual(acoth(bigmath.coth(Big(1))), Big(1));
+    assert.deepEqual(acothBig(bigmath.coth(Big(-1))), Big(-1));
+    assert.deepEqual(acothBig(bigmath.coth(Big(0))), Big(0));
+    assert.deepEqual(acothBig(bigmath.coth(Big(1))), Big(1));
 
     /* Pass in more digits to pi. */
-    //bigmath.config({precision: 21});
-    //assert.deepEqual(acoth(bigmath.coth(Big(-2))), Big(-2));
-    //assert.deepEqual(acoth(bigmath.coth(Big(2))), Big(2));
+    assert.deepEqual(acothBig(biggermath.coth(Big(-2))), Big(-2));
+    assert.deepEqual(acothBig(biggermath.coth(Big(2))), Big(2));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/acsc.test.js
+++ b/test/function/trigonometry/acsc.test.js
@@ -9,25 +9,27 @@ var assert = require('assert'),
     acsc = math.acsc,
     csc = math.csc,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 21}),
+    acscBig = bigmath.acsc,
     Big = bigmath.bignumber;
 
 describe('acsc', function() {
   it('should return the arccsc of a boolean', function () {
     approx.equal(acsc(true), pi / 2);
-    assert.ok(isNaN(acsc(false)));
-    //assert.deepEqual(acsc(false), complex(0, Infinity));
+    assert.deepEqual(acsc(false), complex(pi / 2, Infinity));
+    //assert.ok(isNaN(acsc(false)));
   });
 
   it('should return the arccsc of null', function () {
-    assert.ok(isNaN(acsc(null)));
-    //assert.deepEqual(acsc(null), complex(0, Infinity));
+    assert.deepEqual(acsc(null), complex(pi / 2, Infinity));
+    //assert.ok(isNaN(acsc(null)));
   });
 
   it('should return the arccsc of a number', function() {
     approx.equal(acsc(-2) / pi, -1/6);
     approx.equal(acsc(-1) / pi, -0.5);
-    assert.ok(isNaN(acsc(0)));
-    //assert.deepEqual(acsc(0), complex(0, Infinity));
+    assert.deepEqual(acsc(0), complex(pi / 2, Infinity));
+    //assert.ok(isNaN(acsc(0)));
     approx.equal(acsc(1) / pi, 0.5);
     approx.equal(acsc(2) / pi, 1/6);
   });
@@ -37,12 +39,12 @@ describe('acsc', function() {
     var arg2 = Big(-1.71);
     var arg3 = Big(-1);
 
-    assert.deepEqual(acsc(arg1), Big('-0.5235987755982988731'));
-    assert.deepEqual(acsc(arg2), Big('-0.624627713324716013'));
-    assert.deepEqual(acsc(arg3), Big('-1.5707963267948966192'));
-    assert.deepEqual(acsc(Big(1)), Big('1.5707963267948966192'));
-    assert.deepEqual(acsc(Big(1.71)), Big('0.624627713324716013'));
-    assert.deepEqual(acsc(Big(2)), Big('0.5235987755982988731'));
+    assert.deepEqual(acscBig(arg1), Big('-0.5235987755982988731'));
+    assert.deepEqual(acscBig(arg2), Big('-0.624627713324716013'));
+    assert.deepEqual(acscBig(arg3), Big('-1.5707963267948966192'));
+    assert.deepEqual(acscBig(Big(1)), Big('1.5707963267948966192'));
+    assert.deepEqual(acscBig(Big(1.71)), Big('0.624627713324716013'));
+    assert.deepEqual(acscBig(Big(2)), Big('0.5235987755982988731'));
 
     // Make sure args were not changed
     assert.deepEqual(arg1, Big(-2));
@@ -53,7 +55,7 @@ describe('acsc', function() {
     bigmath.config({precision: 61});
 
     var arg4 = Big(1.00000001);
-    assert.deepEqual(acsc(arg4).toString(), '1.570654905439248565373629613450057180739125884090554026623514');
+    assert.deepEqual(acscBig(arg4), Big('1.570654905439248565373629613450057180739125884090554026623514'));
     assert.deepEqual(arg4, Big(1.00000001));
   });
 
@@ -67,23 +69,22 @@ describe('acsc', function() {
 
   it('should be the inverse function of bignumber csc', function() {
     // More Newton's method test cases
-    assert.deepEqual(acsc(bigmath.csc(Big(-2))).toString(), '-1.141592653589793238462643383279502884197169399375105820974945');
-    assert.deepEqual(acsc(bigmath.csc(Big(-0.5))).toString(), '-0.5');
-    assert.deepEqual(acsc(bigmath.csc(Big(-0.1))).toString(), '-0.1');
-    assert.deepEqual(acsc(bigmath.csc(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(acsc(bigmath.csc(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(acsc(bigmath.csc(Big(2))).toString(), '1.141592653589793238462643383279502884197169399375105820974945');
+    assert.deepEqual(acscBig(bigmath.csc(Big(-2))), Big('-1.141592653589793238462643383279502884197169399375105820974945'));
+    assert.deepEqual(acscBig(bigmath.csc(Big(-0.5))), Big(-0.5));
+    assert.deepEqual(acscBig(bigmath.csc(Big(-0.1))), Big(-0.1));
+    assert.deepEqual(acscBig(bigmath.csc(Big(0.1))), Big(0.1));
+    assert.deepEqual(acscBig(bigmath.csc(Big(0.5))), Big(0.5));
+    assert.deepEqual(acscBig(bigmath.csc(Big(2))), Big('1.141592653589793238462643383279502884197169399375105820974945'));
 
-    bigmath.config({precision: 20});
     // Full decimal Taylor test cases
-    /* csc(-1) =                      -0.8414709848078965067
-       acsc(-0.8414709848078965067) = -1.00000000000000000008 => (rounding up) -1.0000000000000000001
-    assert.deepEqual(acsc(bigmath.csc(Big(-1))), Big('-1')); */
+    bigmath.config({precision: 20});
+    assert.deepEqual(acscBig(bigmath.csc(Big(0))), Big(0));
+    assert.deepEqual(acscBig(bigmath.csc(Big(0.1))), Big(0.1));
+    assert.deepEqual(acscBig(bigmath.csc(Big(0.5))), Big(0.5));
 
-    assert.ok(acsc(bigmath.csc(Big(0))).isZero());
-    assert.deepEqual(acsc(bigmath.csc(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(acsc(bigmath.csc(Big(0.5))).toString(), '0.5');
-    //assert.deepEqual(acsc(bigmath.csc(Big(2))).toString(), '1.1415926535897932385');
+    // Pass in an extra digit
+    assert.deepEqual(acscBig(biggermath.csc(Big(-1))), Big('-1'));
+    assert.deepEqual(acscBig(biggermath.csc(Big(2))), Big('1.1415926535897932385'));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/acsch.test.js
+++ b/test/function/trigonometry/acsch.test.js
@@ -9,6 +9,7 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    acschBig = bigmath.acsch,
     Big = bigmath.bignumber;
 
 describe('acsch', function() {
@@ -32,12 +33,12 @@ describe('acsch', function() {
 
   it('should return the hyperbolic arccsc of a bignumber', function() {
     var arg = Big(-2);
-    assert.deepEqual(acsch(arg), Big('-0.4812118250596034475'));
-    assert.deepEqual(acsch(Big(-1)), Big('-0.88137358701954302523'));
-    assert.deepEqual(acsch(Big(0)), Big(Infinity));
-    assert.deepEqual(acsch(Big(1)), Big('0.88137358701954302523'));
-    assert.deepEqual(acsch(Big(2)), Big('0.4812118250596034475'));
-    assert.deepEqual(acsch(bigmath.pi).toString(), '0.31316588045086837587');
+    assert.deepEqual(acschBig(arg), Big('-0.4812118250596034475'));
+    assert.deepEqual(acschBig(Big(-1)), Big('-0.88137358701954302523'));
+    assert.deepEqual(acschBig(Big(0)), Big(Infinity));
+    assert.deepEqual(acschBig(Big(1)), Big('0.88137358701954302523'));
+    assert.deepEqual(acschBig(Big(2)), Big('0.4812118250596034475'));
+    assert.deepEqual(acschBig(bigmath.pi).toString(), '0.31316588045086837587');
 
     //Make sure arg was not changed
     assert.deepEqual(arg, Big(-2));
@@ -52,13 +53,13 @@ describe('acsch', function() {
   });
 
   it('should be the inverse function of bignumber csch', function() {
-    assert.deepEqual(acsch(bigmath.csch(Big(-2))), Big(-2));
-    assert.deepEqual(acsch(bigmath.csch(Big(-0.5))), Big(-0.5));
-    assert.deepEqual(acsch(bigmath.csch(Big(-0.1))), Big(-0.1));
-    assert.deepEqual(acsch(bigmath.csch(Big(0))), Big(0));
-    assert.deepEqual(acsch(bigmath.csch(Big(0.1))), Big(0.1));
-    assert.deepEqual(acsch(bigmath.csch(Big(0.5))), Big(0.5));
-    assert.deepEqual(acsch(bigmath.csch(Big(2))), Big(2));
+    assert.deepEqual(acschBig(bigmath.csch(Big(-2))), Big(-2));
+    assert.deepEqual(acschBig(bigmath.csch(Big(-0.5))), Big(-0.5));
+    assert.deepEqual(acschBig(bigmath.csch(Big(-0.1))), Big(-0.1));
+    assert.deepEqual(acschBig(bigmath.csch(Big(0))), Big(0));
+    assert.deepEqual(acschBig(bigmath.csch(Big(0.1))), Big(0.1));
+    assert.deepEqual(acschBig(bigmath.csch(Big(0.5))), Big(0.5));
+    assert.deepEqual(acschBig(bigmath.csch(Big(2))), Big(2));
   });
 
   it('should return the arccsch of a complex number', function() {

--- a/test/function/trigonometry/asec.test.js
+++ b/test/function/trigonometry/asec.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 21}),
+    asecBig = bigmath.asec,
     Big = bigmath.bignumber;
 
 describe('asec', function() {
@@ -26,27 +28,30 @@ describe('asec', function() {
   it('should return the arcsec of a number', function() {
     approx.equal(asec(-2) / pi, 2 / 3);
     approx.equal(asec(-1) / pi, 1);
-    /*approx.equal(asec(-0.5) / pi, 2 / 3);
-    approx.equal(asec(0.5) / pi, 1 / 3);*/
     approx.equal(asec(1) / pi, 0);
     approx.equal(asec(2) / pi, 1 / 3);
+
+    approx.deepEqual(asec(-0.5), complex(pi, -1.3169578969248));
+    approx.deepEqual(asec(0.5), complex(0, 1.3169578969248));
   });
 
   it('should return the arcsec of a bignumber', function() {
     var arg1 = Big(-2);
     var arg2 = Big(-1);
-    assert.deepEqual(asec(arg1).toString(), bigmath.tau.div(3).toString());
-    assert.deepEqual(asec(arg2).toString(), bigmath.pi.toString());
-    assert.deepEqual(asec(Big(1)), Big(0));
-    assert.deepEqual(asec(Big(2)).toString(), bigmath.pi.div(3).toString());
-
-    // Hit Newton's method case
-    bigmath.config({precision: 61});
-    assert.deepEqual(asec(Big(3.00000001)).toString(), '1.230959418519285979938614206185297709155969929825366328254265');
+    assert.deepEqual(asecBig(arg1).toString(), bigmath.tau.div(3).toString());
+    assert.deepEqual(asecBig(arg2).toString(), bigmath.pi.toString());
+    assert.deepEqual(asecBig(Big(1)), Big(0));
+    assert.deepEqual(asecBig(Big(2)).toString(), bigmath.pi.div(3).toString());
 
     //Make sure arg was not changed
     assert.deepEqual(arg1, Big(-2));
     assert.deepEqual(arg2, Big(-1));
+
+    // Hit Newton's method case
+    bigmath.config({precision: 61});
+    var arg = Big(3.00000001);
+    assert.deepEqual(asecBig(arg), Big('1.230959418519285979938614206185297709155969929825366328254265'));
+    assert.deepEqual(arg, Big(3.00000001));
   });
 
   it('should be the inverse function of sec', function() {
@@ -59,11 +64,13 @@ describe('asec', function() {
 
   it('should be the inverse function of bignumber sec', function() {
     bigmath.config({precision: 20});
-    assert.deepEqual(asec(bigmath.sec(Big(-1))).toString(), '1');
-    assert.ok(asec(bigmath.sec(Big(0))).isZero());
-    //assert.deepEqual(asec(bigmath.sec(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(asec(bigmath.sec(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(asec(bigmath.sec(Big(2))).toString(), '2');
+    assert.deepEqual(asecBig(bigmath.sec(Big(-1))), Big(1));
+    assert.deepEqual(asecBig(bigmath.sec(Big(0))), Big(0));
+    assert.deepEqual(asecBig(bigmath.sec(Big(0.5))), Big(0.5));
+    assert.deepEqual(asecBig(bigmath.sec(Big(2))), Big(2));
+
+    // Pass in extra digit
+    assert.deepEqual(asecBig(biggermath.sec(Big(0.1))), Big(0.1));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/asech.test.js
+++ b/test/function/trigonometry/asech.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 22}),
+    asechBig = bigmath.asech,
     Big = bigmath.bignumber;
 
 describe('asech', function() {
@@ -37,11 +39,11 @@ describe('asech', function() {
   it('should return the hyperbolic arcsec of a bignumber', function() {
     var arg1 = Big(0);
     var arg2 = Big(0.25);
-    assert.deepEqual(asech(arg1), Big(Infinity));
-    assert.deepEqual(asech(arg2), Big('2.0634370688955605467'));
-    assert.deepEqual(asech(Big(0.5)), Big('1.3169578969248167086'));
-    assert.deepEqual(asech(Big(0.75)), Big('0.79536546122390563053'));
-    assert.deepEqual(asech(Big(1)), Big(0));
+    assert.deepEqual(asechBig(arg1), Big(Infinity));
+    assert.deepEqual(asechBig(arg2), Big('2.0634370688955605467'));
+    assert.deepEqual(asechBig(Big(0.5)), Big('1.3169578969248167086'));
+    assert.deepEqual(asechBig(Big(0.75)), Big('0.79536546122390563053'));
+    assert.deepEqual(asechBig(Big(1)), Big(0));
 
     //Make sure arg was not changed
     assert.deepEqual(arg1, Big(0));
@@ -57,14 +59,13 @@ describe('asech', function() {
   });
 
   it('should be the inverse function of bignumber sech', function() {
-    assert.deepEqual(asech(bigmath.sech(Big(-1))), Big(1));
-    assert.deepEqual(asech(bigmath.sech(Big(0))), Big(0));
-    assert.deepEqual(asech(bigmath.sech(Big(0.5))), Big(0.5));
-    assert.deepEqual(asech(bigmath.sech(Big(2))), Big(2));
+    assert.deepEqual(asechBig(bigmath.sech(Big(-1))), Big(1));
+    assert.deepEqual(asechBig(bigmath.sech(Big(0))), Big(0));
+    assert.deepEqual(asechBig(bigmath.sech(Big(0.5))), Big(0.5));
+    assert.deepEqual(asechBig(bigmath.sech(Big(2))), Big(2));
 
     /* Pass in more digits to pi. */
-    //bigmath.config({precision: 21});
-    //assert.deepEqual(asech(bigmath.sech(Big(0.1))), Big(0.1));
+    assert.deepEqual(asechBig(biggermath.sech(Big(0.1))), Big(0.1));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/asin.test.js
+++ b/test/function/trigonometry/asin.test.js
@@ -9,16 +9,18 @@ var assert = require('assert'),
     asin = math.asin,
     sin = math.sin,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 21}),
+    asinBig = bigmath.asin,
     Big = bigmath.bignumber;
 
 describe('asin', function() {
   it('should return the arcsin of a boolean', function () {
     approx.equal(asin(true), 0.5 * pi);
-    approx.equal(asin(false), 0);
+    assert.equal(asin(false), 0);
   });
 
   it('should return the arcsin of null', function () {
-    approx.equal(asin(null), 0);
+    assert.equal(asin(null), 0);
   });
 
   it('should return the arcsin of a number', function() {
@@ -34,13 +36,13 @@ describe('asin', function() {
     var arg2 = Big(-0.581);
     var arg3 = Big(-0.5);
 
-    assert.deepEqual(asin(arg1), Big('-1.5707963267948966192'));
-    assert.deepEqual(asin(arg2), Big('-0.6199567994522537004'));
-    assert.deepEqual(asin(arg3), Big('-0.5235987755982988731'));
-    assert.deepEqual(asin(Big(0)), Big(0));
-    assert.deepEqual(asin(Big(0.5)), Big('0.5235987755982988731'));
-    assert.deepEqual(asin(Big(0.581)), Big('0.6199567994522537004'));
-    assert.deepEqual(asin(Big(1)), Big('1.5707963267948966192'));
+    assert.deepEqual(asinBig(arg1), Big('-1.5707963267948966192'));
+    assert.deepEqual(asinBig(arg2), Big('-0.6199567994522537004'));
+    assert.deepEqual(asinBig(arg3), Big('-0.5235987755982988731'));
+    assert.deepEqual(asinBig(Big(0)), Big(0));
+    assert.deepEqual(asinBig(Big(0.5)), Big('0.5235987755982988731'));
+    assert.deepEqual(asinBig(Big(0.581)), Big('0.6199567994522537004'));
+    assert.deepEqual(asinBig(Big(1)), Big('1.5707963267948966192'));
 
     // Make sure args were not changed
     assert.deepEqual(arg1, Big(-1));
@@ -51,7 +53,7 @@ describe('asin', function() {
     bigmath.config({precision: 61});
 
     var arg4 = Big(0.00000001);
-    assert.deepEqual(asin(arg4).toString(), '1.0000000000000000166666666666666674166666666666667113e-8');
+    assert.deepEqual(asinBig(arg4), Big('1.0000000000000000166666666666666674166666666666667113e-8'));
     assert.deepEqual(arg4, Big(0.00000001));
   });
 
@@ -65,23 +67,21 @@ describe('asin', function() {
 
   it('should be the inverse function of bignumber sin', function() {
     // More Newton's method test cases
-    assert.deepEqual(asin(bigmath.sin(Big(-2))).toString(), '-1.141592653589793238462643383279502884197169399375105820974945');
-    assert.deepEqual(asin(bigmath.sin(Big(-0.5))).toString(), '-0.5');
-    assert.deepEqual(asin(bigmath.sin(Big(-0.1))).toString(), '-0.1');
-    assert.deepEqual(asin(bigmath.sin(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(asin(bigmath.sin(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(asin(bigmath.sin(Big(2))).toString(), '1.141592653589793238462643383279502884197169399375105820974945');
+    assert.deepEqual(asinBig(bigmath.sin(Big(-2))), Big('-1.141592653589793238462643383279502884197169399375105820974945'));
+    assert.deepEqual(asinBig(bigmath.sin(Big(-0.5))), Big(-0.5));
+    assert.deepEqual(asinBig(bigmath.sin(Big(-0.1))), Big(-0.1));
+    assert.deepEqual(asinBig(bigmath.sin(Big(0.1))), Big(0.1));
+    assert.deepEqual(asinBig(bigmath.sin(Big(0.5))), Big(0.5));
+    assert.deepEqual(asinBig(bigmath.sin(Big(2))), Big('1.141592653589793238462643383279502884197169399375105820974945'));
 
-    bigmath.config({precision: 20});
     // Full decimal Taylor test cases
-    /* sin(-1) =                      -0.8414709848078965067
-       asin(-0.8414709848078965067) = -1.00000000000000000008 => (rounding up) -1.0000000000000000001
-    assert.deepEqual(asin(bigmath.sin(Big(-1))), Big('-1')); */
+    bigmath.config({precision: 20});
+    assert.deepEqual(asinBig(bigmath.sin(Big(0))), Big(0));
+    assert.deepEqual(asinBig(bigmath.sin(Big(0.1))), Big(0.1));
+    assert.deepEqual(asinBig(bigmath.sin(Big(0.5))), Big(0.5));
+    assert.deepEqual(asinBig(bigmath.sin(Big(2))), Big('1.1415926535897932385'));
 
-    assert.ok(asin(bigmath.sin(Big(0))).isZero());
-    assert.deepEqual(asin(bigmath.sin(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(asin(bigmath.sin(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(asin(bigmath.sin(Big(2))).toString(), '1.1415926535897932385');
+    assert.deepEqual(asinBig(biggermath.sin(Big(-1))), Big('-1'));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/asinh.test.js
+++ b/test/function/trigonometry/asinh.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 21}),
+    asinhBig = bigmath.asinh,
     Big = bigmath.bignumber;
 
 describe('asinh', function() {
@@ -32,12 +34,12 @@ describe('asinh', function() {
 
   it('should return the hyperbolic arcsin of a bignumber', function() {
     var arg = Big(-2);
-    assert.deepEqual(asinh(arg), Big('-1.4436354751788103425'));
-    assert.deepEqual(asinh(Big(-1)), Big('-0.88137358701954302523'));
-    assert.deepEqual(asinh(Big(0)), Big(0));
-    assert.deepEqual(asinh(Big(1)), Big('0.88137358701954302523'));
-    assert.deepEqual(asinh(Big(2)), Big('1.4436354751788103425'));
-    assert.deepEqual(asinh(bigmath.pi).toString(), '1.8622957433108482199');
+    assert.deepEqual(asinhBig(arg), Big('-1.4436354751788103425'));
+    assert.deepEqual(asinhBig(Big(-1)), Big('-0.88137358701954302523'));
+    assert.deepEqual(asinhBig(Big(0)), Big(0));
+    assert.deepEqual(asinhBig(Big(1)), Big('0.88137358701954302523'));
+    assert.deepEqual(asinhBig(Big(2)), Big('1.4436354751788103425'));
+    assert.deepEqual(asinhBig(bigmath.pi).toString(), '1.8622957433108482199');
 
     //Make sure arg was not changed
     assert.deepEqual(arg, Big(-2));
@@ -52,14 +54,13 @@ describe('asinh', function() {
   });
 
   it('should be the inverse function of bignumber sinh', function() {
-    assert.deepEqual(asinh(bigmath.sinh(Big(-1))), Big(-1));
-    assert.deepEqual(asinh(bigmath.sinh(Big(0))), Big(0));
-    assert.deepEqual(asinh(bigmath.sinh(Big(0.5))), Big(0.5));
-    assert.deepEqual(asinh(bigmath.sinh(Big(2))), Big(2));
+    assert.deepEqual(asinhBig(bigmath.sinh(Big(-1))), Big(-1));
+    assert.deepEqual(asinhBig(bigmath.sinh(Big(0))), Big(0));
+    assert.deepEqual(asinhBig(bigmath.sinh(Big(0.5))), Big(0.5));
+    assert.deepEqual(asinhBig(bigmath.sinh(Big(2))), Big(2));
 
     /* Pass in more digits to pi. */
-    //bigmath.config({precision: 21});
-    //assert.deepEqual(asinh(bigmath.sinh(Big(0.1))), Big(0.1));
+    assert.deepEqual(asinhBig(biggermath.sinh(Big(0.1))), Big(0.1));
   });
 
   it('should return the arcsinh of a complex number', function() {

--- a/test/function/trigonometry/atan.test.js
+++ b/test/function/trigonometry/atan.test.js
@@ -9,6 +9,7 @@ var assert = require('assert'),
     atan = math.atan,
     tan = math.tan,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    atanBig = bigmath.atan;
     Big = bigmath.bignumber;
 
 describe('atan', function() {
@@ -34,12 +35,12 @@ describe('atan', function() {
     var arg2 = Big(-0.5);
     var arg3 = Big(0);
     var arg6 = Big(2);
-    assert.deepEqual(atan(arg1), Big('-0.7853981633974483096'));
-    assert.deepEqual(atan(arg2), Big('-0.4636476090008061162'));
-    assert.deepEqual(atan(arg3), Big(0));
-    assert.deepEqual(atan(Big(0.5)), Big('0.4636476090008061162'));
-    assert.deepEqual(atan(Big(1)), Big('0.7853981633974483096'));
-    assert.deepEqual(atan(arg6), Big('1.107148717794090503'));
+    assert.deepEqual(atanBig(arg1), Big('-0.7853981633974483096'));
+    assert.deepEqual(atanBig(arg2), Big('-0.4636476090008061162'));
+    assert.deepEqual(atanBig(arg3), Big(0));
+    assert.deepEqual(atanBig(Big(0.5)), Big('0.4636476090008061162'));
+    assert.deepEqual(atanBig(Big(1)), Big('0.7853981633974483096'));
+    assert.deepEqual(atanBig(arg6), Big('1.107148717794090503'));
 
     // Ensure the arguments where not changed
     assert.deepEqual(arg1, Big(-1));
@@ -49,7 +50,7 @@ describe('atan', function() {
 
     // Hit Newton's method case
     bigmath.config({precision: 61});
-    assert.deepEqual(atan(Big(0.9)).toString(), '0.732815101786506591640792072734280251985755679358256086310506');
+    assert.deepEqual(atanBig(Big(0.9)), Big('0.732815101786506591640792072734280251985755679358256086310506'));
   });
 
   it('should be the inverse function of tan', function() {
@@ -62,12 +63,12 @@ describe('atan', function() {
 
   it('should be the inverse function of bignumber tan', function() {
     bigmath.config({precision: 20});
-    assert.deepEqual(atan(bigmath.tan(Big(-1))).toString(), '-1');
-    assert.ok(atan(bigmath.tan(Big(0))).isZero());
-    assert.deepEqual(atan(bigmath.tan(Big(0.1))).toString(), '0.1');
-    assert.deepEqual(atan(bigmath.tan(Big(0.5))).toString(), '0.5');
-    assert.deepEqual(atan(bigmath.tan(Big(2))).toString(), '-1.1415926535897932385');
-    assert.deepEqual(atan(bigmath.tan(bigmath.pi.div(2))).toString(), '-1.5707963267948966192');
+    assert.deepEqual(atanBig(bigmath.tan(Big(-1))), Big(-1));
+    assert.deepEqual(atanBig(bigmath.tan(Big(0))), Big(0));
+    assert.deepEqual(atanBig(bigmath.tan(Big(0.1))), Big(0.1));
+    assert.deepEqual(atanBig(bigmath.tan(Big(0.5))), Big(0.5));
+    assert.deepEqual(atanBig(bigmath.tan(Big(2))), Big('-1.1415926535897932385'));
+    assert.deepEqual(atanBig(bigmath.tan(bigmath.pi.div(2))).toString(), '-1.5707963267948966192');
   });
 
   it('should return the arctan of a complex number', function() {

--- a/test/function/trigonometry/atanh.test.js
+++ b/test/function/trigonometry/atanh.test.js
@@ -9,6 +9,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     bigmath = math.create({number: 'bignumber', precision: 20}),
+    biggermath = math.create({precision: 21}),
+    atanhBig = bigmath.atanh,
     Big = bigmath.bignumber;
 
 describe('atanh', function() {
@@ -37,11 +39,11 @@ describe('atanh', function() {
   it('should return the hyperbolic arctan of a bignumber', function() {
     var arg1 = Big(-1);
     var arg2 = Big(-0.5);
-    assert.deepEqual(atanh(arg1), Big(-Infinity));
-    assert.deepEqual(atanh(arg2), Big('-0.5493061443340548457')); 
-    assert.deepEqual(atanh(Big(0)), Big(0));
-    assert.deepEqual(atanh(Big(0.5)), Big('0.5493061443340548457')); 
-    assert.deepEqual(atanh(Big(1)), Big(Infinity));
+    assert.deepEqual(atanhBig(arg1), Big(-Infinity));
+    assert.deepEqual(atanhBig(arg2), Big('-0.5493061443340548457')); 
+    assert.deepEqual(atanhBig(Big(0)), Big(0));
+    assert.deepEqual(atanhBig(Big(0.5)), Big('0.5493061443340548457')); 
+    assert.deepEqual(atanhBig(Big(1)), Big(Infinity));
 
     //Make sure arg was not changed
     assert.deepEqual(arg1, Big(-1));
@@ -56,14 +58,15 @@ describe('atanh', function() {
   });
 
   it('should be the inverse function of bignumber tanh', function() {
-    assert.deepEqual(atanh(bigmath.tanh(Big(-0.5))), Big(-0.5));
-    assert.deepEqual(atanh(bigmath.tanh(Big(0))), Big(0));
-    assert.deepEqual(atanh(bigmath.tanh(Big(0.5))), Big(0.5));
+    assert.deepEqual(atanhBig(bigmath.tanh(Big(-0.5))), Big(-0.5));
+    assert.deepEqual(atanhBig(bigmath.tanh(Big(0))), Big(0));
+    assert.deepEqual(atanhBig(bigmath.tanh(Big(0.5))), Big(0.5));
 
     /* Pass in more digits to pi. */
-    //bigmath.config({precision: 21});
-    //assert.deepEqual(atanh(bigmath.tanh(Big(-1))), Big(-1));
-    //assert.deepEqual(atanh(bigmath.tanh(Big(0.1))), Big(0.1));
+    var arg = Big(-1);
+    assert.deepEqual(atanhBig(biggermath.tanh(arg)), Big(-1));
+    assert.deepEqual(atanhBig(biggermath.tanh(Big(0.1))), Big(0.1));
+    assert.deepEqual(arg, Big(-1));
   });
 
   it('should throw an error if the bignumber result is complex', function() {

--- a/test/function/trigonometry/cosh.test.js
+++ b/test/function/trigonometry/cosh.test.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    cosh = math.cosh;
+    cosh = math.cosh,
+    bigmath = math.create({number: 'bignumber', precision: 20});
 
 describe('cosh', function() {
   it('should return the cosh of a boolean', function () {
@@ -27,23 +28,23 @@ describe('cosh', function() {
   });
 
   it('should return the cosh of a bignumber', function() {
-    var bigmath = math.create({number: 'bignumber', precision: 20});
+    var coshBig = bigmath.cosh;
     var Big = bigmath.bignumber;
     var bigInfinity = Big(Infinity);
 
     var arg1 = Big(-3);
     var arg9 = Big(Infinity);
     var arg10 = Big(-Infinity);
-    assert.deepEqual(cosh(arg1), Big('10.067661995777765842'));
-    assert.deepEqual(cosh(Big(-2)), Big('3.7621956910836314596'));
-    assert.deepEqual(cosh(Big(-1)), Big('1.5430806348152437785'));
-    assert.deepEqual(cosh(Big(0)), Big(1));
-    assert.deepEqual(cosh(Big(1)), Big('1.5430806348152437785'));
-    assert.deepEqual(cosh(Big(2)), Big('3.7621956910836314596'));
-    assert.deepEqual(cosh(Big(3)), Big('10.067661995777765842'));
-    assert.deepEqual(cosh(bigmath.pi).toString(), '11.591953275521520628');
-    assert.deepEqual(cosh(arg9), bigInfinity);
-    assert.deepEqual(cosh(arg10), bigInfinity);
+    assert.deepEqual(coshBig(arg1), Big('10.067661995777765842'));
+    assert.deepEqual(coshBig(Big(-2)), Big('3.7621956910836314596'));
+    assert.deepEqual(coshBig(Big(-1)), Big('1.5430806348152437785'));
+    assert.deepEqual(coshBig(Big(0)), Big(1));
+    assert.deepEqual(coshBig(Big(1)), Big('1.5430806348152437785'));
+    assert.deepEqual(coshBig(Big(2)), Big('3.7621956910836314596'));
+    assert.deepEqual(coshBig(Big(3)), Big('10.067661995777765842'));
+    assert.deepEqual(coshBig(bigmath.pi).toString(), '11.591953275521520628');
+    assert.deepEqual(coshBig(arg9), bigInfinity);
+    assert.deepEqual(coshBig(arg10), bigInfinity);
 
     // Ensure args were not changed
     assert.deepEqual(arg1, Big(-3));

--- a/test/function/trigonometry/coth.test.js
+++ b/test/function/trigonometry/coth.test.js
@@ -7,7 +7,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     coth = math.coth,
-    bigmath = math.create({number: 'bignumber', precision: 20});
+    bigmath = math.create({precision: 20}),
+    biggermath = math.create({number: 'bignumber', precision: 21});
 
 describe('coth', function() {
   it('should return the coth of a boolean', function () {
@@ -28,14 +29,15 @@ describe('coth', function() {
   });
 
   it('should return the coth of a bignumber', function() {
+    var cothBig = bigmath.coth;
     var Big = bigmath.bignumber;
-    assert.deepEqual(coth(Big(0)), Big(Number.POSITIVE_INFINITY));
-    assert.deepEqual(coth(Big(1)), Big('1.3130352854993313036'));
-    assert.deepEqual(coth(Big(2)), Big('1.0373147207275480959'));
-    assert.deepEqual(coth(Big(3)), Big('1.0049698233136891711'));
+    assert.deepEqual(cothBig(Big(0)), Big(Number.POSITIVE_INFINITY));
+    assert.deepEqual(cothBig(Big(1)), Big('1.3130352854993313036'));
+    assert.deepEqual(cothBig(Big(2)), Big('1.0373147207275480959'));
+    assert.deepEqual(cothBig(Big(3)), Big('1.0049698233136891711'));
 
     /* Pass in extra digits to pi. */
-    //assert.deepEqual(coth(bigmath.pi), Big('0.0862667383340544147'));
+    assert.deepEqual(cothBig(biggermath.pi), Big('1.0037418731973212882'));
   });
 
   it('should return the coth of a complex number', function() {

--- a/test/function/trigonometry/csc.test.js
+++ b/test/function/trigonometry/csc.test.js
@@ -39,7 +39,7 @@ describe('csc', function() {
     var bigPi = bigmath.pi;
     var sqrt2 = bigmath.SQRT2.toString();
 
-    assert.ok(!bigmath.csc(Big(0)).isFinite());
+    assert.deepEqual(bigmath.csc(Big(0)), Big(Infinity));
     assert.deepEqual(bigmath.csc(bigPi.div(8)).toString(), '2.6131259297527530557');
     assert.deepEqual(bigmath.csc(bigPi.div(4)).toString(), sqrt2);
     assert.deepEqual(bigmath.csc(bigPi.div(2)).toString(), '1');

--- a/test/function/trigonometry/csch.test.js
+++ b/test/function/trigonometry/csch.test.js
@@ -7,7 +7,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     csch = math.csch,
-    bigmath = math.create({number: 'bignumber', precision: 20});
+    bigmath = math.create({precision: 20}),
+    biggermath = math.create({number: 'bignumber', precision: 22});
 
 describe('csch', function() {
   it('should return the csch of a boolean', function () {
@@ -30,15 +31,16 @@ describe('csch', function() {
   });
 
   it('should return the csch of a bignumber', function() {
+    var cschBig = bigmath.csch;
     var Big = bigmath.bignumber;
 
-    assert.deepEqual(csch(Big(0)), Big(Infinity));
-    assert.deepEqual(csch(Big(1)), Big('0.85091812823932154513'));
-    assert.deepEqual(csch(Big(2)), Big('0.27572056477178320776'));
-    assert.deepEqual(csch(Big(3)), Big('0.099821569668822732851'));
+    assert.deepEqual(cschBig(Big(0)), Big(Infinity));
+    assert.deepEqual(cschBig(Big(1)), Big('0.85091812823932154513'));
+    assert.deepEqual(cschBig(Big(2)), Big('0.27572056477178320776'));
+    assert.deepEqual(cschBig(Big(3)), Big('0.099821569668822732851'));
 
     /* Pass in extra digits to pi. */
-    //assert.deepEqual(csch(bigmath.pi).toString(), '0.086589537530046941828');
+    assert.deepEqual(cschBig(biggermath.pi).toString(), '0.086589537530046941828');
   });
 
   it('should return the csch of a complex number', function() {

--- a/test/function/trigonometry/sec.test.js
+++ b/test/function/trigonometry/sec.test.js
@@ -13,11 +13,11 @@ var assert = require('assert'),
 describe('sec', function() {
   it('should return the secant of a boolean', function () {
     approx.equal(sec(true), 1.85081571768093);
-    approx.equal(sec(false), Infinity);
+    assert.equal(sec(false), 1);
   });
 
   it('should return the secant of null', function () {
-    approx.equal(sec(null), Infinity);
+    assert.equal(sec(null), 1);
   });
 
   it('should return the secant of a number', function() {
@@ -47,7 +47,7 @@ describe('sec', function() {
     var bigPi = bigmath.pi;
     var sqrt2 = bigmath.SQRT2.toString();
 
-    assert.deepEqual(bigmath.sec(Big(0)).toString(), '1');
+    assert.deepEqual(bigmath.sec(Big(0)), Big(1));
     assert.deepEqual(bigmath.sec(bigPi.div(8)).toString(), '1.0823922002923939688');
     assert.deepEqual(bigmath.sec(bigPi.div(4)).toString(), sqrt2);
     assert.deepEqual(bigmath.sec(bigPi).toString(), '-1');

--- a/test/function/trigonometry/sech.test.js
+++ b/test/function/trigonometry/sech.test.js
@@ -7,7 +7,8 @@ var assert = require('assert'),
     matrix = math.matrix,
     unit = math.unit,
     sech = math.sech,
-    bigmath = math.create({number: 'bignumber', precision: 20});
+    bigmath = math.create({precision: 20}),
+    biggermath = math.create({number: 'bignumber', precision: 21});
 
 describe('sech', function() {
   it('should return the sech of a boolean', function () {
@@ -28,15 +29,16 @@ describe('sech', function() {
   });
 
   it('should return the sech of a bignumber', function() {
+    var sechBig = bigmath.sech;
     var Big = bigmath.bignumber;
 
-    assert.deepEqual(sech(Big(0)), Big(1));
-    assert.deepEqual(sech(Big(1)), Big('0.64805427366388539957'));
-    assert.deepEqual(sech(Big(2)), Big('0.26580222883407969212'));
-    assert.deepEqual(sech(Big(3)), Big('0.099327927419433207829'));
+    assert.deepEqual(sechBig(Big(0)), Big(1));
+    assert.deepEqual(sechBig(Big(1)), Big('0.64805427366388539957'));
+    assert.deepEqual(sechBig(Big(2)), Big('0.26580222883407969212'));
+    assert.deepEqual(sechBig(Big(3)), Big('0.099327927419433207829'));
 
     /* Pass in extra digits to pi. */
-    //assert.deepEqual(sech(bigmath.pi), Big('0.0862667383340544147'));
+    assert.deepEqual(sechBig(biggermath.pi), Big('0.086266738334054414697'));
   });
 
   it('should return the sech of a complex number', function() {

--- a/test/function/trigonometry/sin.test.js
+++ b/test/function/trigonometry/sin.test.js
@@ -33,23 +33,22 @@ describe('sin', function() {
   });
 
   it('should return the sine of a bignumber', function() {
-    assert.ok(bigmath.sin(bigmath.bignumber(0)).isZero());
+    var Big = bigmath.bignumber;
+    assert.deepEqual(bigmath.sin(Big(0)), Big(0));
 
     // 103.64 % tau = 3.109... <- pretty close to the pi boundary
-    var result_val = bigmath.sin(bigmath.bignumber(103.64));
-    assert.equal(result_val.constructor.precision, 242);
-    assert.deepEqual(result_val.toString(), '0.032551816956616158442731315994267213051204459121689332893471030' +
-                                              '714804383298805501395839512341888732261080924779366105855493575' +
-                                              '835362891900420559398509489530577719840860106717522689249606121' +
-                                              '2602629134186583352145117086874446046421403346033616');
-    var arg = bigmath.bignumber(-103.64);
+    var result_val = bigmath.sin(Big(103.64));
+    assert.deepEqual(result_val, Big('0.0325518169566161584427313159942672130512044591216893328934710' +
+                                       '3071480438329880550139583951234188873226108092477936610585549' +
+                                       '3575835362891900420559398509489530577719840860106717522689249' +
+                                       '6061212602629134186583352145117086874446046421403346033616'));
+    var arg = Big(-103.64);
     result_val = bigmath.sin(arg);
-    assert.deepEqual(arg, bigmath.bignumber(-103.64));   // Make sure arg wasn't changed
-    assert.equal(result_val.constructor.precision, 242);
-    assert.deepEqual(result_val.toString(), '-0.0325518169566161584427313159942672130512044591216893328934710' +
-                                               '3071480438329880550139583951234188873226108092477936610585549' +
-                                               '3575835362891900420559398509489530577719840860106717522689249' +
-                                               '6061212602629134186583352145117086874446046421403346033616');
+    assert.deepEqual(arg, Big(-103.64));   // Make sure arg wasn't changed
+    assert.deepEqual(result_val, Big('-0.0325518169566161584427313159942672130512044591216893328934710' +
+                                        '3071480438329880550139583951234188873226108092477936610585549' +
+                                        '3575835362891900420559398509489530577719840860106717522689249' +
+                                        '6061212602629134186583352145117086874446046421403346033616'));
     bigmath.config({number: 'bignumber', precision: 15});
 
     var bigPi = bigmath.pi;

--- a/test/function/trigonometry/sinh.test.js
+++ b/test/function/trigonometry/sinh.test.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    sinh = math.sinh;
+    sinh = math.sinh,
+    bigmath = math.create({number: 'bignumber', precision: 20});
 
 describe('sinh', function() {
   it('should return the sinh of a boolean', function () {
@@ -31,27 +32,27 @@ describe('sinh', function() {
   })
 
   it('should return the sinh of a bignumber', function() {
-    var bigmath = math.create({number: 'bignumber', precision: 20});
+    var sinhBig = bigmath.sinh;
     var Big = bigmath.bignumber;
 
-    var arg1 = Big(-1);
-    var arg6 = Big(Infinity);
-    var arg7 = Big(-Infinity);
-    assert.deepEqual(sinh(arg1), Big('-1.1752011936438014569'));
-    assert.deepEqual(sinh(Big(0)), Big(0));
-    assert.deepEqual(sinh(bigmath.pi).toString(), '11.548739357257748378');
-    assert.deepEqual(sinh(Big(1)), Big('1.1752011936438014569'));
-    assert.deepEqual(sinh(Big(-1e-10)), Big(-1e-10));
-    assert.deepEqual(sinh(arg6), Big(Infinity));
-    assert.deepEqual(sinh(arg7), Big(-Infinity));
+    var arg1 = Big(-Infinity);
+    var arg2 = Big(-1);
+    var arg7 = Big(Infinity);
+    assert.deepEqual(sinhBig(arg1), Big(-Infinity));
+    assert.deepEqual(sinhBig(arg2), Big('-1.1752011936438014569'));
+    assert.deepEqual(sinhBig(Big(-1e-10)), Big(-1e-10));
+    assert.deepEqual(sinhBig(Big(0)), Big(0));
+    assert.deepEqual(sinhBig(Big(1)), Big('1.1752011936438014569'));
+    assert.deepEqual(sinhBig(bigmath.pi).toString(), '11.548739357257748378');
+    assert.deepEqual(sinhBig(arg7), Big(Infinity));
 
     // Ensure args were not changed
-    assert.deepEqual(arg1, Big(-1));
-    assert.deepEqual(arg6, Big(Infinity));
-    assert.deepEqual(arg7, Big(-Infinity));
+    assert.deepEqual(arg1, Big(-Infinity));
+    assert.deepEqual(arg2, Big(-1));
+    assert.deepEqual(arg7, Big(Infinity));
 
     bigmath.config({precision: 50});
-    assert.deepEqual(sinh(Big(1e-50)), Big(1e-50));
+    assert.deepEqual(sinhBig(Big(1e-50)), Big(1e-50));
   });
 
   it('should return the sinh of a complex number', function() {

--- a/test/function/trigonometry/tan.test.js
+++ b/test/function/trigonometry/tan.test.js
@@ -6,11 +6,11 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    sin = math.sin,
-    cos = math.cos,
     tan = math.tan,
     piBigmath = math.create({number: 'bignumber', precision: 21}),
-    bigmath = math.create({precision: 20});
+    bigmath = math.create({precision: 20}),
+    Big = bigmath.bignumber,
+    bigTan = bigmath.tan;
 
 describe('tan', function() {
   it('should return the tangent of a boolean', function () {
@@ -39,23 +39,23 @@ describe('tan', function() {
     var bigPi = piBigmath.pi;
     var bigTau = piBigmath.tau;
 
-    assert.ok(bigmath.tan(bigmath.bignumber(0)).isZero());
-    assert.deepEqual(bigmath.tan(bigmath.bignumber(-1)).toString(), '-1.5574077246549022305');
+    assert.deepEqual(bigTan(Big(0)), Big(0));
+    assert.deepEqual(bigTan(Big(-1)), Big('-1.5574077246549022305'));
 
-    assert.deepEqual(bigmath.tan(bigPi.div(8)).toString(), '0.4142135623730950488');
-    assert.deepEqual(bigmath.tan(bigPi.div(4)).toString(), '1');
-    assert.ok(!bigmath.tan(bigPi.div(2)).isFinite());
-    assert.ok(!bigmath.tan(bigPi.times(3).div(2)).isFinite());
-    assert.ok(bigmath.tan(bigPi.times(2)).isZero());
-    assert.ok(bigmath.tan(bigPi.times(4)).isZero());
-    assert.ok(bigmath.tan(bigTau).isZero());
-    assert.ok(bigmath.tan(bigTau.times(2)).isZero());
+    assert.deepEqual(bigTan(bigPi.div(8)).toString(), '0.4142135623730950488');
+    assert.deepEqual(bigTan(bigPi.div(4)).toString(), '1');
+    assert.ok(!bigTan(bigPi.div(2)).isFinite());
+    assert.ok(!bigTan(bigPi.times(3).div(2)).isFinite());
+    assert.ok(bigTan(bigPi.times(2)).isZero());
+    assert.ok(bigTan(bigPi.times(4)).isZero());
+    assert.ok(bigTan(bigTau).isZero());
+    assert.ok(bigTan(bigTau.times(2)).isZero());
 
     /* Passes with an extra digit of pi! */
-    assert.deepEqual(bigmath.tan(bigPi.times(3).div(4)).toString(), '-1');
-    assert.ok(bigmath.tan(bigPi).isZero());
-    assert.deepEqual(bigmath.tan(bigPi.times(5).div(4)).toString(), '1');
-    assert.deepEqual(bigmath.tan(bigPi.times(7).div(4)).toString(), '-1');
+    assert.deepEqual(bigTan(bigPi.times(3).div(4)).toString(), '-1');
+    assert.ok(bigTan(bigPi).isZero());
+    assert.deepEqual(bigTan(bigPi.times(5).div(4)).toString(), '1');
+    assert.deepEqual(bigTan(bigPi.times(7).div(4)).toString(), '-1');
   });
 
   it('should return the tangent of a complex number', function() {

--- a/test/function/trigonometry/tanh.test.js
+++ b/test/function/trigonometry/tanh.test.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
     complex = math.complex,
     matrix = math.matrix,
     unit = math.unit,
-    tanh = math.tanh;
+    tanh = math.tanh,
+    bigmath = math.create({number: 'bignumber', precision: 20});
 
 describe('tanh', function() {
   it('should return the tanh of a boolean', function () {
@@ -27,22 +28,22 @@ describe('tanh', function() {
   });
 
   it('should return the tanh of a bignumber', function() {
-    var bigmath = math.create({number: 'bignumber', precision: 20});
+    var tanhBig = bigmath.tanh;
     var Big = bigmath.bignumber;
 
     var arg1 = Big(-Infinity);
     var arg2 = Big(-3);
     var arg10 = Big(Infinity);
-    assert.deepEqual(tanh(arg1), Big(-1));
-    assert.deepEqual(tanh(arg2), Big('-0.9950547536867304513'));
-    assert.deepEqual(tanh(Big(-2)), Big('-0.9640275800758168839'));
-    assert.deepEqual(tanh(Big(-1)), Big('-0.7615941559557648881'));
-    assert.deepEqual(tanh(Big(0)), Big(0));
-    assert.deepEqual(tanh(Big(1)), Big('0.7615941559557648881'));
-    assert.deepEqual(tanh(Big(2)), Big('0.9640275800758168839'));
-    assert.deepEqual(tanh(Big(3)), Big('0.9950547536867304513'));
-    assert.deepEqual(tanh(bigmath.pi).toString(), '0.9962720762207499443');
-    assert.deepEqual(tanh(arg10), Big(1));
+    assert.deepEqual(tanhBig(arg1), Big(-1));
+    assert.deepEqual(tanhBig(arg2), Big('-0.9950547536867304513'));
+    assert.deepEqual(tanhBig(Big(-2)), Big('-0.9640275800758168839'));
+    assert.deepEqual(tanhBig(Big(-1)), Big('-0.7615941559557648881'));
+    assert.deepEqual(tanhBig(Big(0)), Big(0));
+    assert.deepEqual(tanhBig(Big(1)), Big('0.7615941559557648881'));
+    assert.deepEqual(tanhBig(Big(2)), Big('0.9640275800758168839'));
+    assert.deepEqual(tanhBig(Big(3)), Big('0.9950547536867304513'));
+    assert.deepEqual(tanhBig(bigmath.pi).toString(), '0.9962720762207499443');
+    assert.deepEqual(tanhBig(arg10), Big(1));
 
     // Make sure args were not changed
     assert.deepEqual(arg1, Big(-Infinity));


### PR DESCRIPTION
... than create a new one each time. Now all trig functions can have arguments with higher precisions.