### PR TITLE
Add REPL (Read Evaluate Print Loop) to ease interactive debugging

### DIFF
--- a/bin/repl.js
+++ b/bin/repl.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+/*
+ * This simply preloads mathjs and drops you into a REPL to
+ * help interactive debugging.
+ **/
+math = require('../index');
+var repl = require('repl');
+
+repl.start({useGlobal: true});

--- a/docs/command_line_debugging.md
+++ b/docs/command_line_debugging.md
@@ -1,0 +1,19 @@
+# Command Line Debugging
+
+For debugging purposes, `bin/repl.js` provides a REPL (Read Evaluate Print Loop)
+for interactive testing of mathjs without having to build new build files after every
+little change to the source files. You can either start it directly (`./repl.js`) or
+via node (`node repl.js`).
+
+You can exit using either [ctrl]-[C] or [ctrl]-[D].
+
+```bash
+$ ./repl.js 
+> math.parse('1+1')
+{ op: '+',
+  fn: 'add',
+  args: 
+   [ { value: '1', valueType: 'number' },
+     { value: '1', valueType: 'number' } ] }
+> 
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ describing all available functions, constants, and units in detail.
 - [Serialization](serialization.md)
 - [Extension](extension.md)
 - [Command Line Interface](command_line_interface.md)
+- [Command Line Debugging](command_line_debugging.md)
 
 ## Examples
 


### PR DESCRIPTION
A small script that preloads mathjs and then drops the user into a REPL.

This means that I don't need to either build the dist files and do interactive debugging in the browser or run `math = require('../index');` in node anymore.

@josdejong I consider this useful but I don't know if you want little helpers like this to clutter the source tree.