### PR TITLE
Get rid of instanceof for nodes

### DIFF
--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -16,6 +16,8 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
+    this.isArrayNode = true;
+
     this.nodes = nodes || [];
 
     // validate input

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -21,7 +21,8 @@ function factory (type, config, load, typed) {
     this.nodes = nodes || [];
 
     // validate input
-    if (!Array.isArray(this.nodes) || !this.nodes.every(Node.isNode)) {
+    if (!Array.isArray(this.nodes)
+        || !this.nodes.every(function (node) {return node && node.isNode;})) {
       throw new TypeError('Array containing Nodes expected');
     }
   }

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -16,8 +16,6 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
-    this.isArrayNode = true;
-
     this.nodes = nodes || [];
 
     // validate input
@@ -30,6 +28,8 @@ function factory (type, config, load, typed) {
   ArrayNode.prototype = new Node();
 
   ArrayNode.prototype.type = 'ArrayNode';
+
+  ArrayNode.prototype.isArrayNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -22,8 +22,6 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
-    this.isAssignmentNode = true;
-
     // validate input
     if (typeof name !== 'string') throw new TypeError('String expected for parameter "name"');
     if (!(expr && expr.isNode))  throw new TypeError('Node expected for parameter "expr"');
@@ -36,6 +34,8 @@ function factory (type, config, load, typed) {
   AssignmentNode.prototype = new Node();
 
   AssignmentNode.prototype.type = 'AssignmentNode';
+
+  AssignmentNode.prototype.isAssignmentNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -22,6 +22,8 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
+    this.isAssignmentNode = true;
+
     // validate input
     if (typeof name !== 'string') throw new TypeError('String expected for parameter "name"');
     if (!(expr instanceof Node))  throw new TypeError('Node expected for parameter "expr"');

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -26,7 +26,7 @@ function factory (type, config, load, typed) {
 
     // validate input
     if (typeof name !== 'string') throw new TypeError('String expected for parameter "name"');
-    if (!(expr instanceof Node))  throw new TypeError('Node expected for parameter "expr"');
+    if (!(expr && expr.isNode))  throw new TypeError('Node expected for parameter "expr"');
     if (name in keywords)         throw new Error('Illegal symbol name, "'  + name +  '" is a reserved keyword');
 
     this.name = name;

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -19,8 +19,6 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
-    this.isBlockNode = true;
-
     // validate input, copy blocks
     if (!Array.isArray(blocks)) throw new Error('Array expected');
     this.blocks = blocks.map(function (block) {
@@ -40,6 +38,8 @@ function factory (type, config, load, typed) {
   BlockNode.prototype = new Node();
 
   BlockNode.prototype.type = 'BlockNode';
+
+  BlockNode.prototype.isBlockNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -19,6 +19,8 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
+    this.isBlockNode = true;
+
     // validate input, copy blocks
     if (!Array.isArray(blocks)) throw new Error('Array expected');
     this.blocks = blocks.map(function (block) {

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -27,7 +27,7 @@ function factory (type, config, load, typed) {
       var node = block && block.node;
       var visible = block && block.visible !== undefined ? block.visible : true;
 
-      if (!(node instanceof Node))      throw new TypeError('Property "node" must be a Node');
+      if (!(node && node.isNode))      throw new TypeError('Property "node" must be a Node');
       if (typeof visible !== 'boolean') throw new TypeError('Property "visible" must be a boolean');
 
       return {

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -28,6 +28,8 @@ function factory (type, config, load, typed) {
     if (!(trueExpr instanceof Node))  throw new TypeError('Parameter trueExpr must be a Node');
     if (!(falseExpr instanceof Node)) throw new TypeError('Parameter falseExpr must be a Node');
 
+    this.isConditionalNode = true;
+
     this.condition = condition;
     this.trueExpr = trueExpr;
     this.falseExpr = falseExpr;

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -28,8 +28,6 @@ function factory (type, config, load, typed) {
     if (!(trueExpr && trueExpr.isNode))  throw new TypeError('Parameter trueExpr must be a Node');
     if (!(falseExpr && falseExpr.isNode)) throw new TypeError('Parameter falseExpr must be a Node');
 
-    this.isConditionalNode = true;
-
     this.condition = condition;
     this.trueExpr = trueExpr;
     this.falseExpr = falseExpr;
@@ -38,6 +36,8 @@ function factory (type, config, load, typed) {
   ConditionalNode.prototype = new Node();
 
   ConditionalNode.prototype.type = 'ConditionalNode';
+
+  ConditionalNode.prototype.isConditionalNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -24,9 +24,9 @@ function factory (type, config, load, typed) {
     if (!(this instanceof ConditionalNode)) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
-    if (!(condition instanceof Node)) throw new TypeError('Parameter condition must be a Node');
-    if (!(trueExpr instanceof Node))  throw new TypeError('Parameter trueExpr must be a Node');
-    if (!(falseExpr instanceof Node)) throw new TypeError('Parameter falseExpr must be a Node');
+    if (!(condition && condition.isNode)) throw new TypeError('Parameter condition must be a Node');
+    if (!(trueExpr && trueExpr.isNode))  throw new TypeError('Parameter trueExpr must be a Node');
+    if (!(falseExpr && falseExpr.isNode)) throw new TypeError('Parameter falseExpr must be a Node');
 
     this.isConditionalNode = true;
 

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -40,6 +40,8 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
+    this.isConstantNode = true;
+
     if (valueType) {
       if (typeof valueType !== 'string') {
         throw new TypeError('String expected for parameter "valueType"');

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -40,8 +40,6 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
-    this.isConstantNode = true;
-
     if (valueType) {
       if (typeof valueType !== 'string') {
         throw new TypeError('String expected for parameter "valueType"');
@@ -75,6 +73,8 @@ function factory (type, config, load, typed) {
   ConstantNode.prototype = new Node();
 
   ConstantNode.prototype.type = 'ConstantNode';
+
+  ConstantNode.prototype.isConstantNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -31,8 +31,6 @@ function factory (type, config, load, typed) {
     if (!(expr && expr.isNode)) throw new TypeError('Node expected for parameter "expr"');
     if (name in keywords) throw new Error('Illegal function name, "' + name + '" is a reserved keyword');
 
-    this.isFunctionAssignmentNode = true;
-
     this.name = name;
     this.params = params;
     this.expr = expr;
@@ -41,6 +39,8 @@ function factory (type, config, load, typed) {
   FunctionAssignmentNode.prototype = new Node();
 
   FunctionAssignmentNode.prototype.type = 'FunctionAssignmentNode';
+
+  FunctionAssignmentNode.prototype.isFunctionAssignmentNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -31,6 +31,8 @@ function factory (type, config, load, typed) {
     if (!(expr instanceof Node)) throw new TypeError('Node expected for parameter "expr"');
     if (name in keywords) throw new Error('Illegal function name, "' + name + '" is a reserved keyword');
 
+    this.isFunctionAssignmentNode = true;
+
     this.name = name;
     this.params = params;
     this.expr = expr;

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -28,7 +28,7 @@ function factory (type, config, load, typed) {
     // validate input
     if (typeof name !== 'string') throw new TypeError('String expected for parameter "name"');
     if (!Array.isArray(params) || !params.every(isString))  throw new TypeError('Array containing strings expected for parameter "params"');
-    if (!(expr instanceof Node)) throw new TypeError('Node expected for parameter "expr"');
+    if (!(expr && expr.isNode)) throw new TypeError('Node expected for parameter "expr"');
     if (name in keywords) throw new Error('Illegal function name, "' + name + '" is a reserved keyword');
 
     this.isFunctionAssignmentNode = true;

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -24,6 +24,8 @@ function factory (type, config, load, typed, math) {
       throw new TypeError('Array containing Nodes expected for parameter "args"');
     }
 
+    this.isFunctionNode = true;
+
     this.name = name;
     this.args = args || [];
   }

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -25,8 +25,6 @@ function factory (type, config, load, typed, math) {
       throw new TypeError('Array containing Nodes expected for parameter "args"');
     }
 
-    this.isFunctionNode = true;
-
     this.name = name;
     this.args = args || [];
   }
@@ -34,6 +32,8 @@ function factory (type, config, load, typed, math) {
   FunctionNode.prototype = new Node();
 
   FunctionNode.prototype.type = 'FunctionNode';
+
+  FunctionNode.prototype.isFunctionNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -20,7 +20,8 @@ function factory (type, config, load, typed, math) {
 
     // validate input
     if (typeof name !== 'string') throw new TypeError('string expected for parameter "name"');
-    if (!Array.isArray(args) || !args.every(Node.isNode)) {
+    if (!Array.isArray(args)
+        || !args.every(function (arg) {return arg && arg.isNode;})) {
       throw new TypeError('Array containing Nodes expected for parameter "args"');
     }
 

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -25,7 +25,7 @@ function factory (type, config, load, typed) {
     }
 
     // validate input
-    if (!(object instanceof Node)) throw new TypeError('Node expected for parameter "object"');
+    if (!(object && object.isNode)) throw new TypeError('Node expected for parameter "object"');
     if (!isArray(ranges)
         || !ranges.every(function (range) {return range && range.isNode;})) {
       throw new TypeError('Array containing Nodes expected for parameter "ranges"');
@@ -68,7 +68,7 @@ function factory (type, config, load, typed) {
   IndexNode.prototype.compileSubset = function (defs, replacement) {
     // check whether any of the ranges expressions uses the context symbol 'end'
     function test(node) {
-      return (node instanceof SymbolNode) && (node.name == 'end');
+      return (node && node.isSymbolNode) && (node.name == 'end');
     }
 
     var someUseEnd = false;
@@ -95,7 +95,7 @@ function factory (type, config, load, typed) {
 
     var ranges = this.ranges.map(function (range, i) {
       var useEnd = rangesUseEnd[i];
-      if (range instanceof RangeNode) {
+      if (range && range.isRangeNode) {
         if (useEnd) {
           defs.args.end = true;
 

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -31,8 +31,6 @@ function factory (type, config, load, typed) {
       throw new TypeError('Array containing Nodes expected for parameter "ranges"');
     }
 
-    this.isIndexNode = true;
-
     this.object = object;
     this.ranges = ranges;
   }
@@ -40,6 +38,8 @@ function factory (type, config, load, typed) {
   IndexNode.prototype = new Node();
 
   IndexNode.prototype.type = 'IndexNode';
+
+  IndexNode.prototype.isIndexNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -31,6 +31,8 @@ function factory (type, config, load, typed) {
       throw new TypeError('Array containing Nodes expected for parameter "ranges"');
     }
 
+    this.isIndexNode = true;
+
     this.object = object;
     this.ranges = ranges;
   }

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -8,7 +8,6 @@ function factory (type, config, load, typed) {
   var BigNumber = load(require('../../type/BigNumber'));
   var Range = require('../../type/Range');
 
-  var isNode = Node.isNode;
   var isArray = Array.isArray;
 
   /**
@@ -27,7 +26,8 @@ function factory (type, config, load, typed) {
 
     // validate input
     if (!(object instanceof Node)) throw new TypeError('Node expected for parameter "object"');
-    if (!isArray(ranges) || !ranges.every(isNode)) {
+    if (!isArray(ranges)
+        || !ranges.every(function (range) {return range && range.isNode;})) {
       throw new TypeError('Array containing Nodes expected for parameter "ranges"');
     }
 

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -106,7 +106,7 @@ function factory (type, config, load, typed) {
    * @protected
    */
   Node.prototype._ifNode = function (node) {
-    if (!(node instanceof Node)) {
+    if (!(node && node.isNode)) {
       throw new TypeError('Callback function must return a Node');
     }
 
@@ -141,7 +141,7 @@ function factory (type, config, load, typed) {
    * ConstantNode with value 2:
    *
    *     var res = Node.transform(function (node, path, parent) {
-   *       if (node instanceof SymbolNode) && (node.name == 'x')) {
+   *       if (node && node.isSymbolNode) && (node.name == 'x')) {
    *         return new ConstantNode(2);
    *       }
    *       else {
@@ -178,7 +178,7 @@ function factory (type, config, load, typed) {
    * find all nodes of type SymbolNode having name 'x':
    *
    *     var results = Node.filter(function (node) {
-   *       return (node instanceof SymbolNode) && (node.name == 'x');
+   *       return (node && node.isSymbolNode) && (node.name == 'x');
    *     });
    *
    * @param {function(node: Node, path: string, parent: Node) : Node} callback

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -10,6 +10,8 @@ function factory (type, config, load, typed) {
     if (!(this instanceof Node)) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
+
+    this.isNode = true;
   }
 
   /**
@@ -289,15 +291,6 @@ function factory (type, config, load, typed) {
    */
   Node.prototype.getIdentifier = function () {
     return this.type;
-  };
-
-  /**
-   * Test whether an object is a Node
-   * @param {*} object
-   * @returns {boolean} isNode
-   */
-  Node.isNode = function (object) {
-    return object instanceof Node;
   };
 
   /**

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -10,8 +10,6 @@ function factory (type, config, load, typed) {
     if (!(this instanceof Node)) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
-
-    this.isNode = true;
   }
 
   /**
@@ -25,6 +23,8 @@ function factory (type, config, load, typed) {
   };
 
   Node.prototype.type = 'Node';
+
+  Node.prototype.isNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -34,6 +34,8 @@ function factory (type, config, load, typed, math) {
       throw new TypeError('Array containing Nodes expected for parameter "args"');
     }
 
+    this.isOperatorNode = true;
+
     this.op = op;
     this.fn = fn;
     this.args = args || [];

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -30,7 +30,8 @@ function factory (type, config, load, typed, math) {
     if (typeof fn !== 'string') {
       throw new TypeError('string expected for parameter "fn"');
     }
-    if (!Array.isArray(args) || !args.every(Node.isNode)) {
+    if (!Array.isArray(args)
+        || !args.every(function (node) {return node && node.isNode;})) {
       throw new TypeError('Array containing Nodes expected for parameter "args"');
     }
 

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -35,8 +35,6 @@ function factory (type, config, load, typed, math) {
       throw new TypeError('Array containing Nodes expected for parameter "args"');
     }
 
-    this.isOperatorNode = true;
-
     this.op = op;
     this.fn = fn;
     this.args = args || [];
@@ -45,6 +43,8 @@ function factory (type, config, load, typed, math) {
   OperatorNode.prototype = new Node();
 
   OperatorNode.prototype.type = 'OperatorNode';
+
+  OperatorNode.prototype.isOperatorNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -24,8 +24,6 @@ function factory (type, config, load, typed) {
     if (step && !(step && step.isNode)) throw new TypeError('Node expected');
     if (arguments.length > 3) throw new Error('Too many arguments');
 
-    this.isRangeNode = true;
-
     this.start = start;         // included lower-bound
     this.end = end;           // included upper-bound
     this.step = step || null;  // optional step
@@ -34,6 +32,8 @@ function factory (type, config, load, typed) {
   RangeNode.prototype = new Node();
 
   RangeNode.prototype.type = 'RangeNode';
+
+  RangeNode.prototype.isRangeNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -19,9 +19,9 @@ function factory (type, config, load, typed) {
     }
 
     // validate inputs
-    if (!start || !start.isNode) throw new TypeError('Node expected');
-    if (!end || !end.isNode) throw new TypeError('Node expected');
-    if (step && (!step || !step.isNode)) throw new TypeError('Node expected');
+    if (!(start && start.isNode)) throw new TypeError('Node expected');
+    if (!(end && end.isNode)) throw new TypeError('Node expected');
+    if (step && !(step && step.isNode)) throw new TypeError('Node expected');
     if (arguments.length > 3) throw new Error('Too many arguments');
 
     this.isRangeNode = true;

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -24,6 +24,8 @@ function factory (type, config, load, typed) {
     if (step && !Node.isNode(step)) throw new TypeError('Node expected');
     if (arguments.length > 3) throw new Error('Too many arguments');
 
+    this.isRangeNode = true;
+
     this.start = start;         // included lower-bound
     this.end = end;           // included upper-bound
     this.step = step || null;  // optional step

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -19,9 +19,9 @@ function factory (type, config, load, typed) {
     }
 
     // validate inputs
-    if (!Node.isNode(start)) throw new TypeError('Node expected');
-    if (!Node.isNode(end)) throw new TypeError('Node expected');
-    if (step && !Node.isNode(step)) throw new TypeError('Node expected');
+    if (!start || !start.isNode) throw new TypeError('Node expected');
+    if (!end || !end.isNode) throw new TypeError('Node expected');
+    if (step && (!step || !step.isNode)) throw new TypeError('Node expected');
     if (arguments.length > 3) throw new Error('Too many arguments');
 
     this.isRangeNode = true;

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -22,14 +22,14 @@ function factory (type, config, load, typed, math) {
     // validate input
     if (typeof name !== 'string')  throw new TypeError('String expected for parameter "name"');
 
-    this.isSymbolNode = true;
-
     this.name = name;
   }
 
   SymbolNode.prototype = new Node();
 
   SymbolNode.prototype.type = 'SymbolNode';
+
+  SymbolNode.prototype.isSymbolNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -22,6 +22,8 @@ function factory (type, config, load, typed, math) {
     // validate input
     if (typeof name !== 'string')  throw new TypeError('String expected for parameter "name"');
 
+    this.isSymbolNode = true;
+
     this.name = name;
   }
 

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -17,10 +17,10 @@ function factory (type, config, load, typed) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
-    if (!(index instanceof IndexNode)) {
+    if (!(index && index.isIndexNode)) {
       throw new TypeError('Expected IndexNode for parameter "index"');
     }
-    if (!(expr instanceof Node)) {
+    if (!(expr && expr.isNode)) {
       throw new TypeError('Expected Node for parameter "expr"');
     }
 

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -24,6 +24,8 @@ function factory (type, config, load, typed) {
       throw new TypeError('Expected Node for parameter "expr"');
     }
 
+    this.isUpdateNode = true;
+
     this.index = index;
     this.expr = expr;
   }

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -24,8 +24,6 @@ function factory (type, config, load, typed) {
       throw new TypeError('Expected Node for parameter "expr"');
     }
 
-    this.isUpdateNode = true;
-
     this.index = index;
     this.expr = expr;
   }
@@ -33,6 +31,8 @@ function factory (type, config, load, typed) {
   UpdateNode.prototype = new Node();
 
   UpdateNode.prototype.type = 'UpdateNode';
+
+  UpdateNode.prototype.isUpdateNode = true;
 
   /**
    * Compile the node to javascript code

--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -507,27 +507,27 @@ function factory (type, config, load, typed) {
     var node = parseConditional();
 
     if (token == '=') {
-      if (node instanceof SymbolNode) {
+      if (node && node.isSymbolNode) {
         // parse a variable assignment like 'a = 2/3'
         name = node.name;
         getTokenSkipNewline();
         expr = parseAssignment();
         return new AssignmentNode(name, expr);
       }
-      else if (node instanceof IndexNode) {
+      else if (node && node.isIndexNode) {
         // parse a matrix subset assignment like 'A[1,2] = 4'
         getTokenSkipNewline();
         expr = parseAssignment();
         return new UpdateNode(node, expr);
       }
-      else if (node instanceof FunctionNode) {
+      else if (node && node.isFunctionNode) {
         // parse function assignment like 'f(x) = x^2'
         valid = true;
         args = [];
 
         name = node.name;
         node.args.forEach(function (arg, index) {
-          if (arg instanceof SymbolNode) {
+          if (arg && arg.isSymbolNode) {
             args[index] = arg.name;
           }
           else {
@@ -874,8 +874,8 @@ function factory (type, config, load, typed) {
 
     // parse implicit multiplication
     if ((token_type == TOKENTYPE.SYMBOL) ||
-        (token == 'in' && (node instanceof ConstantNode)) ||
-        (token_type == TOKENTYPE.NUMBER && !(node instanceof ConstantNode)) ||
+        (token == 'in' && (node && node.isConstantNode)) ||
+        (token_type == TOKENTYPE.NUMBER && !(node && node.isConstantNode)) ||
         (token == '(' || token == '[')) {
       // symbol:      implicit multiplication like '2a', '(2+3)a', 'a b'
       // number:      implicit multiplication like '(2+3)2'

--- a/lib/expression/transform/filter.transform.js
+++ b/lib/expression/transform/filter.transform.js
@@ -19,7 +19,7 @@ function factory (type, config, load, typed) {
     }
 
     if (args[1]) {
-      if (args[1] instanceof SymbolNode) {
+      if (args[1] && args[1].isSymbolNode) {
         // a function pointer, like filter([3, -2, 5], myTestFunction);
         test = args[1].compile(math).eval(scope);
       }
@@ -30,7 +30,7 @@ function factory (type, config, load, typed) {
         var _scope = scope || {};
         var symbol = args[1]
             .filter(function (node) {
-              return (node instanceof SymbolNode) &&
+              return (node && node.isSymbolNode) &&
                   !(node.name in math) &&
                   !(node.name in _scope);
             })[0];

--- a/test/expression/node/ArrayNode.test.js
+++ b/test/expression/node/ArrayNode.test.js
@@ -20,6 +20,12 @@ describe('ArrayNode', function() {
     assert.equal(b.type, 'ArrayNode');
   });
 
+  it ('should have isArrayNode', function () {
+    var node = new ArrayNode([]);
+
+    assert(node.isArrayNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {ArrayNode()}, SyntaxError);
   });

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -19,6 +19,11 @@ describe('AssignmentNode', function() {
     assert.equal(n.type, 'AssignmentNode');
   });
 
+  it ('should have isAssignmentNode', function () {
+    var node = new AssignmentNode('a', new Node());
+    assert(node.isAssignmentNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {AssignmentNode('a', new Node())}, SyntaxError);
   });

--- a/test/expression/node/BlockNode.test.js
+++ b/test/expression/node/BlockNode.test.js
@@ -20,6 +20,11 @@ describe('BlockNode', function() {
     assert.equal(n.type, 'BlockNode');
   });
 
+  it ('should have isBlockNode', function () {
+    var node = new BlockNode([]);
+    assert(node.isBlockNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {BlockNode()}, SyntaxError);
   });

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -24,6 +24,11 @@ describe('ConditionalNode', function() {
     assert.equal(n.type, 'ConditionalNode');
   });
 
+  it ('should have isConditionalNode', function () {
+    var node = new ConditionalNode(condition, a, b);
+    assert(node.isConditionalNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {ConditionalNode()}, SyntaxError);
   });

--- a/test/expression/node/ConstantNode.test.js
+++ b/test/expression/node/ConstantNode.test.js
@@ -29,6 +29,11 @@ describe('ConstantNode', function() {
     assert.deepEqual(new ConstantNode(undefined), new ConstantNode('undefined', 'undefined'));
   });
 
+  it ('should have isConstantNode', function () {
+    var node = new ConstantNode(1);
+    assert(node.isConstantNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {ConstantNode('3', 'number')}, SyntaxError);
   });

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -21,6 +21,11 @@ describe('FunctionAssignmentNode', function() {
     assert.equal(n.type, 'FunctionAssignmentNode');
   });
 
+  it ('should have isFunctionAssignmentNode', function () {
+    var node = new FunctionAssignmentNode('f', ['x'], new ConstantNode(2));
+    assert(node.isFunctionAssignmentNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {FunctionAssignmentNode('f', ['x'], new ConstantNode(2))}, SyntaxError);
   });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -19,6 +19,12 @@ describe('FunctionNode', function() {
     assert.equal(n.type, 'FunctionNode');
   });
 
+  it ('should have isFunctionNode', function () {
+    var c = new ConstantNode(1);
+    var node = new FunctionNode('square', [c]);
+    assert(node.isFunctionNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     var s = new SymbolNode('sqrt');
     var c = new ConstantNode(4);

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -18,6 +18,11 @@ describe('IndexNode', function() {
     assert.equal(n.type, 'IndexNode');
   });
 
+  it ('should have isIndexNode', function () {
+    var node = new IndexNode(new Node(), []);
+    assert(node.isIndexNode);
+  });
+
   it ('should throw an error when calling with wrong arguments', function () {
     assert.throws(function () {new IndexNode()}, TypeError);
     assert.throws(function () {new IndexNode('a', [])}, TypeError);

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -17,6 +17,11 @@ describe('Node', function() {
     assert(n instanceof Node);
   });
 
+  it ('should have isNode', function () {
+    var node = new Node();
+    assert(node.isNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {Node()}, SyntaxError);
   });
@@ -61,12 +66,6 @@ describe('Node', function() {
       var a = new Node();
       a.clone();
     }, /Cannot clone a Node interface/);
-  });
-
-  it ('should test whether an object is a Node', function () {
-    assert.equal(Node.isNode(new Node()), true);
-    assert.equal(Node.isNode(new Date()), false);
-    assert.equal(Node.isNode(2), false);
   });
 
   it ('should stringify a Node', function () {

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -17,6 +17,11 @@ describe('OperatorNode', function() {
     assert.equal(n.type, 'OperatorNode');
   });
 
+  it ('should have isOperatorNode', function () {
+    var node = new OperatorNode('op', 'fn', []);
+    assert(node.isOperatorNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     var a = new ConstantNode(2);
     var b = new ConstantNode(3);

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -19,6 +19,14 @@ describe('RangeNode', function() {
     assert.equal(n.type, 'RangeNode');
   });
 
+  it ('should have isRangeNode', function () {
+    var start = new ConstantNode(0);
+    var end = new ConstantNode(10);
+    var node = new RangeNode(start, end);
+
+    assert(node.isRangeNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     var start = new ConstantNode(0);
     var end = new ConstantNode(10);

--- a/test/expression/node/SymbolNode.test.js
+++ b/test/expression/node/SymbolNode.test.js
@@ -16,6 +16,11 @@ describe('SymbolNode', function() {
     assert.equal(n.type, 'SymbolNode');
   });
 
+  it ('should have isSymbolNode', function () {
+    var node = new SymbolNode('a');
+    assert(node.isSymbolNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     assert.throws(function () {SymbolNode('sqrt')}, SyntaxError);
   });

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -25,6 +25,17 @@ describe('UpdateNode', function() {
     assert.equal(n.type, 'UpdateNode');
   });
 
+  it ('should have isUpdateNode', function () {
+    var a = new SymbolNode('a');
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(1);
+    var i = new IndexNode(a, [b, c]);
+    var v = new ConstantNode(5);
+    var node = new UpdateNode(i, v);
+
+    assert(node.isUpdateNode);
+  });
+
   it ('should throw an error when calling without new operator', function () {
     var a = new SymbolNode('a');
     var b = new ConstantNode(2);


### PR DESCRIPTION
This removes the use of `instanceof` for nodes. Therefore the `Node.isNode()` function got replaced by a boolean property `isNode` and every node has it's own property, like `isSymbolNode` for example.

See  #345 