### PR TITLE
math.transpose() refactoring

### DIFF
--- a/lib/function/arithmetic/norm.js
+++ b/lib/function/arithmetic/norm.js
@@ -10,6 +10,7 @@ function factory (type, config, load, typed) {
   var larger    = load(require('../relational/larger'));
   var smaller   = load(require('../relational/smaller'));
   var matrix    = load(require('../construction/matrix'));
+  var transpose = load(require('../matrix/transpose'));
   
   var complexAbs = abs.signatures['Complex'];
 
@@ -188,7 +189,7 @@ function factory (type, config, load, typed) {
       }
       if (p === 'fro') {
         // norm(x) = sqrt(sum(diag(x'x)))
-        return sqrt(x.transpose().multiply(x).trace());
+        return sqrt(transpose(x).multiply(x).trace());
       }
       if (p === 2) {
         // not implemented

--- a/lib/function/matrix/transpose.js
+++ b/lib/function/matrix/transpose.js
@@ -1,10 +1,16 @@
 'use strict';
 
-var size = require('../../util/array').size;
 var clone = require('../../util/object').clone;
 var format = require('../../util/string').format;
 
 function factory (type, config, load, typed) {
+
+  var matrix = load(require('../construction/matrix'));
+
+  var DenseMatrix = type.DenseMatrix,
+      CcsMatrix = type.CcsMatrix,
+      CrsMatrix = type.CrsMatrix;
+
   /**
    * Transpose a matrix. All values of the matrix are reflected over its
    * main diagonal. Only two dimensional matrices are supported.
@@ -25,14 +31,57 @@ function factory (type, config, load, typed) {
    * @param {Array | Matrix} x  Matrix to be transposed
    * @return {Array | Matrix}   The transposed matrix
    */
-  return typed('transpose', {
+  var transpose = typed('transpose', {
+
     'Array': function (x) {
-      return _transpose(x, size(x));
+      // use dense matrix implementation
+      return transpose(matrix(x)).valueOf();
     },
 
     'Matrix': function (x) {
-      // use optimized matrix implementation if available
-      return x.transpose();
+      // matrix size
+      var size = x.size();
+
+      // result
+      var c;
+      
+      // process dimensions
+      switch (size.length) {
+        case 1:
+          // vector
+          c = x.clone();
+          break;
+
+        case 2:
+          // rows and columns
+          var rows = size[0];
+          var columns = size[1];
+
+          // check columns
+          if (columns === 0) {
+            // throw exception
+            throw new RangeError('Cannot transpose a 2D matrix with no columns (size: ' + format(size) + ')');
+          }
+
+          // process storage format
+          switch (x.storage()) {
+            case 'dense':
+              c = _denseTranspose(x, rows, columns);
+              break;
+            case 'ccs':
+              c = _ccsTranspose(x, rows, columns);
+              break;
+            case 'crs':
+              c = _crsTranspose(x, rows, columns);
+              break;
+          }
+          break;
+          
+        default:
+          // multi dimensional
+          throw new RangeError('Matrix must be a vector or two dimensional (size: ' + format(this._size) + ')');
+      }
+      return c;
     },
 
     // scalars
@@ -41,46 +90,136 @@ function factory (type, config, load, typed) {
     }
   });
 
-  /**
-   * Transpose an array
-   * @param {Array} data
-   * @param {Array} size
-   * @returns {Array}
-   * @private
-   */
-  function _transpose (data, size) {
-    switch (size.length) {
-      case 1:
-        // vector
-        return clone(data);
-
-      case 2:
-        // two dimensional array
-        var rows = size[1];
-        var cols = size[0];
-        var transposed = [];
-
-        if (rows === 0) {
-          // whoops
-          throw new RangeError('Cannot transpose a 2D matrix with no rows' +
-          '(size: ' + format(size) + ')');
-        }
-
-        for (var r = 0; r < rows; r++) {
-          var transposedRow = transposed[r] = [];
-          for (var c = 0; c < cols; c++) {
-            transposedRow[c] = clone(data[c][r]);
-          }
-        }
-
-        return transposed;
-
-      default:
-        // multi dimensional array
-        throw new RangeError('Matrix must be a vector or two dimensional ' +
-        '(size: ' + format(size) + ')');
+  var _denseTranspose = function (m, rows, columns) {
+    // matrix array
+    var data = m._data;
+    // transposed matrix data
+    var transposed = [];
+    var transposedRow;
+    // loop columns
+    for (var j = 0; j < columns; j++) {
+      // initialize row
+      transposedRow = transposed[j] = [];
+      // loop rows
+      for (var i = 0; i < rows; i++) {
+        // set data
+        transposedRow[i] = clone(data[i][j]);
+      }
     }
-  }
+    // return matrix
+    return new DenseMatrix({
+      data: transposed,
+      size: [columns, rows]
+    });
+  };
+
+  var _ccsTranspose = function (m, rows, columns) {
+    // matrix arrays
+    var values = m._values;
+    var index = m._index;
+    var ptr = m._ptr;
+        // result matrices
+    var cvalues = [];
+    var cindex = [];
+    var cptr = [];
+    // row counts
+    var w = new Array(rows);
+    for (var x = 0; x < rows; x++)
+      w[x] = 0;
+    // vars
+    var p, l, j;
+    // loop values in matrix
+    for (p = 0, l = index.length; p < l; p++) {
+      // number of values in row
+      w[index[p]]++;
+    }
+    // cumulative sum
+    var sum = 0;
+    // initialize cptr with the cummulative sum of row counts
+    for (var i = 0; i < rows; i++) {
+      // update cptr
+      cptr.push(sum);
+      // update sum
+      sum += w[i];
+      // update w
+      w[i] = cptr[i];
+    }
+    // update cptr
+    cptr.push(sum);
+    // loop columns
+    for (j = 0; j < columns; j++) {
+      // values & index in column
+      for (var k0 = ptr[j], k1 = ptr[j + 1], k = k0; k < k1; k++) {
+        // C values & index
+        var q = w[index[k]]++;
+        // C[j, i] = A[i, j]
+        cindex[q] = j;
+        cvalues[q] = clone(values[k]);
+      }
+    }
+    // return matrix
+    return new CcsMatrix({
+      values: cvalues,
+      index: cindex,
+      ptr: cptr,
+      size: [columns, rows]
+    });
+  };
+  
+  var _crsTranspose = function (m, rows, columns) {
+    // matrix arrays
+    var values = m._values;
+    var index = m._index;
+    var ptr = m._ptr;
+    // result matrices
+    var cvalues = [];
+    var cindex = [];
+    var cptr = [];
+    // column counts
+    var w = new Array(columns);
+    for (var x = 0; x < columns; x++)
+      w[x] = 0;
+    // vars
+    var p, l, i;
+    // loop values in matrix
+    for (p = 0, l = index.length; p < l; p++) {
+      // number of values in column
+      w[index[p]]++;
+    }
+    // cumulative sum
+    var sum = 0;
+    // initialize cptr with the cummulative sum of column counts
+    for (var j = 0; j < columns; j++) {
+      // update cptr
+      cptr.push(sum);
+      // update sum
+      sum += w[j];
+      // update w
+      w[j] = cptr[j];
+    }
+    // update cptr
+    cptr.push(sum);
+    // loop rows
+    for (i = 0; i < rows; i++) {
+      // values & index in row
+      for (var k0 = ptr[i], k1 = ptr[i + 1], k = k0; k < k1; k++) {
+        // C values & index
+        var q = w[index[k]]++;
+        // C[j, i] = A[i, j]
+        cindex[q] = i;
+        cvalues[q] = clone(values[k]);
+      }
+    }
+    // return matrix
+    return new CrsMatrix({
+      values: cvalues,
+      index: cindex,
+      ptr: cptr,
+      size: [columns, rows]
+    });
+  };
+
+  return transpose;
 }
 
 exports.name = 'transpose';

--- a/lib/type/Matrix.js
+++ b/lib/type/Matrix.js
@@ -228,15 +228,6 @@ function factory (type, config, load, typed) {
   };
 
   /**
-   * Calculates the transpose of the matrix
-   * @returns {Matrix}
-   */
-  Matrix.prototype.transpose = function () {
-    // must be implemented by each of the Matrix implementations
-    throw new Error('Cannot invoke transpose on a Matrix interface');
-  };
-
-  /**
    * Calculate the trace of a matrix: the sum of the elements on the main
    * diagonal of a square matrix.
    *

--- a/lib/type/matrix/CcsMatrix.js
+++ b/lib/type/matrix/CcsMatrix.js
@@ -863,28 +863,6 @@ function factory (type, config, load, typed) {
   };
 
   /**
-   * Calculates the transpose of the matrix
-   * @returns {Matrix}
-   */
-  CcsMatrix.prototype.transpose = function () {
-    // rows and columns
-    var rows = this._size[0];
-    var columns = this._size[1];
-    // check columns
-    if (columns === 0) {
-      // throw exception
-      throw new RangeError('Cannot transpose a 2D matrix with no columns (size: ' + string.format(this._size) + ')');
-    }
-    // ccs transpose is a crs matrix with the same structure
-    return new type.CrsMatrix({
-      values: object.clone(this._values),
-      index: object.clone(this._index),
-      ptr: object.clone(this._ptr),
-      size: [columns, rows]
-    });
-  };
-
-  /**
    * Get the kth Matrix diagonal.
    *
    * @param {Number | BigNumber} [k=0]     The kth diagonal where the vector will retrieved.

--- a/lib/type/matrix/CrsMatrix.js
+++ b/lib/type/matrix/CrsMatrix.js
@@ -857,28 +857,6 @@ function factory (type, config, load, typed) {
   };
 
   /**
-   * Calculates the transpose of the matrix
-   * @returns {Matrix}
-   */
-  CrsMatrix.prototype.transpose = function () {
-    // rows and columns
-    var rows = this._size[0];
-    var columns = this._size[1];
-    // check columns
-    if (columns === 0) {
-      // throw exception
-      throw new RangeError('Cannot transpose a 2D matrix with no columns (size: ' + string.format(this._size) + ')');
-    }
-    // crs transpose is a ccs matrix with the same structure
-    return new type.CcsMatrix({
-      values: object.clone(this._values),
-      index: object.clone(this._index),
-      ptr: object.clone(this._ptr),
-      size: [columns, rows]
-    });
-  };
-
-  /**
    * Get the kth Matrix diagonal.
    *
    * @param {Number | BigNumber} [k=0]     The kth diagonal where the vector will retrieved.

--- a/lib/type/matrix/DenseMatrix.js
+++ b/lib/type/matrix/DenseMatrix.js
@@ -540,49 +540,6 @@ function factory (type, config, load, typed) {
   };
   
   /**
-   * Calculates the transpose of the matrix
-   * @returns {Matrix}
-   */
-  DenseMatrix.prototype.transpose = function () {
-    // check dimensions
-    switch (this._size.length) {
-        case 1:
-          // vector
-          return this.clone();
-        case 2:
-          // rows and columns
-          var rows = this._size[0];
-          var columns = this._size[1];
-          // check columns
-          if (columns === 0) {
-            // throw exception
-            throw new RangeError('Cannot transpose a 2D matrix with no columns (size: ' + string.format(this._size) + ')');
-          }
-          // transposed matrix data
-          var transposed = [];
-          var transposedRow;
-          // loop columns
-          for (var j = 0; j < columns; j++) {
-            // initialize row
-            transposedRow = transposed[j] = [];
-            // loop rows
-            for (var i = 0; i < rows; i++) {
-              // set data
-              transposedRow[i] = object.clone(this._data[i][j]);
-            }
-          }
-          // return matrix
-          return new DenseMatrix({
-            data: transposed,
-            size: [columns, rows]
-          });
-        default:
-          // multi dimensional
-          throw new RangeError('Matrix must be two dimensional (size: ' + string.format(this._size) + ')');
-    }
-  };
-  
-  /**
    * Get the kth Matrix diagonal.
    *
    * @param {Number | BigNumber} [k=0]     The kth diagonal where the vector will retrieved.

--- a/test/function/matrix/transpose.test.js
+++ b/test/function/matrix/transpose.test.js
@@ -1,6 +1,5 @@
 // test transpose
 var assert = require('assert'),
-    error = require('../../../lib/error/index'),
     math = require('../../../index'),
     transpose = math.transpose;
 
@@ -32,8 +31,77 @@ describe('transpose', function() {
   });
 
   it('should throw an error if called with an invalid number of arguments', function() {
-    assert.throws(function () {transpose()}, /TypeError: Too few arguments/);
-    assert.throws(function () {transpose([1,2],2)}, /TypeError: Too many arguments/);
+    assert.throws(function () {transpose();}, /TypeError: Too few arguments/);
+    assert.throws(function () {transpose([1,2],2);}, /TypeError: Too many arguments/);
+  });
+  
+  describe('DenseMatrix', function () {
+
+    it('should transpose a 2d matrix', function() {
+      var m = math.matrix([[1,2,3],[4,5,6]]);
+      assert.deepEqual(transpose(m).valueOf(), [[1,4],[2,5],[3,6]]);
+
+      m = math.matrix([[1,4],[2,5],[3,6]]);
+      assert.deepEqual(transpose(m).toArray(), [[1,2,3],[4,5,6]]);
+      
+      m = math.matrix([[1,2],[3,4]]);
+      assert.deepEqual(transpose(m).valueOf(), [[1,3],[2,4]]);
+
+      m = math.matrix([[1,2,3,4]]);
+      assert.deepEqual(transpose(m).valueOf(), [[1],[2],[3],[4]]);
+    });
+
+    it('should throw an error for invalid matrix transpose', function() {
+      var m = math.matrix([[]]);
+      assert.throws(function () { transpose(m); });
+
+      m = math.matrix([[[1],[2]],[[3],[4]]]);
+      assert.throws(function () { transpose(m); });
+    });
+  });
+  
+  describe('CcsMatrix', function () {
+
+    it('should transpose a 2d matrix', function() {
+      var m = math.matrix([[1,2,3],[4,5,6]], 'ccs');
+      assert.deepEqual(transpose(m).valueOf(), [[1,4],[2,5],[3,6]]);
+
+      m = math.matrix([[1,4],[2,5],[3,6]], 'ccs');
+      assert.deepEqual(transpose(m).toArray(), [[1,2,3],[4,5,6]]);
+      
+      m = math.matrix([[1,2],[3,4]], 'ccs');
+      assert.deepEqual(transpose(m).valueOf(), [[1,3],[2,4]]);
+
+      m = math.matrix([[1,2,3,4]]);
+      assert.deepEqual(transpose(m).valueOf(), [[1],[2],[3],[4]]);
+    });
+
+    it('should throw an error for invalid matrix transpose', function() {
+      var m = math.matrix([[]], 'ccs');
+      assert.throws(function () { transpose(m); });
+    });
+  });
+
+  describe('CrsMatrix', function () {
+
+    it('should transpose a 2d matrix', function() {
+      var m = math.matrix([[1,2,3],[4,5,6]], 'crs');
+      assert.deepEqual(transpose(m).toArray(), [[1,4],[2,5],[3,6]]);
+      
+      m = math.matrix([[1,4],[2,5],[3,6]], 'crs');
+      assert.deepEqual(transpose(m).toArray(), [[1,2,3],[4,5,6]]);
+
+      m = math.matrix([[1,2],[3,4]], 'crs');
+      assert.deepEqual(transpose(m).toArray(), [[1,3],[2,4]]);
+
+      m = math.matrix([[1,2,3,4]], 'crs');
+      assert.deepEqual(transpose(m).toArray(), [[1],[2],[3],[4]]);
+    });
+
+    it('should throw an error for invalid matrix transpose', function() {
+      var m = math.matrix([[]], 'crs');
+      assert.throws(function () { transpose(m); });
+    });
   });
 
   it('should LaTeX transpose', function () {

--- a/test/type/matrix/CcsMatrix.test.js
+++ b/test/type/matrix/CcsMatrix.test.js
@@ -1739,25 +1739,6 @@ describe('CcsMatrix', function() {
     });
   });
   
-  describe('transpose', function () {
-    
-    it('should transpose a 2d matrix', function() {
-      var m = new CcsMatrix([[1,2,3],[4,5,6]]);
-      assert.deepEqual(m.transpose().toArray(), [[1,4],[2,5],[3,6]]);
-      
-      m = new CcsMatrix([[1,2],[3,4]]);
-      assert.deepEqual(m.transpose().toArray(), [[1,3],[2,4]]);
-      
-      m = new CcsMatrix([[1,2,3,4]]);
-      assert.deepEqual(m.transpose().toArray(), [[1],[2],[3],[4]]);
-    });
-    
-    it('should throw an error for invalid matrix transpose', function() {
-      var m = new CcsMatrix([[]]);
-      assert.throws(function () { m.transpose(); });
-    });
-  });
-  
   describe('trace', function () {
 
     it('should calculate trace on a square matrix', function() {

--- a/test/type/matrix/CrsMatrix.test.js
+++ b/test/type/matrix/CrsMatrix.test.js
@@ -1720,25 +1720,6 @@ describe('CrsMatrix', function() {
       assert.deepEqual(m.diagonal(-2), new CrsMatrix([4]));
     });
   });
-  
-  describe('transpose', function () {
-
-    it('should transpose a 2d matrix', function() {
-      var m = new CrsMatrix([[1,2,3],[4,5,6]]);
-      assert.deepEqual(m.transpose().toArray(), [[1,4],[2,5],[3,6]]);
-
-      m = new CrsMatrix([[1,2],[3,4]]);
-      assert.deepEqual(m.transpose().toArray(), [[1,3],[2,4]]);
-
-      m = new CrsMatrix([[1,2,3,4]]);
-      assert.deepEqual(m.transpose().toArray(), [[1],[2],[3],[4]]);
-    });
-
-    it('should throw an error for invalid matrix transpose', function() {
-      var m = new CrsMatrix([[]]);
-      assert.throws(function () { m.transpose(); });
-    });
-  });
 
   describe('trace', function () {
 

--- a/test/type/matrix/DenseMatrix.test.js
+++ b/test/type/matrix/DenseMatrix.test.js
@@ -1064,28 +1064,6 @@ describe('DenseMatrix', function() {
     });
   });
   
-  describe('transpose', function () {
-
-    it('should transpose a 2d matrix', function() {
-      var m = new DenseMatrix([[1,2,3],[4,5,6]]);
-      assert.deepEqual(m.transpose().toArray(), [[1,4],[2,5],[3,6]]);
-
-      m = new DenseMatrix([[1,2],[3,4]]);
-      assert.deepEqual(m.transpose().toArray(), [[1,3],[2,4]]);
-
-      m = new DenseMatrix([[1,2,3,4]]);
-      assert.deepEqual(m.transpose().toArray(), [[1],[2],[3],[4]]);
-    });
-
-    it('should throw an error for invalid matrix transpose', function() {
-      var m = new DenseMatrix([[]]);
-      assert.throws(function () { m.transpose(); });
-      
-      m = new DenseMatrix([[[1],[2]],[[3],[4]]]);
-      assert.throws(function () { m.transpose(); });
-    });
-  });
-  
   describe('trace', function () {
 
     it('should calculate trace on a square matrix', function() {


### PR DESCRIPTION
Removed transpose() from Matrix types.
Implemented native CCS and CRS transpose()