### PR TITLE
gammaln

### DIFF
--- a/lib/function/probability/gammaln.js
+++ b/lib/function/probability/gammaln.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = function(math, config) {
+
+  var util = require('../../util/index'),
+      isNumber = util.number.isNumber,
+      collection = math.collection,
+      isCollection = collection.isCollection;
+
+  /**
+   * Logarithm of the gamma function.
+   * Based off of Tom Minka's lightspeed toolbox.
+   *
+   *
+   */
+  math.gammaln = function gammaln(x) {
+
+      if (arguments.length != 1) {
+          throw new math.error.ArgumentsError('gammaln', arguments.length, 1);
+      }
+
+      if(isNumber(x)) {
+        if(x < 0) return NaN;
+        if(x == 0) return Infinity;
+        if(!isFinite(x)) return x;
+
+        var lnSqrt2PI = 0.91893853320467274178;
+        var gamma_series = [76.18009172947146,
+                            -86.50532032941677,
+                            24.01409824083091,
+                            -1.231739572450155,
+                            0.1208650973866179e-2,
+                            -0.5395239384953e-5];
+        var denom;
+        var x1;
+        var series;
+
+        // Lanczos method
+        denom = x+1;
+        x1 = x + 5.5;
+        series = 1.000000000190015;
+        for(var i = 0; i < 6; i++) {
+          series += gamma_series[i] / denom;
+          denom += 1.0;
+        }
+        return( lnSqrt2PI + (x+0.5)*Math.log(x1) - x1 + Math.log(series/x) );
+      }
+
+      if(isCollection(x)) {
+          return collection.deepMap(x, gammaln);
+      }
+
+      throw new math.error.UnsupportedTypeError('gammaln', math['typeof'](x));
+
+  };
+
+};

--- a/lib/function/probability/gammaln.js
+++ b/lib/function/probability/gammaln.js
@@ -8,10 +8,27 @@ module.exports = function(math, config) {
       isCollection = collection.isCollection;
 
   /**
-   * Logarithm of the gamma function.
+   * Logarithm of the gamma function for real, positive numbers.
    * Based off of Tom Minka's lightspeed toolbox.
    *
+   * For matrices, the function works elementwise.
    *
+   * Syntax:
+   *
+   *    math.gammaln(x)
+   *
+   * Examples:
+   *
+   *    math.gammaln(3);     // returns 0.82769459232343701
+   *    math.gammaln(0.)     // returns Infinity
+   *    math.gammaln(-0.5);  // returns NaN
+   *
+   * See also:
+   *
+   *    gamma
+   *
+   * @param {Number | Array | Matrix} x  A real number > 0.
+   * @return {Number | Array | Matrix}  The logarathim of `gamma(x)`.
    */
   math.gammaln = function gammaln(x) {
 
@@ -52,6 +69,22 @@ module.exports = function(math, config) {
 
       throw new math.error.UnsupportedTypeError('gammaln', math['typeof'](x));
 
+  };
+
+  /**
+   * Logarithm of the multivariate Gamma function, defined as
+   * Gamma_d(x) = pi^(d*(d-1)/4)*prod_{i=1..d} Gamma(x + (1-i)/2)
+   * Based off of Tom Minka's lightspeed toolbox.
+   * http://en.wikipedia.org/wiki/Multivariate_gamma_function
+   */
+  math.gammaln2 = function gammaln2(x, d) {
+    if (arguments.length != 2) {
+        throw new math.error.ArgumentsError('gammaln', arguments.length, 2);
+    }
+    var lnPI = 1.14472988584940;
+    var r = d*(d-1)/4.*lnPI;
+    for(var i = 0; i < d; i++) r += gammaln(x - 0.5*i);
+    return r;
   };
 
 };

--- a/lib/math.js
+++ b/lib/math.js
@@ -303,6 +303,7 @@ function create (config) {
   //require('./function/probability/distribution')(math, _config); // TODO: rethink math.distribution
   require('./function/probability/factorial')(math, _config);
   require('./function/probability/gamma')(math, _config);
+  require('./function/probability/gammaln')(math, _config);
   require('./function/probability/random')(math, _config);
   require('./function/probability/randomInt')(math, _config);
   require('./function/probability/pickRandom')(math, _config);

--- a/test/function/probability/gammaln.test.js
+++ b/test/function/probability/gammaln.test.js
@@ -9,15 +9,26 @@ var assert = require('assert'),
 describe('gammaln', function () {
 
     it('should calculate the gammaln of a whole number', function () {
+      approx.equal(gammaln(1.), 0.);
+      approx.equal(gammaln(2.), 0.);
       approx.equal(gammaln(3), 0.69314718055994529);
+      approx.equal(gammaln(4.), 1.791759469228055000812477);
+      approx.equal(gammaln(8.), 8.525161361065414300165531);
+      approx.equal(gammaln(64.), 201.00931639928152667928);
+      approx.equal(gammaln(256.), 1161.71210111840065079);
     });
 
     it('should calculate the gammaln of a rational number', function () {
+      approx.equal(gammaln(0.1), 2.2527126517342059598697);
       approx.equal(gammaln(0.5), 0.57236494292469997);
+      approx.equal(gammaln(0.6), 0.39823385806923489961685);
+      approx.equal(gammaln(0.7), 0.26086724653166651438573);
+      approx.equal(gammaln(3.4), 1.0923280598027415674947);
     });
 
     it('should calculate the gammaln of a irrational number', function () {
       approx.equal(gammaln(Math.PI), 0.82769459232343701);
+      approx.equal(gammaln(Math.E), 0.449461741820069);
     });
 
     it('should calculate the gamma of each element in a matrix', function () {

--- a/test/function/probability/gammaln.test.js
+++ b/test/function/probability/gammaln.test.js
@@ -1,0 +1,43 @@
+var assert = require('assert'),
+    approx = require('../../../tools/approx'),
+    error = require('../../../lib/error/index'),
+    math = require('../../../index'),
+    bigUtil = require('../../../lib/util/index').bignumber,
+    bignumber = math.bignumber,
+    gammaln = math.gammaln;
+
+describe('gammaln', function () {
+
+    it('should calculate the gammaln of a whole number', function () {
+      approx.equal(gammaln(3), 0.69314718055994529);
+    });
+
+    it('should calculate the gammaln of a rational number', function () {
+      approx.equal(gammaln(0.5), 0.57236494292469997);
+    });
+
+    it('should calculate the gammaln of a irrational number', function () {
+      approx.equal(gammaln(Math.PI), 0.82769459232343701);
+    });
+
+    it('should calculate the gamma of each element in a matrix', function () {
+      approx.deepEqual(gammaln(math.matrix([1,2,3,4,5])),
+                       math.matrix([0.,-2.220446049250313e-16,0.693147180559944,1.791759469228054,3.178053830347945]));
+    });
+
+    it('should calculate the gamma of each element in an array', function () {
+      approx.deepEqual(gammaln([1,2,3,4,5]),
+                       [0.,-2.220446049250313e-16,0.693147180559944,1.791759469228054,3.178053830347945]);
+    });
+
+    it('should throw en error if called with invalid number of arguments', function() {
+      assert.throws(function() { gammaln(); });
+      assert.throws(function() { gammaln(1,3); });
+    });
+
+    it('should throw en error if called with invalid type of argument', function() {
+      assert.throws(function() { gamma(new Date()); });
+      assert.throws(function() { gamma('a string'); });
+    });
+
+});


### PR DESCRIPTION
This implements the Lanzcos method to compute the logarithm of the gamma function since `log(gamma(x))` can result in numerical problems.

The current commit is not complete in that the tests should be expanded, the documentation needs to be thorough, and there may be some other types that `gammaln` should handle.  However, I wanted to submit this to start getting feedback.

Thanks.
