### PR TITLE
custom toTex for mathjs v1

### DIFF
--- a/docs/expressions/customization.md
+++ b/docs/expressions/customization.md
@@ -139,3 +139,127 @@ math.import({
 math.eval('myFunction(2 + 3, sqrt(4))');
 // returns 'arguments: 2 + 3, sqrt(4), evaluated: 5, 2'
 ```
+
+## Custom LaTeX conversion
+
+You can provide the `toTex` function of an expression tree with your own LaTeX converters.
+This can be used to override the builtin LaTeX conversion or provide LaTeX output for your own custom functions.
+
+You can pass your own callback(s) to `toTex`. If it returns nothing, the standard LaTeX conversion will be use.
+If your callback returns a string, this string will be used.
+
+There's two ways of passing callbacks:
+1. Pass a function to `toTex`. This function will then be used for every node.
+2. Pass an object that maps identifiers to callbacks. Those callbacks will be used whenever the identifier applies
+to the node's type of `getIdentifier()`.
+
+**Examples for option 1:**
+
+```js
+var customLaTeX = function (node, callback) {
+  if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
+    //don't forget to pass the callback to the toTex functions
+    return node.args[0].toTex(callback) + ' plus ' + node.args[1].toTex(callback);
+  }
+  else if (node.type === 'ConstantNode')
+    if (node.value == 0) {
+        return '\\mbox{zero}';
+    }
+    else if (node.value == 1) {
+        return '\\mbox{one}';
+    }
+    else if (node.value == 2) {
+        return '\\mbox{two}';
+    }
+    else {
+        return value;
+    }
+  }
+};
+```
+You can simply use your custom `toTex` functions by passing them to `toTex`:
+```js
+var expression = math.parse('1+2');
+var latex = expression.toTex(customLaTeX);
+//latex now contains '\mbox{one} plus \mbox{two}'
+```
+Another example in conjunction with custom functions:
+```js
+var customFunctions = {
+  binomial: function (n, k) {
+    //calculate n choose k
+    // (do some stuff)
+    return result;
+  }
+};
+
+var customLaTeX = function (node, callback) {
+  if ((node.type === 'FunctionNode') && (node.name === 'binomial')) {
+      return '\\binom{' + node.args[0].toTex(callback) + '}{' + node.args[1].toTex(callback) + '}';
+  }
+};
+
+math.import(customFunctions);
+var expression = math.parse('binomial(2,1)');
+var latex = expression.toTex(customLaTeX);
+//latex now contains "\binom{2}{1}"
+```
+
+
+**Examples for option 2**
+The same examples as above but using the second option:
+
+```js
+var customLaTeX = {
+  'OperatorNode:add': function (node, callbacks) {
+    //don't forget to call the toTex functions of the child nodes with the callbacks
+    return node.args[0].toTex(callbacks) + ' plus ' + node.args[1].toTex(callbacks);
+  },
+  'ConstantNode': function (node, callbacks) {
+    if (value == 0) {
+        return '\\mbox{zero}';
+    }
+    else if (value == 1) {
+        return '\\mbox{one}';
+    }
+    else if (value == 2) {
+        return '\\mbox{two}';
+    }
+    else {
+        return value;
+    }
+  }
+};
+```
+The object property is either the type of a node (`ConstantNode` in this example) or the identifier of a node (`OperatorNode:add` in this example. The identifier is available via the node's `getIdentifier()` function. In the above example, your custom toTex would get called for every OperatorNode that calls `add`).
+
+First argument of every callback function is the list of callback functions itself, which has to be passed on to every `toTex` your calling inside the function. The other arguments are the same with which the constructor of the given node is called (those can be found in `lib/expression/node/`). You can also access additional properties of the node via the `this` reference.
+
+You can simply use your custom `toTex` functions by passing them to `toTex`:
+```js
+var expression = math.parse('1+2');
+var latex = expression.toTex(customLaTeX);
+//latex now contains '\mbox{one} plus \mbox{two}'
+```
+
+Another example in conjunction with custom functions:
+```js
+var customFunctions = {
+  binomial: function (n, k) {
+    //calculate n choose k
+    // (do some stuff)
+    return result;
+  }
+};
+
+var customLaTeX = {
+  'FunctionNode:binomial': function (node, callbacks) {
+    return '\\binom{' + node.args[0].toTex(callbacks) + '}{' + node.args[1].toTex(callbacks) + '}';
+  }
+};
+
+math.import(customFunctions);
+var expression = math.parse('binomial(2,1)');
+var latex = expression.toTex(customLaTeX);
+//latex now contains "\binom{2}{1}"
+```

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -99,9 +99,9 @@ ArrayNode.prototype.toString = function() {
  * @param {String} type
  * @return {String} str
  */
-ArrayNode.prototype._toTex = function(customFunctions, type) {
-  type = type || 'bmatrix';
-  var s = '\\begin{' + type + '}';
+ArrayNode.prototype._toTex = function(customFunctions) {
+  this.latexType = this.latexType || 'bmatrix';
+  var s = '\\begin{' + this.latexType + '}';
 
   this.nodes.forEach(function(node) {
     if (node.nodes) {
@@ -116,7 +116,7 @@ ArrayNode.prototype._toTex = function(customFunctions, type) {
     // new line
     s += '\\\\';
   });
-  s += '\\end{' + type + '}';
+  s += '\\end{' + this.latexType + '}';
   return s;
 };
 

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -99,7 +99,7 @@ ArrayNode.prototype.toString = function() {
  * @param {String} type
  * @return {String} str
  */
-ArrayNode.prototype.toTex = function(customFunctions, type) {
+ArrayNode.prototype._toTex = function(customFunctions, type) {
   type = type || 'bmatrix';
   var s = '\\begin{' + type + '}';
 

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -95,20 +95,22 @@ ArrayNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
+ * @param {String} type
  * @return {String} str
  */
-ArrayNode.prototype.toTex = function(type) {
+ArrayNode.prototype.toTex = function(customFunctions, type) {
   type = type || 'bmatrix';
   var s = '\\begin{' + type + '}';
 
   this.nodes.forEach(function(node) {
     if (node.nodes) {
       s += node.nodes.map(function(childNode) {
-        return childNode.toTex();
+        return childNode.toTex(customFunctions);
       }).join('&');
     }
     else {
-      s += node.toTex();
+      s += node.toTex(customFunctions);
     }
 
     // new line

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -92,7 +92,7 @@ AssignmentNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String}
  */
-AssignmentNode.prototype.toTex = function(customFunctions) {
+AssignmentNode.prototype._toTex = function(customFunctions) {
   var precedence = operators.getPrecedence(this);
   var exprPrecedence = operators.getPrecedence(this.expr);
 

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -89,13 +89,14 @@ AssignmentNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String}
  */
-AssignmentNode.prototype.toTex = function() {
+AssignmentNode.prototype.toTex = function(customFunctions) {
   var precedence = operators.getPrecedence(this);
   var exprPrecedence = operators.getPrecedence(this.expr);
 
-  var expr = this.expr.toTex();
+  var expr = this.expr.toTex(customFunctions);
   if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
     //adds visible round brackets
     expr = latex.addBraces(expr, true);

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -125,7 +125,7 @@ BlockNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-BlockNode.prototype.toTex = function(customFunctions) {
+BlockNode.prototype._toTex = function(customFunctions) {
   return this.blocks.map(function (param) {
     return param.node.toTex(customFunctions) + (param.visible ? '' : ';');
   }).join('\n');

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -122,11 +122,12 @@ BlockNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-BlockNode.prototype.toTex = function() {
+BlockNode.prototype.toTex = function(customFunctions) {
   return this.blocks.map(function (param) {
-    return param.node.toTex() + (param.visible ? '' : ';');
+    return param.node.toTex(customFunctions) + (param.visible ? '' : ';');
   }).join('\n');
 };
 

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -151,15 +151,16 @@ ConditionalNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-ConditionalNode.prototype.toTex = function() {
+ConditionalNode.prototype.toTex = function(customFunctions) {
   var s = (
-      latex.addBraces(this.trueExpr.toTex()) +
+      latex.addBraces(this.trueExpr.toTex(customFunctions)) +
       ', &\\quad' +
-      latex.addBraces('\\text{if}\\;' + this.condition.toTex())
+      latex.addBraces('\\text{if}\\;' + this.condition.toTex(customFunctions))
       ) + '\\\\' + (
-      latex.addBraces(this.falseExpr.toTex()) +
+      latex.addBraces(this.falseExpr.toTex(customFunctions)) +
       ', &\\quad' +
       latex.addBraces('\\text{otherwise}')
       );

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -154,7 +154,7 @@ ConditionalNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-ConditionalNode.prototype.toTex = function(customFunctions) {
+ConditionalNode.prototype._toTex = function(customFunctions) {
   var s = (
       latex.addBraces(this.trueExpr.toTex(customFunctions)) +
       ', &\\quad' +

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -159,7 +159,7 @@ ConstantNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-ConstantNode.prototype.toTex = function(customFunctions) {
+ConstantNode.prototype._toTex = function(customFunctions) {
   var value = this.value,
       index;
   switch (this.valueType) {

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -156,9 +156,10 @@ ConstantNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-ConstantNode.prototype.toTex = function() {
+ConstantNode.prototype.toTex = function(customFunctions) {
   var value = this.value,
       index;
   switch (this.valueType) {

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -113,7 +113,7 @@ FunctionAssignmentNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-FunctionAssignmentNode.prototype.toTex = function(customFunctions) {
+FunctionAssignmentNode.prototype._toTex = function(customFunctions) {
   var precedence = operators.getPrecedence(this);
   var exprPrecedence = operators.getPrecedence(this.expr);
 

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -110,13 +110,14 @@ FunctionAssignmentNode.prototype.toString = function() {
 
 /**
  * get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-FunctionAssignmentNode.prototype.toTex = function() {
+FunctionAssignmentNode.prototype.toTex = function(customFunctions) {
   var precedence = operators.getPrecedence(this);
   var exprPrecedence = operators.getPrecedence(this.expr);
 
-  var expr = this.expr.toTex();
+  var expr = this.expr.toTex(customFunctions);
   if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
     //adds visible round brackets
     expr = latex.addBraces(expr, true);
@@ -127,7 +128,7 @@ FunctionAssignmentNode.prototype.toTex = function() {
   }
 
   return latex.toFunction(this.name)
-       + latex.addBraces(this.params.map(latex.toSymbol).join(', '), true) + '='
+       + latex.addBraces(this.params.map(latex.toSymbol).join(', '), true) + '=' //FIXME, this doesn't call toTex on the parameters AFAIK (toSymbol)
        + expr;
 };
 

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -116,7 +116,7 @@ FunctionNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-FunctionNode.prototype.toTex = function(customFunctions) {
+FunctionNode.prototype._toTex = function(customFunctions) {
   return latex.toArgs(this, customFunctions);
 };
 

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -113,10 +113,11 @@ FunctionNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-FunctionNode.prototype.toTex = function() {
-  return latex.toArgs(this);
+FunctionNode.prototype.toTex = function(customFunctions) {
+  return latex.toArgs(this, customFunctions);
 };
 
 /**

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -209,10 +209,11 @@ IndexNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-IndexNode.prototype.toTex = function() {
-  return this.object.toTex() + '[' + this.ranges.join(', ') + ']';
+IndexNode.prototype.toTex = function(customFunctions) {
+  return this.object.toTex(customFunctions) + '[' + this.ranges.join(', ') + ']';
 };
 
 module.exports = IndexNode;

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -212,7 +212,7 @@ IndexNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-IndexNode.prototype.toTex = function(customFunctions) {
+IndexNode.prototype._toTex = function(customFunctions) {
   return this.object.toTex(customFunctions) + '[' + this.ranges.join(', ') + ']';
 };
 

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -269,6 +269,10 @@ Node.prototype.toTex = function(customFunctions) {
  * @throws {Error}
  */
 Node.prototype._toTex = function () {
+  if (this.type === 'Node') {
+    //FIXME remove this in v2
+    return '';
+  }
   //must be implemented by each of the Node implementations
   throw new Error('_toTex not implemented for this Node');
 };

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -245,6 +245,14 @@ Node.prototype.toTex = function(customFunctions) {
     //if customFunctions is a callback function
     customTex = customFunctions(this, customFunctions);
   }
+  else if ((typeof customFunctions === 'string') && (this.type === 'ArrayNode')) {
+    //FIXME this is only a workaround for a breaking change,
+    //remove this in version2
+    this.latexType = customFunctions;
+  }
+  else if (typeof customFunctions !== 'undefined') {
+    throw new TypeError('Object or function expected as callback');
+  }
 
   if (typeof customTex !== 'undefined') {
     return customTex;

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -222,10 +222,23 @@ Node.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String}
  */
-Node.prototype.toTex = function() {
-  return '';
+Node.prototype.toTex = function(customFunctions) {
+  return this._toTex(customFunctions);
+};
+
+/**
+ * Internal function to generate the LaTeX output.
+ * This has to be implemented by every Node
+ *
+ * @param {Object}|function}
+ * @throws {Error}
+ */
+Node.prototype._toTex = function () {
+  //must be implemented by each of the Node implementations
+  throw new Error('_toTex not implemented for this Node');
 };
 
 /**

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -221,11 +221,35 @@ Node.prototype.toString = function() {
 };
 
 /**
- * Get LaTeX representation
+ * Get LaTeX representation. (wrapper function)
+ * This functions get's either an object containing callbacks or
+ * a single callback. It decides whether to call the callback and if
+ * not or if the callback returns nothing, it calls the default
+ * LaTeX implementation of the node (_toTex).
+ *
  * @param {Object|function} callback(s)
  * @return {String}
  */
 Node.prototype.toTex = function(customFunctions) {
+  var customTex;
+  if (typeof customFunctions === 'object') {
+    //if customFunctions is a map of callback functions
+    if (customFunctions.hasOwnProperty(this.type)) {
+      customTex = customFunctions[this.type](this, customFunctions);
+    }
+    else if (customFunctions.hasOwnProperty(this.getIdentifier())) {
+      customTex = customFunctions[this.getIdentifier()](this, customFunctions);
+    }
+  }
+  else if (typeof customFunctions === 'function') {
+    //if customFunctions is a callback function
+    customTex = customFunctions(this, customFunctions);
+  }
+
+  if (typeof customTex !== 'undefined') {
+    return customTex;
+  }
+
   return this._toTex(customFunctions);
 };
 

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -239,7 +239,7 @@ OperatorNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String} str
  */
-OperatorNode.prototype.toTex = function(customFunctions) {
+OperatorNode.prototype._toTex = function(customFunctions) {
  var args = this.args; 
  var parens = calculateNecessaryParentheses(this, args);
  var op = latex.toOperator(this.op); //operator

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -236,9 +236,10 @@ OperatorNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  */
-OperatorNode.prototype.toTex = function() {
+OperatorNode.prototype.toTex = function(customFunctions) {
  var args = this.args; 
  var parens = calculateNecessaryParentheses(this, args);
  var op = latex.toOperator(this.op); //operator
@@ -247,7 +248,7 @@ OperatorNode.prototype.toTex = function() {
    case 1: //unary operators
      var assoc = operators.getAssociativity(this);
 
-     var operand = args[0].toTex();
+     var operand = args[0].toTex(customFunctions);
      if (parens[0]) {
        operand = latex.addBraces(operand, true);
      }
@@ -265,9 +266,9 @@ OperatorNode.prototype.toTex = function() {
    case 2: //binary operators
      var lhs = args[0]; //left hand side
      //reminder: if parens[0] is false, this puts it in curly braces
-     var lhsTex = latex.addBraces(lhs.toTex(), parens[0]);
+     var lhsTex = latex.addBraces(lhs.toTex(customFunctions), parens[0]);
      var rhs = args[1]; //right hand side
-     var rhsTex = latex.addBraces(rhs.toTex(), parens[1]);
+     var rhsTex = latex.addBraces(rhs.toTex(customFunctions), parens[1]);
 
      switch (this.getIdentifier()) {
        case 'OperatorNode:divide':
@@ -275,7 +276,7 @@ OperatorNode.prototype.toTex = function() {
          return op + lhsTex + rhsTex;
 
        case 'OperatorNode:to':
-         rhsTex = latex.toUnit(rhs.toTex());
+         rhsTex = latex.toUnit(rhs.toTex(customFunctions));
          rhsTex = latex.addBraces(rhsTex, parens[1]);
          break;
      }

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -121,14 +121,15 @@ RangeNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @params {Object|function} callback(s)
  * @return {String} str
  */
-RangeNode.prototype.toTex = function() {
-  var str = this.start.toTex();
+RangeNode.prototype.toTex = function(customFunctions) {
+  var str = this.start.toTex(customFunctions);
   if (this.step) {
-    str += ':' + this.step.toTex();
+    str += ':' + this.step.toTex(customFunctions);
   }
-  str += ':' + this.end.toTex();
+  str += ':' + this.end.toTex(customFunctions);
 
   return str;
 };

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -124,7 +124,7 @@ RangeNode.prototype.toString = function() {
  * @params {Object|function} callback(s)
  * @return {String} str
  */
-RangeNode.prototype.toTex = function(customFunctions) {
+RangeNode.prototype._toTex = function(customFunctions) {
   var str = this.start.toTex(customFunctions);
   if (this.step) {
     str += ':' + this.step.toTex(customFunctions);

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -103,7 +103,7 @@ SymbolNode.prototype.toString = function() {
  * @return {String} str
  * @override
  */
-SymbolNode.prototype.toTex = function(customFunctions) {
+SymbolNode.prototype._toTex = function(customFunctions) {
   return latex.toSymbol(this.name, customFunctions);
 };
 

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -99,11 +99,12 @@ SymbolNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String} str
  * @override
  */
-SymbolNode.prototype.toTex = function() {
-  return latex.toSymbol(this.name);
+SymbolNode.prototype.toTex = function(customFunctions) {
+  return latex.toSymbol(this.name, customFunctions);
 };
 
 module.exports = SymbolNode;

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -87,7 +87,7 @@ UpdateNode.prototype.toString = function() {
  * @param {Object|function} callback(s)
  * @return {String}
  */
-UpdateNode.prototype.toTex = function(customFunctions) {
+UpdateNode.prototype._toTex = function(customFunctions) {
   return this.index.toTex(customFunctions) + ' = ' + this.expr.toTex(customFunctions);
 };
 

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -84,10 +84,11 @@ UpdateNode.prototype.toString = function() {
 
 /**
  * Get LaTeX representation
+ * @param {Object|function} callback(s)
  * @return {String}
  */
-UpdateNode.prototype.toTex = function() {
-  return this.index.toTex() + ' = ' + this.expr.toTex();
+UpdateNode.prototype.toTex = function(customFunctions) {
+  return this.index.toTex(customFunctions) + ' = ' + this.expr.toTex(customFunctions);
 };
 
 module.exports = UpdateNode;

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -466,7 +466,9 @@ exports.toArgs = function(that, customFunctions) {
 
     case 'det':
       if (that.args[0] instanceof ArrayNode) {
-        return that.args[0].toTex(customFunctions, 'vmatrix');
+        //FIXME passing 'vmatrix' like that is really ugly
+        that.args[0].latexType = 'vmatrix';
+        return that.args[0].toTex(customFunctions);
       }
 
       brace = 'vmatrix';

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -286,7 +286,7 @@ exports.addBraces = function(s, brace, type) {
   return braces[0] + s + braces[1];
 };
 
-exports.toArgs = function(that) {
+exports.toArgs = function(that, customFunctions) {
   var name = that.name,
       args = that.args,
       func = exports.toSymbol(that.name),
@@ -358,13 +358,13 @@ exports.toArgs = function(that) {
           op = '!';
         }
         else {
-          return '{\\left(' + args[0].toTex() + '\\right)!}';
+          return '{\\left(' + args[0].toTex(customFunctions) + '\\right)!}';
         }
       }
       else {
         // op = 'P';
-        var n = args[0].toTex(),
-            k = args[1].toTex();
+        var n = args[0].toTex(customFunctions),
+            k = args[1].toTex(customFunctions);
         return '\\frac{' + n + '!}{\\left(' + n + ' - ' + k + '\\right)!}';
       }
       break;
@@ -385,7 +385,7 @@ exports.toArgs = function(that) {
       type = 'lr';
 
       if (args.length === 2) {
-        var tmp = args[1].toTex();
+        var tmp = args[1].toTex(customFunctions);
 
         if (tmp === '\\text{inf}') {
           tmp = '\\infty';
@@ -417,7 +417,7 @@ exports.toArgs = function(that) {
       type = 'lr';
 
       if (args.length === 2) {
-        suffix = '_' + exports.addBraces(args[1].toTex());
+        suffix = '_' + exports.addBraces(args[1].toTex(customFunctions));
         args = [args[0]];
       }
       break;
@@ -437,7 +437,7 @@ exports.toArgs = function(that) {
     case 'log':
       var base = 'e';
       if (args.length === 2) {
-        base = args[1].toTex();
+        base = args[1].toTex(customFunctions);
         func = '\\log_{' + base + '}';
         args = [args[0]];
       }
@@ -466,7 +466,7 @@ exports.toArgs = function(that) {
 
     case 'det':
       if (that.args[0] instanceof ArrayNode) {
-        return that.args[0].toTex('vmatrix');
+        return that.args[0].toTex(customFunctions, 'vmatrix');
       }
 
       brace = 'vmatrix';
@@ -480,7 +480,7 @@ exports.toArgs = function(that) {
 
   if (op !== null) {
     brace = (op === '+' || op === '-');
-    texParams = (new OperatorNode(op, name, args)).toTex();
+    texParams = (new OperatorNode(op, name, args)).toTex(customFunctions);
   }
   else {
     op = ', ';
@@ -491,7 +491,7 @@ exports.toArgs = function(that) {
   }
 
   texParams = texParams || args.map(function(param) {
-    return '{' + param.toTex() + '}'  ;
+    return '{' + param.toTex(customFunctions) + '}'  ;
   }).join(op);
 
   return prefix + (showFunc ? func : '') +

--- a/test/expression/node/ArrayNode.test.js
+++ b/test/expression/node/ArrayNode.test.js
@@ -236,4 +236,29 @@ describe('ArrayNode', function() {
     assert.equal(n.toTex(), '\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}');
   });
 
+  it ('should LaTeX an ArrayNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      ArrayNode: function (node, callbacks) {
+        var latex = '\\left[';
+        node.nodes.forEach(function (node) {
+          latex += node.toTex(callbacks) + ', ';
+        });
+
+        latex += '\\right]';
+        return latex;
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new ArrayNode([a, b]);
+
+    assert.equal(n.toTex(customFunctions), '\\left[const\\left(1, number\\right), const\\left(2, number\\right), \\right]');
+  });
+
 });

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -225,4 +225,22 @@ describe('AssignmentNode', function() {
     assert.equal(n.toTex(), '{b}=\\left({{a}={2}}\\right)');
   });
 
+  it ('should LaTeX an AssignmentNode with custom toTex', function () {
+    //Also checks if custom funcions get passed to the children
+    var customFunctions = {
+      AssignmentNode: function (node, callbacks) {
+        return node.name + '\\mbox{equals}' + node.expr.toTex(callbacks);
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+
+    var n = new AssignmentNode('a', a);
+
+    assert.equal(n.toTex(customFunctions), 'a\\mbox{equals}const\\left(1, number\\right)');
+  });
+
 });

--- a/test/expression/node/BlockNode.test.js
+++ b/test/expression/node/BlockNode.test.js
@@ -256,4 +256,28 @@ describe('BlockNode', function() {
     assert.equal(n.toTex(), '5\n{foo}={3};\nfoo');
   });
 
+  it ('should LaTeX a BlockNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      BlockNode: function (node, callbacks) {
+        var latex = '';
+        node.blocks.forEach(function (block) {
+          latex += block.node.toTex(callbacks) + '; ';
+        });
+
+        return latex;
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new BlockNode([{node: a}, {node: b}]);
+
+    assert.equal(n.toTex(customFunctions), 'const\\left(1, number\\right); const\\left(2, number\\right); ');
+  });
+
 });

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -260,4 +260,26 @@ describe('ConditionalNode', function() {
     assert.equal(n.toTex(), '\\left\\{\\begin{array}{l l}{{a}={2}}, &\\quad{\\text{if}\\;true}\\\\{{b}={3}}, &\\quad{\\text{otherwise}}\\end{array}\\right.');
   });
 
+  it ('should LaTeX a ConditionalNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      ConditionalNode: function (node, callbacks) {
+        return 'if ' + node.condition.toTex(callbacks)
+          + ' then ' + node.trueExpr.toTex(callbacks)
+          + ' else ' + node.falseExpr.toTex(callbacks);
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(3);
+
+    var n = new ConditionalNode(a, b, c);
+
+    assert.equal(n.toTex(customFunctions), 'if const\\left(1, number\\right) then const\\left(2, number\\right) else const\\left(3, number\\right)');
+  });
+
 });

--- a/test/expression/node/ConstantNode.test.js
+++ b/test/expression/node/ConstantNode.test.js
@@ -139,4 +139,17 @@ describe('ConstantNode', function() {
     assert.equal(new ConstantNode('null', 'null').toTex(), 'null');
   });
 
+  it ('should LaTeX a ConstantNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var n = new ConstantNode(1);
+
+    assert.equal(n.toTex(customFunctions), 'const\\left(1, number\\right)');
+  });
+
 });

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -206,4 +206,29 @@ describe('FunctionAssignmentNode', function() {
 
     assert.equal(n.toTex(), 'f\\left({x}\\right)=\\left({{a}={2}}\\right)');
   });
+
+  it ('should LaTeX a FunctionAssignmentNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      FunctionAssignmentNode: function (node, callbacks) {
+        var latex = '\\mbox{' + node.name + '}\\left(';
+        node.params.forEach(function (param) {
+          latex += param + ', ';
+        });
+
+        latex += '\\right)=' + node.expr.toTex(customFunctions);
+        return latex;
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+
+    var n = new FunctionAssignmentNode('func', ['x'], a);
+
+    assert.equal(n.toTex(customFunctions), '\\mbox{func}\\left(x, \\right)=const\\left(1, number\\right)');
+  });
+
 });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -288,4 +288,51 @@ describe('FunctionNode', function() {
     assert.equal(n.getIdentifier(), 'FunctionNode:factorial');
   });
 
+  it ('should LaTeX a FunctionNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      'FunctionNode': function (node, callbacks) {
+        var latex = '\\mbox{' + node.name + '}\\left(';
+        node.args.forEach(function (arg) {
+          latex += arg.toTex(callbacks) + ', ';
+        });
+        latex += '\\right)';
+        return latex;
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n1 = new FunctionNode('add', [a, b]);
+    var n2 = new FunctionNode('subtract', [a, b]);
+
+    assert.equal(n1.toTex(customFunctions), '\\mbox{add}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
+    assert.equal(n2.toTex(customFunctions), '\\mbox{subtract}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
+  });
+
+  it ('should LaTeX a FunctionNode with custom toTex for a single function', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      'FunctionNode:add': function (node, callbacks) {
+        return node.args[0].toTex(callbacks) 
+          + ' ' + node.name + ' ' 
+          + node.args[1].toTex(callbacks);
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new FunctionNode('add', [a, b]);
+
+    assert.equal(n.toTex(customFunctions), 'const\\left(1, number\\right) add const\\left(2, number\\right)');
+  });
+
 });

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -285,4 +285,29 @@ describe('IndexNode', function() {
     assert.equal(n2.toTex(), 'a[]')
   });
 
+  it ('should LaTeX an IndexNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      IndexNode: function (node, callbacks) {
+        var latex = node.object.toTex(callbacks) + ' at ';
+        node.ranges.forEach(function (range) {
+          latex += range.toTex(callbacks) + ', ';
+        });
+
+        return latex;
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new SymbolNode('a');
+    var b = new ConstantNode(1);
+    var c = new ConstantNode(2);
+
+    var n = new IndexNode(a, [b, c]);
+
+    assert.equal(n.toTex(customFunctions), 'a at const\\left(1, number\\right), const\\left(2, number\\right), ');
+  });
+
 });

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -77,6 +77,8 @@ describe('Node', function() {
   it ('should throw an error when calling _toTex', function () {
     assert.throws(function () {
       var node = new Node();
+      node.type = 'SpecialNode';  //this is necessary because toTex
+                                  //returns '' for a Node
       node._toTex();
     }, /_toTex not implemented for this Node/);
   });

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -74,11 +74,26 @@ describe('Node', function() {
     assert.equal(node.toString(), '');
   });
 
-  it ('should throw an error when calling toTex', function () {
+  it ('should throw an error when calling _toTex', function () {
     assert.throws(function () {
       var node = new Node();
-      node.toTex();
+      node._toTex();
     }, /_toTex not implemented for this Node/);
+  });
+
+  it ('should ignore custom toTex if it returns nothing', function () {
+    var callback1 = function (node, callback) {};
+    var callback2 = {
+      Node: function (node, callbacks) {}
+    };
+    var mymath = math.create();
+    mymath.expression.node.Node.prototype._toTex = function () {
+      return 'default';
+    };
+    var n = new mymath.expression.node.Node();
+    
+    assert.equal(n.toTex(callback1), 'default');
+    assert.equal(n.toTex(callback2), 'default');
   });
 
   it ('should throw an error in case of wrong arguments for compile', function () {

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -74,9 +74,11 @@ describe('Node', function() {
     assert.equal(node.toString(), '');
   });
 
-  it ('should LaTeX a Node', function () {
-    var node = new Node();
-    assert.equal(node.toTex(), '');
+  it ('should throw an error when calling toTex', function () {
+    assert.throws(function () {
+      var node = new Node();
+      node.toTex();
+    }, /_toTex not implemented for this Node/);
   });
 
   it ('should throw an error in case of wrong arguments for compile', function () {

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -378,4 +378,48 @@ describe('OperatorNode', function() {
     assert.equal(n.getIdentifier(), 'OperatorNode:add');
   });
 
+  it ('should LaTeX an OperatorNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      'OperatorNode': function (node, callbacks) {
+        return node.op + node.fn + '(' 
+          + node.args[0].toTex(customFunctions)
+          + ', ' +  node.args[1].toTex(customFunctions) + ')';
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n1 = new OperatorNode('+', 'add', [a, b]);
+	var n2 = new OperatorNode('-', 'subtract', [a, b]);
+
+    assert.equal(n1.toTex(customFunctions), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
+    assert.equal(n2.toTex(customFunctions), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
+  });
+
+  it ('should LaTeX an OperatorNode with custom toTex for a single operator', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      'OperatorNode:add': function (node, callbacks) {
+        return node.args[0].toTex(customFunctions)
+          + node.op + node.fn + node.op + 
+          node.args[1].toTex(customFunctions);
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    assert.equal(n.toTex(customFunctions), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
+  });
+
 });

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -289,4 +289,26 @@ describe('RangeNode', function() {
     assert.equal(n.toTex(), '0:2:10');
   });
 
+  it ('should LaTeX a RangeNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      RangeNode: function (node, callbacks) {
+        return 'from ' + node.start.toTex(customFunctions)
+          + ' to ' + node.end.toTex(customFunctions)
+          + ' with steps of ' + node.step.toTex(customFunctions);
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(3);
+
+    var n = new RangeNode(a, b, c);
+
+    assert.equal(n.toTex(customFunctions), 'from const\\left(1, number\\right) to const\\left(2, number\\right) with steps of const\\left(3, number\\right)');
+  });
+
 });

--- a/test/expression/node/SymbolNode.test.js
+++ b/test/expression/node/SymbolNode.test.js
@@ -107,4 +107,17 @@ describe('SymbolNode', function() {
     assert.equal(s.toTex(), 'foo');
   });
 
+  it ('should LaTeX a SymbolNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      SymbolNode: function (node, callbacks) {
+        return 'symbol(' + node.name + ')';
+      }
+    };
+
+    var n = new SymbolNode('a');
+
+    assert.equal(n.toTex(customFunctions), 'symbol(a)');
+  });
+
 });

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -322,4 +322,35 @@ describe('UpdateNode', function() {
     assert.equal(n.toString(), 'a[2, 1] = 5');
   });
 
+  it ('should LaTeX an UpdateNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunctions = {
+      UpdateNode: function (node, callbacks) {
+        return node.index.toTex(callbacks) + ' equals ' + node.expr.toTex(customFunctions);
+      },
+      IndexNode: function (node, callbacks) {
+        var latex = node.object.toTex(callbacks) + ' at ';
+        node.ranges.forEach(function (range) {
+          latex += range.toTex(callbacks) + ', ';
+        });
+
+        return latex;
+      },
+      ConstantNode: function (node, callbacks) {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new SymbolNode('a');
+    var ranges = [
+      new ConstantNode(2),
+      new ConstantNode(1)
+    ];
+    var v = new ConstantNode(5);
+
+    var n = new UpdateNode(new IndexNode(a, ranges), v);
+
+    assert.equal(n.toTex(customFunctions), 'a at const\\left(2, number\\right), const\\left(1, number\\right),  equals const\\left(5, number\\right)');
+  });
+
 });


### PR DESCRIPTION
This is not intended to be the final solution, but something that can be used in version 1 without breaking everything. See #276. With this solution, every expression tree has to be compiled once to enable the custom toTex functions.