### PR TITLE
ParenthesisNode and parenthesis configuration options for v2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,13 @@ The following configuration options are available:
   This setting only applies to BigNumbers, not to numbers.
   Default value is `64`.
 
+- `parenthesis`. The way parenthesis is displayed in the output of `toTex` and `toString`
+  There are three available options: `'keep'` (default), `'auto'` and `'all'`.
+  When set to `'keep'`, parentheses will be printed in the same way they were in the input
+  that has been parsed (they are represented in the node tree as `ParenthesisNode`s). When
+  set to `'auto'`, mathjs tries to use as few parentheses as possible, thereby getting rid
+  of unnecessary parentheses. When set to `'all'` mathjs puts almost everything in parentheses
+  to make the structure of the node tree explicit.
 
 ## Examples
 

--- a/docs/expressions/expression_trees.md
+++ b/docs/expressions/expression_trees.md
@@ -446,6 +446,27 @@ var b     = new math.expression.node.ConstantNode(5);
 var node2 = new math.expression.node.OperatorNode('+', 'add', [a, b]);
 ```
 
+### ParenthesisNode
+
+Construction:
+
+```
+new ParenthesisNode(content: Node)
+```
+
+Properties:
+
+- `content: Node`
+
+Examples:
+
+```js
+var node1 = math.parse('(1)');
+
+var a     = new math.expression.node.ConstantNode(1);
+var node2 = new math.expression.node.ParenthesisNode(a);
+```
+
 ### RangeNode
 
 Construction:

--- a/examples/browser/pretty_printing_with_mathjax.html
+++ b/examples/browser/pretty_printing_with_mathjax.html
@@ -60,13 +60,22 @@
     <th>Result</th>
     <td><div id="result"></div></td>
   </tr>
-
 </table>
+<b>Parenthesis option:</b>
+<input type="radio" name="parenthesis" value="keep" onclick="setParenthesis('keep')" checked>keep
+<input type="radio" name="parenthesis" value="auto" onclick="setParenthesis('auto')">auto
+<input type="radio" name="parenthesis" value="all" onclick="setParenthesis('all')">all
+
 
 <script>
   var expr = document.getElementById('expr'),
       pretty = document.getElementById('pretty'),
       result = document.getElementById('result');
+
+  function setParenthesis(option) {
+    math.config({parenthesis: option});
+    expr.oninput();
+  }
 
   // initialize with an example expression
   expr.value = 'sqrt(75 / 3) + det([[-1, 2], [3, 1]]) - sin(pi / 4)^2';

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -17,6 +17,9 @@ function factory (type, config, load, typed, math) {
    *                            {number} precision
    *                              The number of significant digits for BigNumbers.
    *                              Not applicable for Numbers.
+   *                            {string} parenthesis
+   *                              How to display parentheses in LaTeX and String
+   *                              output.
    * @return {Object} Returns the current configuration
    */
   return function _config(options) {

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -19,6 +19,9 @@ var configFactory = require('./config');
  *                            {number} precision
  *                              The number of significant digits for BigNumbers.
  *                              Not applicable for Numbers.
+ *                            {string} parenthesis
+ *                              How to display parentheses in LaTeX and String
+ *                              output.
  * @returns {Object} Returns a bare-bone math.js instance containing
  *                   functions:
  *                   - `import` to add new functions
@@ -57,7 +60,11 @@ exports.create = function create (options) {
 
     // minimum relative difference between two compared values,
     // used by all comparison functions
-    epsilon: 1e-14
+    epsilon: 1e-14,
+
+    // which type of parenthesis to use for toString and toTex
+    // one of 'keep', 'auto', and 'all'
+    parenthesis: 'keep'
   };
 
   if (options) {

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -80,8 +80,8 @@ function factory (type, config, load, typed) {
    * @return {String}
    */
   AssignmentNode.prototype._toString = function() {
-    var precedence = operators.getPrecedence(this);
-    var exprPrecedence = operators.getPrecedence(this.expr);
+    var precedence = operators.getPrecedence(this, config);
+    var exprPrecedence = operators.getPrecedence(this.expr, config);
     var expr = this.expr.toString();
     if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
       expr = '(' + expr + ')';
@@ -95,8 +95,8 @@ function factory (type, config, load, typed) {
    * @return {String}
    */
   AssignmentNode.prototype._toTex = function(callbacks) {
-    var precedence = operators.getPrecedence(this);
-    var exprPrecedence = operators.getPrecedence(this.expr);
+    var precedence = operators.getPrecedence(this, config);
+    var exprPrecedence = operators.getPrecedence(this.expr, config);
 
     var expr = this.expr.toTex(callbacks);
     if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -75,15 +75,24 @@ function factory (type, config, load, typed) {
     return new AssignmentNode(this.name, this.expr);
   };
 
+  /*
+   * Is parenthesis needed?
+   * @private
+   */
+  function needParenthesis(node) {
+    var precedence = operators.getPrecedence(node, config);
+    var exprPrecedence = operators.getPrecedence(node.expr, config);
+    return (config.parenthesis === 'all')
+      || ((exprPrecedence !== null) && (exprPrecedence <= precedence));
+  }
+
   /**
    * Get string representation
    * @return {String}
    */
   AssignmentNode.prototype._toString = function() {
-    var precedence = operators.getPrecedence(this, config);
-    var exprPrecedence = operators.getPrecedence(this.expr, config);
     var expr = this.expr.toString();
-    if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
+    if (needParenthesis(this)) {
       expr = '(' + expr + ')';
     }
     return this.name + ' = ' + expr;
@@ -95,11 +104,8 @@ function factory (type, config, load, typed) {
    * @return {String}
    */
   AssignmentNode.prototype._toTex = function(callbacks) {
-    var precedence = operators.getPrecedence(this, config);
-    var exprPrecedence = operators.getPrecedence(this.expr, config);
-
     var expr = this.expr.toTex(callbacks);
-    if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
+    if (needParenthesis(this)) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -133,21 +133,24 @@ function factory (type, config, load, typed) {
     //purely based on aesthetics and readability
     var condition = this.condition.toString();
     var conditionPrecedence = operators.getPrecedence(this.condition, config);
-    if ((this.condition.type === 'OperatorNode')
+    if ((config.parenthesis === 'all')
+        || (this.condition.type === 'OperatorNode')
         || ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
       condition = '(' + condition + ')';
     }
 
     var trueExpr = this.trueExpr.toString();
     var truePrecedence = operators.getPrecedence(this.trueExpr, config);
-    if ((this.trueExpr.type === 'OperatorNode')
+    if ((config.parenthesis === 'all')
+        || (this.trueExpr.type === 'OperatorNode')
         || ((truePrecedence !== null) && (truePrecedence <= precedence))) {
       trueExpr = '(' + trueExpr + ')';
     }
 
     var falseExpr = this.falseExpr.toString();
     var falsePrecedence = operators.getPrecedence(this.falseExpr, config);
-    if ((this.falseExpr.type === 'OperatorNode')
+    if ((config.parenthesis === 'all')
+        || (this.falseExpr.type === 'OperatorNode')
         || ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {
       falseExpr = '(' + falseExpr + ')';
     }

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -125,28 +125,28 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   ConditionalNode.prototype._toString = function () {
-    var precedence = operators.getPrecedence(this);
+    var precedence = operators.getPrecedence(this, config);
 
     //Enclose Arguments in parentheses if they are an OperatorNode
     //or have lower or equal precedence
     //NOTE: enclosing all OperatorNodes in parentheses is a decision
     //purely based on aesthetics and readability
     var condition = this.condition.toString();
-    var conditionPrecedence = operators.getPrecedence(this.condition);
+    var conditionPrecedence = operators.getPrecedence(this.condition, config);
     if ((this.condition.type === 'OperatorNode')
         || ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
       condition = '(' + condition + ')';
     }
 
     var trueExpr = this.trueExpr.toString();
-    var truePrecedence = operators.getPrecedence(this.trueExpr);
+    var truePrecedence = operators.getPrecedence(this.trueExpr, config);
     if ((this.trueExpr.type === 'OperatorNode')
         || ((truePrecedence !== null) && (truePrecedence <= precedence))) {
       trueExpr = '(' + trueExpr + ')';
     }
 
     var falseExpr = this.falseExpr.toString();
-    var falsePrecedence = operators.getPrecedence(this.falseExpr);
+    var falsePrecedence = operators.getPrecedence(this.falseExpr, config);
     if ((this.falseExpr.type === 'OperatorNode')
         || ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {
       falseExpr = '(' + falseExpr + ')';

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -100,15 +100,24 @@ function factory (type, config, load, typed) {
   };
 
   /**
+   * Is parenthesis needed?
+   * @private
+   */
+  function needParenthesis(node) {
+    var precedence = operators.getPrecedence(node, config);
+    var exprPrecedence = operators.getPrecedence(node.expr, config);
+
+    return (config.parenthesis === 'all')
+      || ((exprPrecedence !== null) && (exprPrecedence <= precedence));
+  }
+
+  /**
    * get string representation
    * @return {String} str
    */
   FunctionAssignmentNode.prototype._toString = function () {
-    var precedence = operators.getPrecedence(this, config);
-    var exprPrecedence = operators.getPrecedence(this.expr, config);
-
     var expr = this.expr.toString();
-    if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
+    if (needParenthesis(this)) {
       expr = '(' + expr + ')';
     }
     return 'function ' + this.name +
@@ -121,11 +130,8 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   FunctionAssignmentNode.prototype._toTex = function (callbacks) {
-    var precedence = operators.getPrecedence(this, config);
-    var exprPrecedence = operators.getPrecedence(this.expr, config);
-
     var expr = this.expr.toTex(callbacks);
-    if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
+    if (needParenthesis(this)) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -104,8 +104,8 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   FunctionAssignmentNode.prototype._toString = function () {
-    var precedence = operators.getPrecedence(this);
-    var exprPrecedence = operators.getPrecedence(this.expr);
+    var precedence = operators.getPrecedence(this, config);
+    var exprPrecedence = operators.getPrecedence(this.expr, config);
 
     var expr = this.expr.toString();
     if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {
@@ -121,8 +121,8 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   FunctionAssignmentNode.prototype._toTex = function (callbacks) {
-    var precedence = operators.getPrecedence(this);
-    var exprPrecedence = operators.getPrecedence(this.expr);
+    var precedence = operators.getPrecedence(this, config);
+    var exprPrecedence = operators.getPrecedence(this.expr, config);
 
     var expr = this.expr.toTex(callbacks);
     if ((exprPrecedence !== null) && (exprPrecedence <= precedence)) {

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -204,12 +204,33 @@ function factory (type, config, load, typed) {
   };
 
   /**
+   * Is parenthesis needed?
+   * @private
+   */
+  function needParenthesis(node) {
+    switch (node.object.type) {
+      case 'ArrayNode':
+      case 'ConstantNode': //TODO don't know if this one makes sense
+      case 'SymbolNode':
+      case 'ParenthesisNode':
+        //those nodes don't need parentheses within an index node
+        return false;
+      default:
+        return true;
+    }
+  }
+
+  /**
    * Get string representation
    * @return {String} str
    */
   IndexNode.prototype._toString = function () {
+    var object = this.object.toString();
+    if (needParenthesis(this)) {
+      object = '(' + object + '(';
+    }
     // format the parameters like "[1, 0:5]"
-    return this.object.toString() + '[' + this.ranges.join(', ') + ']';
+    return object + '[' + this.ranges.join(', ') + ']';
   };
 
   /**
@@ -218,10 +239,16 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   IndexNode.prototype._toTex = function (callbacks) {
+    var object = this.object.toTex(callbacks);
+    if (needParenthesis(this)) {
+      object = '\\left(' + object + '\\right)';
+    }
+
     var ranges = this.ranges.map(function (range) {
       return range.toTex(callbacks);
     });
-    return this.object.toTex(callbacks) + '_{\\left[' + ranges.join(',') + '\\right]}';
+
+    return object + '_{' + ranges.join(',') + '}';
   };
 
   return IndexNode;

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -300,6 +300,14 @@ function factory (type, config, load, typed) {
   };
 
   /**
+   * Get the content of the current Node.
+   * @return {Node} node
+   **/
+  Node.prototype.getContent = function () {
+    return this;
+  }
+
+  /**
    * Validate the symbol names of a scope.
    * Throws an error when the scope contains an illegal symbol.
    * @param {Object} scope

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -121,8 +121,17 @@ function factory (type, config, load, typed, math) {
 
         //handle special cases for LaTeX, where some of the parentheses aren't needed
         if (latex && (operandPrecedence !== null)) {
-          var operandIdentifier = args[0].getIdentifier();
-          var rootIdentifier = root.getIdentifier();
+          var operandIdentifier;
+          var rootIdentifier;
+          if (config.parenthesis === 'keep') {
+            operandIdentifier = args[0].getIdentifier();
+            rootIdentifier = root.getIdentifier();
+          }
+          else {
+            //Ignore Parenthesis Nodes when not in 'keep' mode
+            operandIdentifier = args[0].getContent().getIdentifier();
+            rootIdentifier = root.getContent().getIdentifier();
+          }
           if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
             return [false];
           }
@@ -198,9 +207,20 @@ function factory (type, config, load, typed, math) {
 
         //handle special cases for LaTeX, where some of the parentheses aren't needed
         if (latex) {
-          var rootIdentifier = root.getIdentifier();
-          var lhsIdentifier = root.args[0].getIdentifier();
-          var rhsIdentifier = root.args[1].getIdentifier();
+          var rootIdentifier;
+          var lhsIdentifier;
+          var rhsIdentifier;
+          if (config.parenthesis === 'keep') {
+            rootIdentifier = root.getIdentifier();
+            lhsIdentifier = root.args[0].getIdentifier();
+            rhsIdentifier = root.args[1].getIdentifier();
+          }
+          else {
+            //Ignore ParenthesisNodes when not in 'keep' mode
+            rootIdentifier = root.getContent().getIdentifier();
+            lhsIdentifier = root.args[0].getContent().getIdentifier();
+            rhsIdentifier = root.args[1].getContent().getIdentifier();
+          }
 
           if (lhsPrecedence !== null) {
             if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
@@ -323,6 +343,14 @@ function factory (type, config, load, typed, math) {
         }
 
         //handle some exceptions (due to the way LaTeX works)
+        var lhsIdentifier;
+        if (config.parenthesis === 'keep') {
+          lhsIdentifier = lhs.getIdentifier();
+        }
+        else {
+          //Ignore ParenthesisNodes if in 'keep' mode
+          lhsIdentifier = lhs.getContent().getIdentifier();
+        }
         switch (this.getIdentifier()) {
           case 'OperatorNode:divide':
             //op contains '\\frac' at this point
@@ -330,7 +358,7 @@ function factory (type, config, load, typed, math) {
           case 'OperatorNode:pow':
             lhsTex = '{' + lhsTex + '}';
             rhsTex = '{' + rhsTex + '}';
-            switch (lhs.getIdentifier()) {
+            switch (lhsIdentifier) {
               case 'ConditionalNode': //
               case 'OperatorNode:divide':
                 lhsTex = '\\left(' + lhsTex + '\\right)';

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -111,13 +111,13 @@ function factory (type, config, load, typed, math) {
    */
   function calculateNecessaryParentheses(root, args, latex) {
     //precedence of the root OperatorNode
-    var precedence = operators.getPrecedence(root);
-    var associativity = operators.getAssociativity(root);
+    var precedence = operators.getPrecedence(root, config);
+    var associativity = operators.getAssociativity(root, config);
 
     switch (args.length) {
       case 1: //unary operators
               //precedence of the operand
-        var operandPrecedence = operators.getPrecedence(args[0]);
+        var operandPrecedence = operators.getPrecedence(args[0], config);
 
         //handle special cases for LaTeX, where some of the parentheses aren't needed
         if (latex && (operandPrecedence !== null)) {
@@ -148,9 +148,9 @@ function factory (type, config, load, typed, math) {
       case 2: //binary operators
         var lhsParens; //left hand side needs parenthesis?
         //precedence of the left hand side
-        var lhsPrecedence = operators.getPrecedence(args[0]);
+        var lhsPrecedence = operators.getPrecedence(args[0], config);
         //is the root node associative with the left hand side
-        var assocWithLhs = operators.isAssociativeWith(root, args[0]);
+        var assocWithLhs = operators.isAssociativeWith(root, args[0], config);
 
         if (lhsPrecedence === null) {
           //if the left hand side has no defined precedence, no parens are needed
@@ -173,9 +173,9 @@ function factory (type, config, load, typed, math) {
 
         var rhsParens; //right hand side needs parenthesis?
         //precedence of the right hand side
-        var rhsPrecedence = operators.getPrecedence(args[1]);
+        var rhsPrecedence = operators.getPrecedence(args[1], config);
         //is the root node associative with the right hand side?
-        var assocWithRhs = operators.isAssociativeWith(root, args[1]);
+        var assocWithRhs = operators.isAssociativeWith(root, args[1], config);
 
         if (rhsPrecedence === null) {
           //if the right hand side has no defined precedence, no parens are needed
@@ -244,7 +244,7 @@ function factory (type, config, load, typed, math) {
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this);
+        var assoc = operators.getAssociativity(this, config);
 
         var operand = args[0].toString();
         if (parens[0]) {
@@ -292,7 +292,7 @@ function factory (type, config, load, typed, math) {
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this);
+        var assoc = operators.getAssociativity(this, config);
 
         var operand = args[0].toTex(callbacks);
         if (parens[0]) {

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -114,7 +114,26 @@ function factory (type, config, load, typed, math) {
     var precedence = operators.getPrecedence(root, config);
     var associativity = operators.getAssociativity(root, config);
 
+    if ((config.parenthesis === 'all') || (args.length > 2)) {
+      var parens = [];
+      args.forEach(function (arg) {
+        switch (arg.getContent().type) { //Nodes that don't need extra parentheses
+          case 'ArrayNode':
+          case 'ConstantNode':
+          case 'SymbolNode':
+          case 'ParenthesisNode':
+            parens.push(false);
+            break;
+          default:
+            parens.push(true);
+        }
+      });
+      return parens;
+    }
+
     switch (args.length) {
+      case 0:
+        return [];
       case 1: //unary operators
               //precedence of the operand
         var operandPrecedence = operators.getPrecedence(args[0], config);
@@ -244,13 +263,6 @@ function factory (type, config, load, typed, math) {
         }
 
         return [lhsParens, rhsParens];
-      default:
-        //behavior is undefined, fall back to putting everything in parens
-        var parens = [];
-        args.forEach(function () {
-          parens.push(true);
-        });
-        return parens;
     }
   }
 

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -27,6 +27,8 @@ function factory (type, config, load, typed) {
 
   ParenthesisNode.prototype.type = 'ParenthesisNode';
 
+  ParenthesisNode.prototype.isParenthesisNode = true;
+
   /**
    * Compile the node to javascript code
    * @param {Object} defs     Object which can be used to define functions
@@ -38,6 +40,15 @@ function factory (type, config, load, typed) {
   ParenthesisNode.prototype._compile = function (defs) {
     return this.content._compile(defs);
   };
+
+  /**
+   * Get the content of the current Node.
+   * @return {Node} content
+   * @override
+   **/
+  ParenthesisNode.prototype.getContent = function () {
+    return this.content.getContent();
+  }
 
   /**
    * Execute a callback for each of the child nodes of this node

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -1,0 +1,93 @@
+'use strict';
+
+function factory (type, config, load, typed) {
+  var Node = load(require('./Node'));
+
+  /**
+   * @constructor ParenthesisNode
+   * @extends {Node}
+   * A parenthesis node describes manual parenthesis from the user input
+   * @param {Node} content
+   * @extends {Node}
+   */
+  function ParenthesisNode(content) {
+    if (!(this instanceof ParenthesisNode)) {
+      throw new SyntaxError('Constructor must be called with the new operator');
+    }
+
+    // validate input
+    if (!(content && content.isNode)) {
+      throw new TypeError('Node expected for parameter "content"');
+    }
+
+    this.content = content;
+  }
+
+  ParenthesisNode.prototype = new Node();
+
+  ParenthesisNode.prototype.type = 'ParenthesisNode';
+
+  /**
+   * Compile the node to javascript code
+   * @param {Object} defs     Object which can be used to define functions
+   *                          or constants globally available for the compiled
+   *                          expression
+   * @return {String} js
+   * @private
+   */
+  ParenthesisNode.prototype._compile = function (defs) {
+    return this.content._compile(defs);
+  };
+
+  /**
+   * Execute a callback for each of the child nodes of this node
+   * @param {function(child: Node, path: string, parent: Node)} callback
+   */
+  ParenthesisNode.prototype.forEach = function (callback) {
+    callback(this.content, 'content', this);
+  };
+
+  /**
+   * Create a new ParenthesisNode having it's childs be the results of calling
+   * the provided callback function for each of the childs of the original node.
+   * @param {function(child: Node, path: string, parent: Node) : Node} callback
+   * @returns {ParenthesisNode} Returns a clone of the node
+   */
+  ParenthesisNode.prototype.map = function (callback) {
+    var content = callback(this.content, 'content', this);
+    return new ParenthesisNode(content);
+  };
+
+  /**
+   * Create a clone of this node, a shallow copy
+   * @return {ParenthesisNode}
+   */
+  ParenthesisNode.prototype.clone = function() {
+    return new ParenthesisNode(this.content);
+  };
+
+  /**
+   * Get string representation
+   * @return {String} str
+   * @override
+   */
+  ParenthesisNode.prototype._toString = function() {
+    return '(' + this.content._toString() + ')';
+  };
+
+  /**
+   * Get LaTeX representation
+   * @param {Object|function} callback(s)
+   * @return {String} str
+   * @override
+   */
+  ParenthesisNode.prototype._toTex = function(callbacks) {
+    return '\\left(' + this.content.toTex(callbacks) + '\\right)';
+  };
+
+  return ParenthesisNode;
+}
+
+exports.name = 'ParenthesisNode';
+exports.path = 'expression.node';
+exports.factory = factory;

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -83,7 +83,10 @@ function factory (type, config, load, typed) {
    * @override
    */
   ParenthesisNode.prototype._toString = function() {
-    return '(' + this.content._toString() + ')';
+    if (config.parenthesis === 'keep') {
+      return '(' + this.content.toString() + ')';
+    }
+    return this.content._toString();
   };
 
   /**
@@ -93,7 +96,10 @@ function factory (type, config, load, typed) {
    * @override
    */
   ParenthesisNode.prototype._toTex = function(callbacks) {
-    return '\\left(' + this.content.toTex(callbacks) + '\\right)';
+    if (config.parenthesis === 'keep') {
+      return '\\left(' + this.content.toTex(callbacks) + '\\right)';
+    }
+    return this.content.toTex(callbacks);
   };
 
   return ParenthesisNode;

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -86,34 +86,58 @@ function factory (type, config, load, typed) {
   };
 
   /**
+   * Calculate the necessary parentheses
+   * @param {Node} node
+   * @return {Object} parentheses
+   * @private
+   */
+  function calculateNecessaryParentheses(node) {
+    var precedence = operators.getPrecedence(node, config);
+    var parens = {};
+
+    var startPrecedence = operators.getPrecedence(node.start, config);
+    parens.start = ((startPrecedence !== null) && (startPrecedence <= precedence))
+      || (config.parenthesis === 'all');
+
+    if (node.step) {
+      var stepPrecedence = operators.getPrecedence(node.step, config);
+      parens.step = ((stepPrecedence !== null) && (stepPrecedence <= precedence))
+        || (config.parenthesis === 'all');
+    }
+
+    var endPrecedence = operators.getPrecedence(node.end, config);
+    parens.end = ((endPrecedence !== null) && (endPrecedence <= precedence))
+      || (config.parenthesis === 'all');
+
+    return parens;
+  }
+
+  /**
    * Get string representation
    * @return {String} str
    */
   RangeNode.prototype._toString = function () {
-    var precedence = operators.getPrecedence(this, config);
+    var parens = calculateNecessaryParentheses(this);
 
     //format string as start:step:stop
     var str;
 
     var start = this.start.toString();
-    var startPrecedence = operators.getPrecedence(this.start, config);
-    if ((startPrecedence !== null) && (startPrecedence <= precedence)) {
+    if (parens.start) {
       start = '(' + start + ')';
     }
     str = start;
 
     if (this.step) {
       var step = this.step.toString();
-      var stepPrecedence = operators.getPrecedence(this.step, config);
-      if ((stepPrecedence !== null) && (stepPrecedence <= precedence)) {
+      if (parens.step) {
         step = '(' + step + ')';
       }
       str += ':' + step;
     }
 
     var end = this.end.toString();
-    var endPrecedence = operators.getPrecedence(this.end, config);
-    if ((endPrecedence !== null) && (endPrecedence <= precedence)) {
+    if (parens.end) {
       end = '(' + end + ')';
     }
     str += ':' + end;
@@ -127,11 +151,26 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   RangeNode.prototype._toTex = function (callbacks) {
+    var parens = calculateNecessaryParentheses(this);
+
     var str = this.start.toTex(callbacks);
-    if (this.step) {
-      str += ':' + this.step.toTex(callbacks);
+    if (parens.start) {
+      str = '\\left(' + str + '\\right)';
     }
-    str += ':' + this.end.toTex(callbacks);
+
+    if (this.step) {
+      var step = this.step.toTex(callbacks);
+      if (parens.step) {
+        step = '\\left(' + step + '\\right)';
+      }
+      str += ':' + step;
+    }
+
+    var end = this.end.toTex(callbacks);
+    if (parens.end) {
+      end = '\\left(' + end + '\\right)';
+    }
+    str += ':' + end;
 
     return str;
   };

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -90,13 +90,13 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   RangeNode.prototype._toString = function () {
-    var precedence = operators.getPrecedence(this);
+    var precedence = operators.getPrecedence(this, config);
 
     //format string as start:step:stop
     var str;
 
     var start = this.start.toString();
-    var startPrecedence = operators.getPrecedence(this.start);
+    var startPrecedence = operators.getPrecedence(this.start, config);
     if ((startPrecedence !== null) && (startPrecedence <= precedence)) {
       start = '(' + start + ')';
     }
@@ -104,7 +104,7 @@ function factory (type, config, load, typed) {
 
     if (this.step) {
       var step = this.step.toString();
-      var stepPrecedence = operators.getPrecedence(this.step);
+      var stepPrecedence = operators.getPrecedence(this.step, config);
       if ((stepPrecedence !== null) && (stepPrecedence <= precedence)) {
         step = '(' + step + ')';
       }
@@ -112,7 +112,7 @@ function factory (type, config, load, typed) {
     }
 
     var end = this.end.toString();
-    var endPrecedence = operators.getPrecedence(this.end);
+    var endPrecedence = operators.getPrecedence(this.end, config);
     if ((endPrecedence !== null) && (endPrecedence <= precedence)) {
       end = '(' + end + ')';
     }

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -87,7 +87,11 @@ function factory (type, config, load, typed) {
    * @return {String}
    */
   UpdateNode.prototype._toString = function () {
-    return this.index.toString() + ' = ' + this.expr._toString();
+    var expr = this.expr.toString();
+    if (config.parenthesis === 'all') {
+      expr = '(' + expr + ')';
+    }
+    return this.index.toString() + ' = ' + expr;
   };
 
   /**
@@ -96,7 +100,11 @@ function factory (type, config, load, typed) {
    * @return {String}
    */
   UpdateNode.prototype._toTex = function (callbacks) {
-    return this.index.toTex(callbacks) + ':=' + this.expr.toTex(callbacks);
+    var expr = this.expr.toTex();
+    if (config.parenthesis === 'all') {
+      expr = '\\left(' + expr + '\\right)';
+    }
+    return this.index.toTex(callbacks) + ':=' + expr;
   };
 
   return UpdateNode;

--- a/lib/expression/node/index.js
+++ b/lib/expression/node/index.js
@@ -9,6 +9,7 @@ module.exports = [
   require('./FunctionNode'),
   require('./Node'),
   require('./OperatorNode'),
+  require('./ParenthesisNode'),
   require('./RangeNode'),
   require('./SymbolNode'),
   require('./UpdateNode')

--- a/lib/expression/operators.js
+++ b/lib/expression/operators.js
@@ -214,7 +214,12 @@ var properties = [
  * @param {Node}
  * @return {Number|null}
  */
-function getPrecedence (node) {
+function getPrecedence (_node, config) {
+  var node = _node;
+  if (config.parenthesis !== 'keep') {
+    //ParenthesisNodes are only ignored when not in 'keep' mode
+    node = _node.getContent();
+  }
   var identifier = node.getIdentifier();
   for (var i = 0; i < properties.length; i++) {
     if (identifier in properties[i]) {
@@ -233,9 +238,14 @@ function getPrecedence (node) {
  * @return {String|null}
  * @throws {Error}
  */
-function getAssociativity (node) {
+function getAssociativity (_node, config) {
+  var node = _node;
+  if (config.parenthesis !== 'keep') {
+    //ParenthesisNodes are only ignored when not in 'keep' mode
+    node = _node.getContent();
+  }
   var identifier = node.getIdentifier();
-  var index = getPrecedence(node);
+  var index = getPrecedence(node, config);
   if (index === null) {
     //node isn't in the list
     return null;
@@ -264,12 +274,20 @@ function getAssociativity (node) {
  *
  * @param {Node} nodeA
  * @param {Node} nodeB
+ * @param {bool} doGetContent
  * @return {bool|null}
  */
-function isAssociativeWith (nodeA, nodeB) {
-  var identifierA = nodeA.getIdentifier();
-  var identifierB = nodeB.getIdentifier();
-  var index = getPrecedence(nodeA);
+function isAssociativeWith (nodeA, nodeB, config) {
+  var a = nodeA;
+  var b = nodeB;
+  if (config.parenthesis !== 'keep') {
+    //ParenthesisNodes are only ignored when not in 'keep' mode
+    var a = nodeA.getContent();
+    var b = nodeB.getContent();
+  }
+  var identifierA = a.getIdentifier();
+  var identifierB = b.getIdentifier();
+  var index = getPrecedence(a, config);
   if (index === null) {
     //node isn't in the list
     return null;

--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -13,6 +13,7 @@ function factory (type, config, load, typed) {
   var FunctionAssignmentNode  = load(require('./node/FunctionAssignmentNode'));
   var IndexNode               = load(require('./node/IndexNode'));
   var OperatorNode            = load(require('./node/OperatorNode'));
+  var ParenthesisNode         = load(require('./node/ParenthesisNode'));
   var FunctionNode            = load(require('./node/FunctionNode'));
   var RangeNode               = load(require('./node/RangeNode'));
   var SymbolNode              = load(require('./node/SymbolNode'));
@@ -1300,7 +1301,7 @@ function factory (type, config, load, typed) {
       closeParams();
       getToken();
 
-      return node;
+      return new ParenthesisNode(node);
     }
 
     return parseEnd();

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -336,6 +336,7 @@ exports.toSymbol = function (name, isUnit) {
 };
 
 //returns the latex output for a given function
+//TODO: this doesn't yet use the different parenthesis options
 exports.toFunction = function (node, callbacks, name) {
   var latexConverter = functions[name];
   var args = node.args.map(function (arg) { //get LaTeX of the arguments

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -198,6 +198,14 @@ describe('AssignmentNode', function() {
     assert.strictEqual(e.expr, d.expr);
   });
 
+  it ('should respect the \'all\' parenthesis option', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    var expr = allMath.parse('a=1');
+    assert.equal(expr.toString(), 'a = (1)');
+    assert.equal(expr.toTex(), 'a:=\\left(1\\right)');
+  });
+
   it ('should stringify a AssignmentNode', function () {
     var b = new ConstantNode(3);
     var n = new AssignmentNode('b', b);

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -253,6 +253,12 @@ describe('ConditionalNode', function() {
     assert.strictEqual(d.falseExpr, c.falseExpr);
   });
 
+  it ('should respect the \'all\' parenthesis option', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    assert.equal(allMath.parse('a?b:c').toString(), '(a) ? (b) : (c)');
+  });
+
   it ('should stringify a ConditionalNode', function () {
     var n = new ConditionalNode(condition, a, b);
 

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -245,6 +245,14 @@ describe('FunctionAssignmentNode', function() {
     assert.strictEqual(e.expr, d.expr);
   });
 
+  it ('should respect the \'all\' parenthesis option', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    var expr = allMath.parse('f(x)=x+1');
+    assert.equal(expr.toString(), 'function f(x) = (x + 1)');
+    assert.equal(expr.toTex(), '\\mathrm{f}\\left(x\\right):=\\left( x+1\\right)');
+  });
+
   it ('should stringify a FunctionAssignmentNode', function () {
     var a = new ConstantNode(2);
     var x = new SymbolNode('x');

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -285,10 +285,10 @@ describe('IndexNode', function() {
     ];
 
     var n = new IndexNode(a, ranges);
-    assert.equal(n.toTex(), ' a_{\\left[2,1\\right]}');
+    assert.equal(n.toTex(), ' a_{2,1}');
 
     var n2 = new IndexNode(a, []);
-    assert.equal(n2.toTex(), ' a_{\\left[\\right]}')
+    assert.equal(n2.toTex(), ' a_{}')
   });
 
   it ('should LaTeX an IndexNode with custom toTex', function () {

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -118,4 +118,10 @@ describe('Node', function() {
     assert.equal(node.getIdentifier(), 'Node');
   });
 
+  it ('should get the content of a Node', function () {
+    var c = new math.expression.node.ConstantNode(1);
+
+    assert.equal(c.getContent(), c);
+    assert.deepEqual(c.getContent(), c);
+  });
 });

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -220,7 +220,6 @@ describe('OperatorNode', function() {
     });
 
     it ('should stringify an OperatorNode with nested operator nodes', function () {
-      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
       var a = new ConstantNode(2);
       var b = new ConstantNode(3);
       var c = new ConstantNode(4);
@@ -235,36 +234,39 @@ describe('OperatorNode', function() {
       assert.equal(n3.toString(), '(2 + 3) * (4 - 5)');
     });
 
-    it.skip ('should stringify left associative OperatorNodes that are associative with another Node', function () {
-      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
-      assert.equal(math.parse('(a+b)+c').toString(), 'a + b + c');
-      assert.equal(math.parse('a+(b+c)').toString(), 'a + b + c');
-      assert.equal(math.parse('(a+b)-c').toString(), 'a + b - c');
-      assert.equal(math.parse('a+(b-c)').toString(), 'a + b - c');
+    it ('should stringify left associative OperatorNodes that are associative with another Node', function () {
+      var autoMath = math.create({parenthesis: 'auto'});
 
-      assert.equal(math.parse('(a*b)*c').toString(), 'a * b * c');
-      assert.equal(math.parse('a*(b*c)').toString(), 'a * b * c');
-      assert.equal(math.parse('(a*b)/c').toString(), 'a * b / c');
-      assert.equal(math.parse('a*(b/c)').toString(), 'a * b / c');
+      assert.equal(autoMath.parse('(a+b)+c').toString(), 'a + b + c');
+      assert.equal(autoMath.parse('a+(b+c)').toString(), 'a + b + c');
+      assert.equal(autoMath.parse('(a+b)-c').toString(), 'a + b - c');
+      assert.equal(autoMath.parse('a+(b-c)').toString(), 'a + b - c');
+
+      assert.equal(autoMath.parse('(a*b)*c').toString(), 'a * b * c');
+      assert.equal(autoMath.parse('a*(b*c)').toString(), 'a * b * c');
+      assert.equal(autoMath.parse('(a*b)/c').toString(), 'a * b / c');
+      assert.equal(autoMath.parse('a*(b/c)').toString(), 'a * b / c');
     });
 
-    it.skip ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
-      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
-      assert.equal(math.parse('(a-b)-c').toString(), 'a - b - c');
-      assert.equal(math.parse('a-(b-c)').toString(), 'a - (b - c)');
-      assert.equal(math.parse('(a-b)+c').toString(), 'a - b + c');
-      assert.equal(math.parse('a-(b+c)').toString(), 'a - (b + c)');
+    it ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
+      var autoMath = math.create({parenthesis: 'auto'});
 
-      assert.equal(math.parse('(a/b)/c').toString(), 'a / b / c');
-      assert.equal(math.parse('a/(b/c)').toString(), 'a / (b / c)');
-      assert.equal(math.parse('(a/b)*c').toString(), 'a / b * c');
-      assert.equal(math.parse('a/(b*c)').toString(), 'a / (b * c)');
+      assert.equal(autoMath.parse('(a-b)-c').toString(), 'a - b - c');
+      assert.equal(autoMath.parse('a-(b-c)').toString(), 'a - (b - c)');
+      assert.equal(autoMath.parse('(a-b)+c').toString(), 'a - b + c');
+      assert.equal(autoMath.parse('a-(b+c)').toString(), 'a - (b + c)');
+
+      assert.equal(autoMath.parse('(a/b)/c').toString(), 'a / b / c');
+      assert.equal(autoMath.parse('a/(b/c)').toString(), 'a / (b / c)');
+      assert.equal(autoMath.parse('(a/b)*c').toString(), 'a / b * c');
+      assert.equal(autoMath.parse('a/(b*c)').toString(), 'a / (b * c)');
     });
 
-    it.skip ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
-      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
-      assert.equal(math.parse('(a^b)^c').toString(), '(a ^ b) ^ c');
-      assert.equal(math.parse('a^(b^c)').toString(), 'a ^ b ^ c');
+    it ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
+      var autoMath = math.create({parenthesis: 'auto'});
+
+      assert.equal(autoMath.parse('(a^b)^c').toString(), '(a ^ b) ^ c');
+      assert.equal(autoMath.parse('a^(b^c)').toString(), 'a ^ b ^ c');
     });
 
     it ('should stringify unary OperatorNodes containing a binary OperatorNode', function () {
@@ -273,11 +275,12 @@ describe('OperatorNode', function() {
       assert.equal(math.parse('-(a+b)').toString(), '-(a + b)');
     });
 
-    it.skip ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
-      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
-      assert.equal(math.parse('(-a)!').toString(), '(-a)!');
-      assert.equal(math.parse('-(a!)').toString(), '-a!');
-      assert.equal(math.parse('-(-a)').toString(), '-(-a)');
+    it ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
+      var autoMath = math.create({parenthesis: 'auto'});
+
+      assert.equal(autoMath.parse('(-a)!').toString(), '(-a)!');
+      assert.equal(autoMath.parse('-(a!)').toString(), '-a!');
+      assert.equal(autoMath.parse('-(-a)').toString(), '-(-a)');
     });
   });
 

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -284,6 +284,19 @@ describe('OperatorNode', function() {
     });
   });
 
+  it ('should respect the \'all\' parenthesis option', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    assert.equal(allMath.parse('1+1+1').toString(), '(1 + 1) + 1' );
+    assert.equal(allMath.parse('1+1+1').toTex(), '\\left(1+1\\right)+1' );
+  });
+
+  it ('should correctly LaTeX fractions in \'all\' parenthesis mode', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    assert.equal(allMath.parse('1/2/3').toTex(), '\\frac{\\left(\\frac{1}{2}\\right)}{3}');
+  });
+
   it ('should LaTeX an OperatorNode', function () {
     var a = new ConstantNode(2);
     var b = new ConstantNode(3);

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -220,6 +220,7 @@ describe('OperatorNode', function() {
     });
 
     it ('should stringify an OperatorNode with nested operator nodes', function () {
+      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
       var a = new ConstantNode(2);
       var b = new ConstantNode(3);
       var c = new ConstantNode(4);
@@ -234,7 +235,8 @@ describe('OperatorNode', function() {
       assert.equal(n3.toString(), '(2 + 3) * (4 - 5)');
     });
 
-    it ('should stringify left associative OperatorNodes that are associative with another Node', function () {
+    it.skip ('should stringify left associative OperatorNodes that are associative with another Node', function () {
+      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
       assert.equal(math.parse('(a+b)+c').toString(), 'a + b + c');
       assert.equal(math.parse('a+(b+c)').toString(), 'a + b + c');
       assert.equal(math.parse('(a+b)-c').toString(), 'a + b - c');
@@ -246,7 +248,8 @@ describe('OperatorNode', function() {
       assert.equal(math.parse('a*(b/c)').toString(), 'a * b / c');
     });
 
-    it ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
+    it.skip ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
+      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
       assert.equal(math.parse('(a-b)-c').toString(), 'a - b - c');
       assert.equal(math.parse('a-(b-c)').toString(), 'a - (b - c)');
       assert.equal(math.parse('(a-b)+c').toString(), 'a - b + c');
@@ -258,7 +261,8 @@ describe('OperatorNode', function() {
       assert.equal(math.parse('a/(b*c)').toString(), 'a / (b * c)');
     });
 
-    it ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
+    it.skip ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
+      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
       assert.equal(math.parse('(a^b)^c').toString(), '(a ^ b) ^ c');
       assert.equal(math.parse('a^(b^c)').toString(), 'a ^ b ^ c');
     });
@@ -269,7 +273,8 @@ describe('OperatorNode', function() {
       assert.equal(math.parse('-(a+b)').toString(), '-(a + b)');
     });
 
-    it ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
+    it.skip ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
+      //TODO fix this test as soon as the 'auto' parenthesis option is implemented
       assert.equal(math.parse('(-a)!').toString(), '(-a)!');
       assert.equal(math.parse('-(a!)').toString(), '-a!');
       assert.equal(math.parse('-(-a)').toString(), '-(-a)');

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -458,4 +458,11 @@ describe('OperatorNode', function() {
     assert.equal(pow.toTex(), '\\left({\\left\\{\\begin{array}{l l}{1}, &\\quad{\\text{if}\\;1}\\\\{1}, &\\quad{\\text{otherwise}}\\end{array}\\right.}\\right)^{1}');
   });
 
+  it ('should LaTeX simple expressions in \'auto\' mode', function () {
+    var autoMath = math.create({parenthesis: 'auto'});
+
+    //this covers a bug that was triggered previously
+    assert.equal(autoMath.parse('1+(1+1)').toTex(), '1+1+1');
+  });
+
 });

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -131,10 +131,38 @@ describe('ParenthesisNode', function() {
     assert.equal(n.toString(), '(1)');
   });
 
+  it ('should stringify a ParenthesisNode when not in keep mode', function () {
+    var allMath = math.create({parenthesis: 'all'});
+    var autoMath = math.create({parenthesis: 'auto'});
+
+    var allC = new allMath.expression.node.ConstantNode(1);
+    var autoC = new autoMath.expression.node.ConstantNode(1);
+
+    var allP = new allMath.expression.node.ParenthesisNode(allC);
+    var autoP = new autoMath.expression.node.ParenthesisNode(autoC);
+
+    assert.equal(allP.toString(), '1');
+    assert.equal(autoP.toString(), '1');
+  });
+
   it ('should LaTeX a ParenthesisNode', function () {
     var a = new ConstantNode(1);
     var n = new ParenthesisNode(a);
 
     assert.equal(n.toTex(), '\\left(1\\right)');
+  });
+
+  it ('should LaTeX a ParenthesisNode when not in keep mode', function () {
+    var allMath = math.create({parenthesis: 'all'});
+    var autoMath = math.create({parenthesis: 'auto'});
+
+    var allC = new allMath.expression.node.ConstantNode(1);
+    var autoC = new autoMath.expression.node.ConstantNode(1);
+
+    var allP = new allMath.expression.node.ParenthesisNode(allC);
+    var autoP = new autoMath.expression.node.ParenthesisNode(autoC);
+
+    assert.equal(allP.toTex(), '1');
+    assert.equal(autoP.toTex(), '1');
   });
 });

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -1,0 +1,128 @@
+// test SymbolNode
+var assert = require('assert');
+var approx = require('../../../tools/approx');
+var math = require('../../../index');
+var Node = math.expression.node.Node;
+var ConstantNode = math.expression.node.ConstantNode;
+var OperatorNode = math.expression.node.OperatorNode;
+var ParenthesisNode = math.expression.node.ParenthesisNode;
+
+describe('ParenthesisNode', function() {
+
+  it ('should create a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+
+    var n = new ParenthesisNode(a);
+    assert(n instanceof ParenthesisNode);
+    assert(n instanceof Node);
+    assert.equal(n.type, 'ParenthesisNode');
+  });
+
+  it ('should throw an error when calling without new operator', function () {
+    var a = new ConstantNode(1);
+    assert.throws(function () {ParenthesisNode(a)}, SyntaxError);
+  });
+
+  it ('should throw an error when calling with wrong arguments', function () {
+    assert.throws(function () {new ParenthesisNode()}, TypeError);
+    assert.throws(function () {new ParenthesisNode(2)}, TypeError);
+  });
+
+  it.skip ('should compile a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+    var n = new ParenthesisNode(a);
+
+    assert.equal(n.compile(math), a.compile(math)); //FIXME doesn't work for whatever reason
+  });
+
+  it ('should filter a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+    var n = new ParenthesisNode(a);
+
+    assert.deepEqual(n.filter(function (node) {return node instanceof ParenthesisNode;}),  [n]);
+    assert.deepEqual(n.filter(function (node) {return node.content instanceof ConstantNode;}),  [n]);
+    assert.deepEqual(n.filter(function (node) {
+        return (typeof node.content !== 'undefined') && (node.content.value == '1');
+    }),  [n]);
+    assert.deepEqual(n.filter(function (node) {
+        return (typeof node.content !== 'undefined') && (node.content.type == 'ConstantNode');
+    }),  [n]);
+    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode;}),  [a]);
+  });
+
+  it ('should run forEach on a ParenthesisNode', function () {
+    var count = 0;
+    var a = new ConstantNode(1);
+
+    var n = new ParenthesisNode(a);
+    n.forEach(function (node, path, _parent) {
+      assert.equal(node.type, 'ConstantNode');
+      assert.equal(path, 'content');
+      assert.deepEqual(_parent, n);
+      count++;
+    });
+
+    assert.equal(count, 1);
+  });
+
+  it ('should map a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+    var b = new ParenthesisNode(a);
+
+    var count = 0;
+
+    var c = b.map(function (node, path, _parent) {
+      count++;
+      assert.equal(node.type, 'ConstantNode');
+      assert.equal(node.value, 1);
+      return new ConstantNode(2);
+    });
+
+    assert.equal(count, 1);
+    assert.equal(c.content.value, 2);
+  });
+
+  it ('should transform a ParenthesisNode', function () {
+    var c1 = new ConstantNode(1);
+    var c2 = new ConstantNode(2);
+
+    var a = new ParenthesisNode(c1);
+    var b = new ParenthesisNode(c2);
+
+    var c = a.transform(function (node) {
+      return node instanceof ParenthesisNode && node.content.value == 1 ? b : node;
+    });
+    assert.deepEqual(c,  b);
+
+    // no match should leave the constant as is
+    var d = a.transform(function (node) {
+      return node instanceof ParenthesisNode && node.name == 2 ? b : node;
+    });
+    assert.deepEqual(d,  a);
+  });
+
+  it ('should clone a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+    var n = new ParenthesisNode(a);
+    var clone = n.clone();
+
+    assert(clone instanceof ParenthesisNode);
+    assert.deepEqual(n, clone);
+    assert.notStrictEqual(n, clone);
+    assert.equal(n.content, clone.content);
+  });
+
+  it ('should stringify a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+    var n = new ParenthesisNode(a);
+
+    assert.equal(n.toString(), '(1)');
+  });
+
+  it ('should LaTeX a ParenthesisNode', function () {
+    var a = new ConstantNode(1);
+    var n = new ParenthesisNode(a);
+
+    assert.equal(n.toTex(), '\\left(1\\right)');
+  });
+});

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -112,6 +112,18 @@ describe('ParenthesisNode', function() {
     assert.equal(n.content, clone.content);
   });
 
+  it ('should get the content of a ParenthesisNode', function () {
+    var c = new math.expression.node.ConstantNode(1);
+    var p1 = new math.expression.node.ParenthesisNode(c);
+    var p2 = new math.expression.node.ParenthesisNode(p1);
+
+    assert.equal(p1.content, c);
+    assert.equal(p1.getContent(), c);
+    assert.deepEqual(p1.getContent(), c);
+    assert.equal(p2.getContent(), c);
+    assert.deepEqual(p2.getContent(), c);
+  });
+
   it ('should stringify a ParenthesisNode', function () {
     var a = new ConstantNode(1);
     var n = new ParenthesisNode(a);

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -280,6 +280,13 @@ describe('RangeNode', function() {
     assert.equal(n.toString(), '(0:10):2:100');
   });
 
+  it ('should respect the \'all\' parenthesis option', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    assert.equal(allMath.parse('1:2:3').toString(), '(1):(2):(3)');
+    assert.equal(allMath.parse('1:2:3').toTex(), '\\left(1\\right):\\left(2\\right):\\left(3\\right)');
+  });
+
   it ('should LaTeX a RangeNode without step', function () {
     var start = new ConstantNode(0);
     var end = new ConstantNode(10);

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -321,6 +321,13 @@ describe('UpdateNode', function() {
     assert.equal(n.toString(), 'a[2, 1] = 5');
   });
 
+  it ('should respect the \'all\' parenthesis option', function () {
+    var allMath = math.create({parenthesis: 'all'});
+
+    assert.equal(allMath.parse('a[1]=2').toString(), 'a[1] = (2)' );
+    assert.equal(allMath.parse('a[1]=2').toTex(), ' a_{1}:=\\left(2\\right)' );
+  });
+
   it ('should LaTeX an UpdateNode', function () {
     var a = new SymbolNode('a');
     var ranges = [
@@ -330,7 +337,7 @@ describe('UpdateNode', function() {
     var v = new ConstantNode(5);
 
     var n = new UpdateNode(new IndexNode(a, ranges), v);
-    assert.equal(n.toTex(), ' a_{\\left[2,1\\right]}:=5');
+    assert.equal(n.toTex(), ' a_{2,1}:=5');
   });
 
   it ('should LaTeX an UpdateNode with custom toTex', function () {

--- a/test/expression/node/index.test.js
+++ b/test/expression/node/index.test.js
@@ -5,7 +5,7 @@ var assert = require('assert'),
 describe('node/index', function() {
 
   it('should contain all nodes', function() {
-    assert.equal(index.length, 13);
+    assert.equal(index.length, 14);
   });
 
 });

--- a/test/expression/operators.test.js
+++ b/test/expression/operators.test.js
@@ -1,12 +1,14 @@
 var assert = require('assert');
 
-var math = require('../../core').create();
+var math = require('../../index');
 var operators = require('../../lib/expression/operators');
-var OperatorNode = math.import(require('../../lib/expression/node/OperatorNode'));
-var AssignmentNode = math.import(require('../../lib/expression/node/AssignmentNode'));
-var ConstantNode = math.import(require('../../lib/expression/node/ConstantNode'));
-var Node = math.import(require('../../lib/expression/node/Node'));
+var OperatorNode = math.expression.node.OperatorNode;
+var AssignmentNode = math.expression.node.AssignmentNode;
+var ConstantNode = math.expression.node.ConstantNode;
+var Node = math.expression.node.Node;
+var ParenthesisNode = math.expression.node.ParenthesisNode;
 
+var config = {parenthesis: 'keep'};
 
 describe('operators', function () {
   it('should return the precedence of a node', function () {
@@ -16,14 +18,26 @@ describe('operators', function () {
     var n1 = new AssignmentNode('a', a);
     var n2 = new OperatorNode('or', 'or', [a, b]);
 
-    assert.equal(operators.getPrecedence(n1), 0);
-    assert.equal(operators.getPrecedence(n2), 2);
+    assert.equal(operators.getPrecedence(n1, config), 0);
+    assert.equal(operators.getPrecedence(n2, config), 2);
   });
 
   it('should return null if precedence is not defined for a node', function () {
     var n = new Node();
 
-    assert.equal(operators.getPrecedence(n), null);
+    assert.equal(operators.getPrecedence(n, config), null);
+  });
+
+  it ('should return the precedence of a ParenthesisNode', function () {
+    var c = new ConstantNode(1);
+
+    var op = new OperatorNode('or', 'or', [c, c]);
+
+    var p = new ParenthesisNode(op);
+
+    assert.equal(operators.getPrecedence(p, {parenthesis: 'all'}), operators.getPrecedence(op, config));
+    assert.equal(operators.getPrecedence(p, {parenthesis: 'auto'}), operators.getPrecedence(op, config));
+    assert.equal(operators.getPrecedence(p, config), null);
   });
 
   it('should return the associativity of a node', function () {
@@ -34,10 +48,22 @@ describe('operators', function () {
     var n3 = new OperatorNode('-', 'unaryMinus', [a]);
     var n4 = new OperatorNode('!', 'factorial', [a]);
 
-    assert.equal(operators.getAssociativity(n1), 'left');
-    assert.equal(operators.getAssociativity(n2), 'right');
-    assert.equal(operators.getAssociativity(n3), 'right');
-    assert.equal(operators.getAssociativity(n4), 'left');
+    assert.equal(operators.getAssociativity(n1, config), 'left');
+    assert.equal(operators.getAssociativity(n2, config), 'right');
+    assert.equal(operators.getAssociativity(n3, config), 'right');
+    assert.equal(operators.getAssociativity(n4, config), 'left');
+  });
+
+  it ('should return the associativity of a ParenthesisNode', function () {
+    var c = new ConstantNode(1);
+
+    var op = new OperatorNode('or', 'or', [c, c]);
+
+    var p = new ParenthesisNode(op);
+
+    assert.equal(operators.getAssociativity(p, {parenthesis: 'all'}), operators.getAssociativity(op, config));
+    assert.equal(operators.getAssociativity(p, {parenthesis: 'auto'}), operators.getAssociativity(op, config));
+    assert.equal(operators.getAssociativity(p, config), null);
   });
 
   it('should return null if associativity is not defined for a node', function () {
@@ -46,8 +72,8 @@ describe('operators', function () {
     var n1 = new Node();
     var n2 = new AssignmentNode('a', a);
 
-    assert.equal(operators.getAssociativity(n1), null);
-    assert.equal(operators.getAssociativity(n2), null);
+    assert.equal(operators.getAssociativity(n1, config), null);
+    assert.equal(operators.getAssociativity(n2, config), null);
   });
 
   it('should return if a Node is associative with another Node', function () {
@@ -56,10 +82,10 @@ describe('operators', function () {
     var n1 = new OperatorNode('+', 'add', [a, a]);
     var n2 = new OperatorNode('-', 'subtract', [a, a]);
 
-    assert.equal(operators.isAssociativeWith(n1, n1), true);
-    assert.equal(operators.isAssociativeWith(n1, n2), true);
-    assert.equal(operators.isAssociativeWith(n2, n2), false);
-    assert.equal(operators.isAssociativeWith(n2, n1), false);
+    assert.equal(operators.isAssociativeWith(n1, n1, config), true);
+    assert.equal(operators.isAssociativeWith(n1, n2, config), true);
+    assert.equal(operators.isAssociativeWith(n2, n2, config), false);
+    assert.equal(operators.isAssociativeWith(n2, n1, config), false);
   });
 
   it('should return null if the associativity between two Nodes is not defined', function () {
@@ -68,9 +94,22 @@ describe('operators', function () {
     var n1 = new Node();
     var n2 = new AssignmentNode('a', a);
 
-    assert.equal(operators.isAssociativeWith(n1, n1), null);
-    assert.equal(operators.isAssociativeWith(n1, n2), null);
-    assert.equal(operators.isAssociativeWith(n2, n2), null);
-    assert.equal(operators.isAssociativeWith(n2, n1), null);
+    assert.equal(operators.isAssociativeWith(n1, n1, config), null);
+    assert.equal(operators.isAssociativeWith(n1, n2, config), null);
+    assert.equal(operators.isAssociativeWith(n2, n2, config), null);
+    assert.equal(operators.isAssociativeWith(n2, n1, config), null);
+  });
+
+  it ('should return if a ParenthesisNode is associative with another Node', function () {
+    var a = new ConstantNode(1);
+
+    var add = new OperatorNode('+', 'add', [a, a]);
+    var sub = new OperatorNode('-', 'subtract', [a, a]);
+
+    var p = new ParenthesisNode(add);
+
+    assert.equal(operators.isAssociativeWith(p, sub, {parenthesis: 'all'}), true);
+    assert.equal(operators.isAssociativeWith(p, sub, {parenthesis: 'auto'}), true);
+    assert.equal(operators.isAssociativeWith(p, sub, config), null);
   });
 });

--- a/test/expression/parse.test.js
+++ b/test/expression/parse.test.js
@@ -1254,16 +1254,16 @@ describe('parse', function() {
         var node = math.parse('a ? (b : c) : (d : e)');
         assert(node instanceof ConditionalNode);
         assert.equal(node.condition.toString(), 'a');
-        assert.equal(node.trueExpr.toString(), 'b:c');
-        assert.equal(node.falseExpr.toString(), 'd:e');
+        assert.equal(node.trueExpr.toString(), '(b:c)');
+        assert.equal(node.falseExpr.toString(), '(d:e)');
       });
 
       it('should respect precedence of conditional operator and range operator (2)', function () {
         var node = math.parse('a ? (b ? c : d) : (e ? f : g)');
         assert(node instanceof ConditionalNode);
         assert.equal(node.condition.toString(), 'a');
-        assert.equal(node.trueExpr.toString(), 'b ? c : d');
-        assert.equal(node.falseExpr.toString(), 'e ? f : g');
+        assert.equal(node.trueExpr.toString(), '(b ? c : d)');
+        assert.equal(node.falseExpr.toString(), '(e ? f : g)');
       });
 
       it('should respect precedence of range operator and relational operators', function () {
@@ -1580,7 +1580,7 @@ describe('parse', function() {
 
       it('should parse custom nodes', function() {
         var node = parse('custom(x, (2+x), sin(x))', options);
-        assert.equal(node.compile(math).eval(), 'CustomNode(x, 2 + x, sin(x))');
+        assert.equal(node.compile(math).eval(), 'CustomNode(x, (2 + x), sin(x))');
       });
 
       it('should parse custom nodes without parameters', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,8 @@ describe('factory', function() {
       matrix: 'matrix',
       number: 'number',
       precision: 64,
-      epsilon: 1e-14
+      epsilon: 1e-14,
+      parenthesis: 'keep'
     });
   });
 
@@ -25,7 +26,8 @@ describe('factory', function() {
       matrix: 'array',
       number: 'bignumber',
       precision: 64,
-      epsilon: 1e-14
+      epsilon: 1e-14,
+      parenthesis: 'keep'
     });
   });
 
@@ -56,21 +58,24 @@ describe('factory', function() {
       matrix: 'matrix',
       number: 'number',
       precision: 64,
-      epsilon: 1e-14
+      epsilon: 1e-14,
+      parenthesis: 'keep'
     });
 
     math1.config({
       matrix: 'array',
       number: 'bignumber',
       precision: 32,
-      epsilon: 1e-7
+      epsilon: 1e-7,
+      parenthesis: 'auto'
     });
 
     assert.deepEqual(math1.config(), {
       matrix: 'array',
       number: 'bignumber',
       precision: 32,
-      epsilon: 1e-7
+      epsilon: 1e-7,
+      parenthesis: 'auto'
     });
 
     // restore the original config


### PR DESCRIPTION
It's finally ready, including an update of the pretty printing example page and an update of the documentation.

This introduces a new `ParenthesisNode` that will always get parsed into the node tree. The `toString` and `toTex` functions then use or ignore those `ParenthesisNodes` based on the parenthesis configuration.

The new parenthesis configuration option has the following three options:
* `keep`: Print parentheses in the same way as they were in the input (default)
* `auto`: Sanitize parentheses. This is the way it has been in v1.
* `all`: Print all parentheses to make the structure of the node tree explicit (this also ignores `ParenthesisNodes`).

What's still missing is a way to pass the configuration to `toTex` and `toString` directly, but I want to have this code reviewed first before implementing that.

How I want to implement the missing part:
* Every function can have a `.toString` or `.toTex` property that is either a callback function or a template string.
* Both `toTex` and `toString` can have two parameters
  - `config`: A config object that locally overrides the global parenthesis option
  - `callback`: The same callback as right now. (this is still necessary because the `.toString` and `.toTex` properties aren't powerful enough to handle all the cases that those callbacks can [like overwriting `toTex` and `toString` of the nodes for example] and it allows changing the behaviour for a single function call). This callback will override the `.toString` and `.toTex` properties.

I'm asking everyone to play around with the LaTeX output and the different parenthesis options (via `examples/browser/pretty_printing_with_mathjax.html`) because this topic is quite complex and there can very well be bugs that slipped through ( even ones that are still present in v1). But if you do so, don't forget to run `npm run build` beforehand. One thing to notice though: The LaTeX output for `FunctionNode`s is still pretty ugly because it isn't able to sanitize parentheses, so there are too many of them in most cases. I haven't tackled this problem so far.