### PR TITLE
Pass configuration to `toTex` and `toString` and callbacks for `toString`

### DIFF
--- a/docs/command_line_interface.md
+++ b/docs/command_line_interface.md
@@ -47,5 +47,5 @@ $ mathjs --tex
 ```bash
 $ mathjs --string
 > (1+1)
-1 + 1
+(1 + 1)
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,14 +37,6 @@ The following configuration options are available:
   This setting only applies to BigNumbers, not to numbers.
   Default value is `64`.
 
-- `parenthesis`. The way parenthesis is displayed in the output of `toTex` and `toString`
-  There are three available options: `'keep'` (default), `'auto'` and `'all'`.
-  When set to `'keep'`, parentheses will be printed in the same way they were in the input
-  that has been parsed (they are represented in the node tree as `ParenthesisNode`s). When
-  set to `'auto'`, mathjs tries to use as few parentheses as possible, thereby getting rid
-  of unnecessary parentheses. When set to `'all'` mathjs puts almost everything in parentheses
-  to make the structure of the node tree explicit.
-
 ## Examples
 
 This section shows a number of configuration examples.

--- a/examples/browser/pretty_printing_with_mathjax.html
+++ b/examples/browser/pretty_printing_with_mathjax.html
@@ -62,24 +62,20 @@
   </tr>
 </table>
 <b>Parenthesis option:</b>
-<input type="radio" name="parenthesis" value="keep" onclick="setParenthesis('keep')" checked>keep
-<input type="radio" name="parenthesis" value="auto" onclick="setParenthesis('auto')">auto
-<input type="radio" name="parenthesis" value="all" onclick="setParenthesis('all')">all
+<input type="radio" name="parenthesis" value="keep" onclick="parenthesis = 'keep'; expr.oninput();" checked>keep
+<input type="radio" name="parenthesis" value="auto" onclick="parenthesis = 'auto'; expr.oninput();">auto
+<input type="radio" name="parenthesis" value="all" onclick="parenthesis = 'all'; expr.oninput();">all
 
 
 <script>
   var expr = document.getElementById('expr'),
       pretty = document.getElementById('pretty'),
-      result = document.getElementById('result');
-
-  function setParenthesis(option) {
-    math.config({parenthesis: option});
-    expr.oninput();
-  }
+      result = document.getElementById('result'),
+      parenthesis = 'keep';
 
   // initialize with an example expression
   expr.value = 'sqrt(75 / 3) + det([[-1, 2], [3, 1]]) - sin(pi / 4)^2';
-  pretty.innerHTML = '$$' + math.parse(expr.value).toTex() + '$$';
+  pretty.innerHTML = '$$' + math.parse(expr.value).toTex({parenthesis: parenthesis}) + '$$';
   result.innerHTML = math.eval(expr.value);
 
   expr.oninput = function () {
@@ -98,7 +94,7 @@
 
     try {
       // export the expression to LaTeX
-      var latex = node ? node.toTex() : '';
+        var latex = node ? node.toTex({parenthesis: parenthesis}) : '';
       console.log('LaTeX expression:', latex);
 
       // display and re-render the expression

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -19,9 +19,6 @@ var configFactory = require('./config');
  *                            {number} precision
  *                              The number of significant digits for BigNumbers.
  *                              Not applicable for Numbers.
- *                            {string} parenthesis
- *                              How to display parentheses in LaTeX and String
- *                              output.
  * @returns {Object} Returns a bare-bone math.js instance containing
  *                   functions:
  *                   - `import` to add new functions
@@ -61,10 +58,6 @@ exports.create = function create (options) {
     // minimum relative difference between two compared values,
     // used by all comparison functions
     epsilon: 1e-14,
-
-    // which type of parenthesis to use for toString and toTex
-    // one of 'keep', 'auto', and 'all'
-    parenthesis: 'keep'
   };
 
   if (options) {

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -94,21 +94,21 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
-   * @param {String} type
    * @return {String} str
    */
-  ArrayNode.prototype._toTex = function(callbacks) {
+  ArrayNode.prototype._toTex = function(localConfig, callbacks) {
     var s = '\\begin{bmatrix}';
 
     this.nodes.forEach(function(node) {
       if (node.nodes) {
         s += node.nodes.map(function(childNode) {
-          return childNode.toTex(callbacks);
+          return childNode.toTex(localConfig, callbacks);
         }).join('&');
       }
       else {
-        s += node.toTex(callbacks);
+        s += node.toTex(localConfig, callbacks);
       }
 
       // new line

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -85,12 +85,11 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  ArrayNode.prototype._toString = function(localConfig, callback) {
+  ArrayNode.prototype._toString = function(options) {
     return string.format(this.nodes);
   };
 

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -85,10 +85,12 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    * @override
    */
-  ArrayNode.prototype._toString = function() {
+  ArrayNode.prototype._toString = function(localConfig, callback) {
     return string.format(this.nodes);
   };
 

--- a/lib/expression/node/ArrayNode.js
+++ b/lib/expression/node/ArrayNode.js
@@ -95,21 +95,20 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  ArrayNode.prototype._toTex = function(localConfig, callbacks) {
+  ArrayNode.prototype._toTex = function(options) {
     var s = '\\begin{bmatrix}';
 
     this.nodes.forEach(function(node) {
       if (node.nodes) {
         s += node.nodes.map(function(childNode) {
-          return childNode.toTex(localConfig, callbacks);
+          return childNode.toTex(options);
         }).join('&');
       }
       else {
-        s += node.toTex(localConfig, callbacks);
+        s += node.toTex(options);
       }
 
       // new line

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -88,13 +88,13 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String}
    */
-  AssignmentNode.prototype._toString = function(localConfig, callback) {
-    var expr = this.expr.toString(localConfig, callback);
-    if (needParenthesis(this, localConfig)) {
+  AssignmentNode.prototype._toString = function(options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var expr = this.expr.toString(options);
+    if (needParenthesis(this, {parenthesis: parenthesis})) {
       expr = '(' + expr + ')';
     }
     return this.name + ' = ' + expr;

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -102,13 +102,13 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String}
    */
-  AssignmentNode.prototype._toTex = function(localConfig, callbacks) {
-    var expr = this.expr.toTex(localConfig, callbacks);
-    if (needParenthesis(this, localConfig)) {
+  AssignmentNode.prototype._toTex = function(options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var expr = this.expr.toTex(options);
+    if (needParenthesis(this, {parenthesis: parenthesis})) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -79,10 +79,10 @@ function factory (type, config, load, typed) {
    * Is parenthesis needed?
    * @private
    */
-  function needParenthesis(node) {
-    var precedence = operators.getPrecedence(node, config);
-    var exprPrecedence = operators.getPrecedence(node.expr, config);
-    return (config.parenthesis === 'all')
+  function needParenthesis(node, localConfig) {
+    var precedence = operators.getPrecedence(node, localConfig);
+    var exprPrecedence = operators.getPrecedence(node.expr, localConfig);
+    return (localConfig.parenthesis === 'all')
       || ((exprPrecedence !== null) && (exprPrecedence <= precedence));
   }
 
@@ -92,7 +92,7 @@ function factory (type, config, load, typed) {
    */
   AssignmentNode.prototype._toString = function() {
     var expr = this.expr.toString();
-    if (needParenthesis(this)) {
+    if (needParenthesis(this, config)) {
       expr = '(' + expr + ')';
     }
     return this.name + ' = ' + expr;
@@ -100,12 +100,13 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String}
    */
-  AssignmentNode.prototype._toTex = function(callbacks) {
-    var expr = this.expr.toTex(callbacks);
-    if (needParenthesis(this)) {
+  AssignmentNode.prototype._toTex = function(localConfig, callbacks) {
+    var expr = this.expr.toTex(localConfig, callbacks);
+    if (needParenthesis(this, localConfig)) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -88,11 +88,13 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String}
    */
-  AssignmentNode.prototype._toString = function() {
-    var expr = this.expr.toString();
-    if (needParenthesis(this, config)) {
+  AssignmentNode.prototype._toString = function(localConfig, callback) {
+    var expr = this.expr.toString(localConfig, callback);
+    if (needParenthesis(this, localConfig)) {
       expr = '(' + expr + ')';
     }
     return this.name + ' = ' + expr;

--- a/lib/expression/node/AssignmentNode.js
+++ b/lib/expression/node/AssignmentNode.js
@@ -77,12 +77,14 @@ function factory (type, config, load, typed) {
 
   /*
    * Is parenthesis needed?
+   * @param {node} node
+   * @param {String} parenthesis
    * @private
    */
-  function needParenthesis(node, localConfig) {
-    var precedence = operators.getPrecedence(node, localConfig);
-    var exprPrecedence = operators.getPrecedence(node.expr, localConfig);
-    return (localConfig.parenthesis === 'all')
+  function needParenthesis(node, parenthesis) {
+    var precedence = operators.getPrecedence(node, parenthesis);
+    var exprPrecedence = operators.getPrecedence(node.expr, parenthesis);
+    return (parenthesis === 'all')
       || ((exprPrecedence !== null) && (exprPrecedence <= precedence));
   }
 
@@ -94,7 +96,7 @@ function factory (type, config, load, typed) {
   AssignmentNode.prototype._toString = function(options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var expr = this.expr.toString(options);
-    if (needParenthesis(this, {parenthesis: parenthesis})) {
+    if (needParenthesis(this, parenthesis)) {
       expr = '(' + expr + ')';
     }
     return this.name + ' = ' + expr;
@@ -108,7 +110,7 @@ function factory (type, config, load, typed) {
   AssignmentNode.prototype._toTex = function(options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var expr = this.expr.toTex(options);
-    if (needParenthesis(this, {parenthesis: parenthesis})) {
+    if (needParenthesis(this, parenthesis)) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -113,14 +113,13 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  BlockNode.prototype._toString = function (localConfig, callback) {
+  BlockNode.prototype._toString = function (options) {
     return this.blocks.map(function (param) {
-      return param.node.toString(localConfig, callback) + (param.visible ? '' : ';');
+      return param.node.toString(options) + (param.visible ? '' : ';');
     }).join('\n');
   };
 

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -113,12 +113,14 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    * @override
    */
-  BlockNode.prototype._toString = function () {
+  BlockNode.prototype._toString = function (localConfig, callback) {
     return this.blocks.map(function (param) {
-      return param.node.toString() + (param.visible ? '' : ';');
+      return param.node.toString(localConfig, callback) + (param.visible ? '' : ';');
     }).join('\n');
   };
 

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -124,12 +124,13 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  BlockNode.prototype._toTex = function (callbacks) {
+  BlockNode.prototype._toTex = function (localConfig, callbacks) {
     return this.blocks.map(function (param) {
-      return param.node.toTex(callbacks) + (param.visible ? '' : ';');
+      return param.node.toTex(localConfig, callbacks) + (param.visible ? '' : ';');
     }).join('\\;\\;\n');
   };
 

--- a/lib/expression/node/BlockNode.js
+++ b/lib/expression/node/BlockNode.js
@@ -125,13 +125,12 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  BlockNode.prototype._toTex = function (localConfig, callbacks) {
+  BlockNode.prototype._toTex = function (options) {
     return this.blocks.map(function (param) {
-      return param.node.toTex(localConfig, callbacks) + (param.visible ? '' : ';');
+      return param.node.toTex(options) + (param.visible ? '' : ';');
     }).join('\\;\\;\n');
   };
 

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -127,14 +127,14 @@ function factory (type, config, load, typed) {
    */
   ConditionalNode.prototype._toString = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var precedence = operators.getPrecedence(this, {parenthesis: parenthesis});
+    var precedence = operators.getPrecedence(this, parenthesis);
 
     //Enclose Arguments in parentheses if they are an OperatorNode
     //or have lower or equal precedence
     //NOTE: enclosing all OperatorNodes in parentheses is a decision
     //purely based on aesthetics and readability
     var condition = this.condition.toString(options);
-    var conditionPrecedence = operators.getPrecedence(this.condition, {parenthesis: parenthesis});
+    var conditionPrecedence = operators.getPrecedence(this.condition, parenthesis);
     if ((parenthesis === 'all')
         || (this.condition.type === 'OperatorNode')
         || ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
@@ -142,7 +142,7 @@ function factory (type, config, load, typed) {
     }
 
     var trueExpr = this.trueExpr.toString(options);
-    var truePrecedence = operators.getPrecedence(this.trueExpr, {parenthesis: parenthesis});
+    var truePrecedence = operators.getPrecedence(this.trueExpr, parenthesis);
     if ((parenthesis === 'all')
         || (this.trueExpr.type === 'OperatorNode')
         || ((truePrecedence !== null) && (truePrecedence <= precedence))) {
@@ -150,7 +150,7 @@ function factory (type, config, load, typed) {
     }
 
     var falseExpr = this.falseExpr.toString(options);
-    var falsePrecedence = operators.getPrecedence(this.falseExpr, {parenthesis: parenthesis});
+    var falsePrecedence = operators.getPrecedence(this.falseExpr, parenthesis);
     if ((parenthesis === 'all')
         || (this.falseExpr.type === 'OperatorNode')
         || ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -122,36 +122,36 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  ConditionalNode.prototype._toString = function (localConfig, callback) {
-    var precedence = operators.getPrecedence(this, localConfig);
+  ConditionalNode.prototype._toString = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var precedence = operators.getPrecedence(this, {parenthesis: parenthesis});
 
     //Enclose Arguments in parentheses if they are an OperatorNode
     //or have lower or equal precedence
     //NOTE: enclosing all OperatorNodes in parentheses is a decision
     //purely based on aesthetics and readability
-    var condition = this.condition.toString(localConfig, callback);
-    var conditionPrecedence = operators.getPrecedence(this.condition, localConfig);
-    if ((localConfig.parenthesis === 'all')
+    var condition = this.condition.toString(options);
+    var conditionPrecedence = operators.getPrecedence(this.condition, {parenthesis: parenthesis});
+    if ((parenthesis === 'all')
         || (this.condition.type === 'OperatorNode')
         || ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
       condition = '(' + condition + ')';
     }
 
-    var trueExpr = this.trueExpr.toString(localConfig, callback);
-    var truePrecedence = operators.getPrecedence(this.trueExpr, localConfig);
-    if ((localConfig.parenthesis === 'all')
+    var trueExpr = this.trueExpr.toString(options);
+    var truePrecedence = operators.getPrecedence(this.trueExpr, {parenthesis: parenthesis});
+    if ((parenthesis === 'all')
         || (this.trueExpr.type === 'OperatorNode')
         || ((truePrecedence !== null) && (truePrecedence <= precedence))) {
       trueExpr = '(' + trueExpr + ')';
     }
 
-    var falseExpr = this.falseExpr.toString(localConfig, callback);
-    var falsePrecedence = operators.getPrecedence(this.falseExpr, localConfig);
-    if ((localConfig.parenthesis === 'all')
+    var falseExpr = this.falseExpr.toString(options);
+    var falsePrecedence = operators.getPrecedence(this.falseExpr, {parenthesis: parenthesis});
+    if ((parenthesis === 'all')
         || (this.falseExpr.type === 'OperatorNode')
         || ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {
       falseExpr = '(' + falseExpr + ')';

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -159,14 +159,15 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  ConditionalNode.prototype._toTex = function (callbacks) {
+  ConditionalNode.prototype._toTex = function (localConfig, callbacks) {
     return '\\left\\{\\begin{array}{l l}{'
-        + this.trueExpr.toTex(callbacks) + '}, &\\quad{\\text{if}\\;'
-        + this.condition.toTex(callbacks)
-        + '}\\\\{' + this.falseExpr.toTex(callbacks)
+        + this.trueExpr.toTex(localConfig, callbacks) + '}, &\\quad{\\text{if}\\;'
+        + this.condition.toTex(localConfig, callbacks)
+        + '}\\\\{' + this.falseExpr.toTex(localConfig, callbacks)
         + '}, &\\quad{\\text{otherwise}}\\end{array}\\right.';
   };
 

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -122,34 +122,36 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  ConditionalNode.prototype._toString = function () {
-    var precedence = operators.getPrecedence(this, config);
+  ConditionalNode.prototype._toString = function (localConfig, callback) {
+    var precedence = operators.getPrecedence(this, localConfig);
 
     //Enclose Arguments in parentheses if they are an OperatorNode
     //or have lower or equal precedence
     //NOTE: enclosing all OperatorNodes in parentheses is a decision
     //purely based on aesthetics and readability
-    var condition = this.condition.toString();
-    var conditionPrecedence = operators.getPrecedence(this.condition, config);
-    if ((config.parenthesis === 'all')
+    var condition = this.condition.toString(localConfig, callback);
+    var conditionPrecedence = operators.getPrecedence(this.condition, localConfig);
+    if ((localConfig.parenthesis === 'all')
         || (this.condition.type === 'OperatorNode')
         || ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
       condition = '(' + condition + ')';
     }
 
-    var trueExpr = this.trueExpr.toString();
-    var truePrecedence = operators.getPrecedence(this.trueExpr, config);
-    if ((config.parenthesis === 'all')
+    var trueExpr = this.trueExpr.toString(localConfig, callback);
+    var truePrecedence = operators.getPrecedence(this.trueExpr, localConfig);
+    if ((localConfig.parenthesis === 'all')
         || (this.trueExpr.type === 'OperatorNode')
         || ((truePrecedence !== null) && (truePrecedence <= precedence))) {
       trueExpr = '(' + trueExpr + ')';
     }
 
-    var falseExpr = this.falseExpr.toString();
-    var falsePrecedence = operators.getPrecedence(this.falseExpr, config);
-    if ((config.parenthesis === 'all')
+    var falseExpr = this.falseExpr.toString(localConfig, callback);
+    var falsePrecedence = operators.getPrecedence(this.falseExpr, localConfig);
+    if ((localConfig.parenthesis === 'all')
         || (this.falseExpr.type === 'OperatorNode')
         || ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {
       falseExpr = '(' + falseExpr + ')';

--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -161,15 +161,14 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  ConditionalNode.prototype._toTex = function (localConfig, callbacks) {
+  ConditionalNode.prototype._toTex = function (options) {
     return '\\left\\{\\begin{array}{l l}{'
-        + this.trueExpr.toTex(localConfig, callbacks) + '}, &\\quad{\\text{if}\\;'
-        + this.condition.toTex(localConfig, callbacks)
-        + '}\\\\{' + this.falseExpr.toTex(localConfig, callbacks)
+        + this.trueExpr.toTex(options) + '}, &\\quad{\\text{if}\\;'
+        + this.condition.toTex(options)
+        + '}\\\\{' + this.falseExpr.toTex(options)
         + '}, &\\quad{\\text{otherwise}}\\end{array}\\right.';
   };
 

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -164,11 +164,10 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  ConstantNode.prototype._toTex = function (localConfig, callbacks) {
+  ConstantNode.prototype._toTex = function (options) {
     var value = this.value,
         index;
     switch (this.valueType) {

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -149,11 +149,10 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  ConstantNode.prototype._toString = function (localConfig, callback) {
+  ConstantNode.prototype._toString = function (options) {
     switch (this.valueType) {
       case 'string':
         return '"' + this.value + '"';

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -149,9 +149,11 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  ConstantNode.prototype._toString = function () {
+  ConstantNode.prototype._toString = function (localConfig, callback) {
     switch (this.valueType) {
       case 'string':
         return '"' + this.value + '"';

--- a/lib/expression/node/ConstantNode.js
+++ b/lib/expression/node/ConstantNode.js
@@ -163,10 +163,11 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  ConstantNode.prototype._toTex = function (callbacks) {
+  ConstantNode.prototype._toTex = function (localConfig, callbacks) {
     var value = this.value,
         index;
     switch (this.valueType) {

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -101,13 +101,15 @@ function factory (type, config, load, typed) {
 
   /**
    * Is parenthesis needed?
+   * @param {Node} node
+   * @param {Object} localConfig
    * @private
    */
-  function needParenthesis(node) {
-    var precedence = operators.getPrecedence(node, config);
-    var exprPrecedence = operators.getPrecedence(node.expr, config);
+  function needParenthesis(node, localConfig) {
+    var precedence = operators.getPrecedence(node, localConfig);
+    var exprPrecedence = operators.getPrecedence(node.expr, localConfig);
 
-    return (config.parenthesis === 'all')
+    return (localConfig.parenthesis === 'all')
       || ((exprPrecedence !== null) && (exprPrecedence <= precedence));
   }
 
@@ -117,7 +119,7 @@ function factory (type, config, load, typed) {
    */
   FunctionAssignmentNode.prototype._toString = function () {
     var expr = this.expr.toString();
-    if (needParenthesis(this)) {
+    if (needParenthesis(this, config)) {
       expr = '(' + expr + ')';
     }
     return 'function ' + this.name +
@@ -126,12 +128,13 @@ function factory (type, config, load, typed) {
 
   /**
    * get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  FunctionAssignmentNode.prototype._toTex = function (callbacks) {
-    var expr = this.expr.toTex(callbacks);
-    if (needParenthesis(this)) {
+  FunctionAssignmentNode.prototype._toTex = function (localConfig, callbacks) {
+    var expr = this.expr.toTex(localConfig, callbacks);
+    if (needParenthesis(this, localConfig)) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -115,11 +115,13 @@ function factory (type, config, load, typed) {
 
   /**
    * get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  FunctionAssignmentNode.prototype._toString = function () {
-    var expr = this.expr.toString();
-    if (needParenthesis(this, config)) {
+  FunctionAssignmentNode.prototype._toString = function (localConfig, callback) {
+    var expr = this.expr.toString(localConfig, callback);
+    if (needParenthesis(this, localConfig)) {
       expr = '(' + expr + ')';
     }
     return 'function ' + this.name +

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -115,13 +115,13 @@ function factory (type, config, load, typed) {
 
   /**
    * get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  FunctionAssignmentNode.prototype._toString = function (localConfig, callback) {
-    var expr = this.expr.toString(localConfig, callback);
-    if (needParenthesis(this, localConfig)) {
+  FunctionAssignmentNode.prototype._toString = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var expr = this.expr.toString(options);
+    if (needParenthesis(this, {parenthesis: parenthesis})) {
       expr = '(' + expr + ')';
     }
     return 'function ' + this.name +

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -130,13 +130,13 @@ function factory (type, config, load, typed) {
 
   /**
    * get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  FunctionAssignmentNode.prototype._toTex = function (localConfig, callbacks) {
-    var expr = this.expr.toTex(localConfig, callbacks);
-    if (needParenthesis(this, localConfig)) {
+  FunctionAssignmentNode.prototype._toTex = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var expr = this.expr.toTex(options);
+    if (needParenthesis(this, {parenthesis: parenthesis})) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -102,14 +102,14 @@ function factory (type, config, load, typed) {
   /**
    * Is parenthesis needed?
    * @param {Node} node
-   * @param {Object} localConfig
+   * @param {Object} parenthesis
    * @private
    */
-  function needParenthesis(node, localConfig) {
-    var precedence = operators.getPrecedence(node, localConfig);
-    var exprPrecedence = operators.getPrecedence(node.expr, localConfig);
+  function needParenthesis(node, parenthesis) {
+    var precedence = operators.getPrecedence(node, parenthesis);
+    var exprPrecedence = operators.getPrecedence(node.expr, parenthesis);
 
-    return (localConfig.parenthesis === 'all')
+    return (parenthesis === 'all')
       || ((exprPrecedence !== null) && (exprPrecedence <= precedence));
   }
 
@@ -121,7 +121,7 @@ function factory (type, config, load, typed) {
   FunctionAssignmentNode.prototype._toString = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var expr = this.expr.toString(options);
-    if (needParenthesis(this, {parenthesis: parenthesis})) {
+    if (needParenthesis(this, parenthesis)) {
       expr = '(' + expr + ')';
     }
     return 'function ' + this.name +
@@ -136,7 +136,7 @@ function factory (type, config, load, typed) {
   FunctionAssignmentNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var expr = this.expr.toTex(options);
-    if (needParenthesis(this, {parenthesis: parenthesis})) {
+    if (needParenthesis(this, parenthesis)) {
       expr = '\\left(' + expr + '\\right)';
     }
 

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -182,7 +182,7 @@ function factory (type, config, load, typed, math) {
    */
   FunctionNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    return latex.toFunction(this, {parenthesis: parenthesis}, this.name);
+    return latex.toFunction(this, options, this.name);
   };
 
   /**

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -157,15 +157,14 @@ function factory (type, config, load, typed, math) {
    * otherwise it falls back to calling Node's toTex
    * function.
    *
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String}
    */
-  FunctionNode.prototype.toTex = function (localConfig, callback) {
+  FunctionNode.prototype.toTex = function (options) {
     var customTex;
-    if ((typeof callback === 'object') && callback.hasOwnProperty(this.name)) {
+    if (options && (typeof options.handler === 'object') && options.handler.hasOwnProperty(this.name)) {
       //callback is a map of callback functions
-      customTex = callback[this.name](this, localConfig, callback);
+      customTex = options.handler[this.name](this, options);
     }
 
     if (typeof customTex !== 'undefined') {
@@ -173,17 +172,17 @@ function factory (type, config, load, typed, math) {
     }
 
     //fall back to Node's toTex
-    return nodeToTex.call(this, localConfig, callback);
+    return nodeToTex.call(this, options);
   };
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  FunctionNode.prototype._toTex = function (localConfig, callbacks) {
-    return latex.toFunction(this, localConfig, callbacks, this.name);
+  FunctionNode.prototype._toTex = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    return latex.toFunction(this, {parenthesis: parenthesis}, this.name);
   };
 
   /**

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -116,16 +116,15 @@ function factory (type, config, load, typed, math) {
    * otherwise it falls back to calling Node's toString
    * function.
    *
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  FunctionNode.prototype.toString = function (localConfig, callback) {
+  FunctionNode.prototype.toString = function (options) {
     var customString;
-    if ((typeof callback === 'object') && callback.hasOwnProperty(this.name)) {
+    if (options && (typeof options.handler === 'object') && options.handler.hasOwnProperty(this.name)) {
       //callback is a map of callback functions
-      customString = callback[this.name](this, localConfig, callback);
+      customString = options.handler[this.name](this, options);
     }
 
     if (typeof customString !== 'undefined') {
@@ -133,16 +132,15 @@ function factory (type, config, load, typed, math) {
     }
 
     //fall back to Node's toString
-    return nodeToString.call(this, localConfig, callback);
+    return nodeToString.call(this, options);
   }
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  FunctionNode.prototype._toString = function (localConfig, callback) {
+  FunctionNode.prototype._toString = function (options) {
     // format the parameters like "add(2, 4.2)"
     return this.name + '(' + this.args.join(', ') + ')';
   };

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -113,6 +113,36 @@ function factory (type, config, load, typed, math) {
     return this.name + '(' + this.args.join(', ') + ')';
   };
 
+  //backup Node's toTex function
+  //@private
+  var nodeToTex = FunctionNode.prototype.toTex;
+
+  /**
+   * Get LaTeX representation. (wrapper function)
+   * This overrides parts of Node's toTex function.
+   * If callback is an object containing callbacks, it
+   * calls the correct callback for the current node,
+   * otherwise it falls back to calling Node's toTex
+   * function.
+   *
+   * @param {Object|function} callback(s)
+   * @return {String}
+   */
+  FunctionNode.prototype.toTex = function (callback) {
+    var customTex;
+    if ((typeof callback === 'object') && callback.hasOwnProperty(this.name)) {
+      //callback is a map of callback functions
+      customTex = callback[this.name](this, callback);
+    }
+
+    if (typeof customTex !== 'undefined') {
+      return customTex;
+    }
+
+    //fall back to Node's toTex
+    return nodeToTex.call(this, callback);
+  };
+
   /**
    * Get LaTeX representation
    * @param {Object|function} callback(s)

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -125,14 +125,15 @@ function factory (type, config, load, typed, math) {
    * otherwise it falls back to calling Node's toTex
    * function.
    *
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String}
    */
-  FunctionNode.prototype.toTex = function (callback) {
+  FunctionNode.prototype.toTex = function (localConfig, callback) {
     var customTex;
     if ((typeof callback === 'object') && callback.hasOwnProperty(this.name)) {
       //callback is a map of callback functions
-      customTex = callback[this.name](this, callback);
+      customTex = callback[this.name](this, localConfig, callback);
     }
 
     if (typeof customTex !== 'undefined') {
@@ -140,16 +141,17 @@ function factory (type, config, load, typed, math) {
     }
 
     //fall back to Node's toTex
-    return nodeToTex.call(this, callback);
+    return nodeToTex.call(this, localConfig, callback);
   };
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  FunctionNode.prototype._toTex = function (callbacks) {
-    return latex.toFunction(this, callbacks, this.name);
+  FunctionNode.prototype._toTex = function (localConfig, callbacks) {
+    return latex.toFunction(this, localConfig, callbacks, this.name);
   };
 
   /**

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -104,11 +104,45 @@ function factory (type, config, load, typed, math) {
     return new FunctionNode(this.name, this.args.slice(0));
   };
 
+  //backup Node's toString function
+  //@private
+  var nodeToString = FunctionNode.prototype.toString;
+
+  /**
+   * Get String representation. (wrapper function)
+   * This overrides parts of Node's toString function.
+   * If callback is an object containing callbacks, it
+   * calls the correct callback for the current node,
+   * otherwise it falls back to calling Node's toString
+   * function.
+   *
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
+   * @return {String} str
+   * @override
+   */
+  FunctionNode.prototype.toString = function (localConfig, callback) {
+    var customString;
+    if ((typeof callback === 'object') && callback.hasOwnProperty(this.name)) {
+      //callback is a map of callback functions
+      customString = callback[this.name](this, localConfig, callback);
+    }
+
+    if (typeof customString !== 'undefined') {
+      return customString;
+    }
+
+    //fall back to Node's toString
+    return nodeToString.call(this, localConfig, callback);
+  }
+
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  FunctionNode.prototype._toString = function () {
+  FunctionNode.prototype._toString = function (localConfig, callback) {
     // format the parameters like "add(2, 4.2)"
     return this.name + '(' + this.args.join(', ') + ')';
   };

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -222,12 +222,11 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  IndexNode.prototype._toString = function (localConfig, callback) {
-    var object = this.object.toString(localConfig, callback);
+  IndexNode.prototype._toString = function (options) {
+    var object = this.object.toString(options);
     if (needParenthesis(this)) {
       object = '(' + object + '(';
     }

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -236,18 +236,17 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  IndexNode.prototype._toTex = function (localConfig, callbacks) {
-    var object = this.object.toTex(localConfig, callbacks);
+  IndexNode.prototype._toTex = function (options) {
+    var object = this.object.toTex(options);
     if (needParenthesis(this)) {
       object = '\\left(' + object + '\\right)';
     }
 
     var ranges = this.ranges.map(function (range) {
-      return range.toTex(localConfig, callbacks);
+      return range.toTex(options);
     });
 
     return object + '_{' + ranges.join(',') + '}';

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -222,10 +222,12 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  IndexNode.prototype._toString = function () {
-    var object = this.object.toString();
+  IndexNode.prototype._toString = function (localConfig, callback) {
+    var object = this.object.toString(localConfig, callback);
     if (needParenthesis(this)) {
       object = '(' + object + '(';
     }

--- a/lib/expression/node/IndexNode.js
+++ b/lib/expression/node/IndexNode.js
@@ -235,17 +235,18 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  IndexNode.prototype._toTex = function (callbacks) {
-    var object = this.object.toTex(callbacks);
+  IndexNode.prototype._toTex = function (localConfig, callbacks) {
+    var object = this.object.toTex(localConfig, callbacks);
     if (needParenthesis(this)) {
       object = '\\left(' + object + '\\right)';
     }
 
     var ranges = this.ranges.map(function (range) {
-      return range.toTex(callbacks);
+      return range.toTex(localConfig, callbacks);
     });
 
     return object + '_{' + ranges.join(',') + '}';

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -270,48 +270,49 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation. (wrapper function)
-   * This functions gets either an object containing callbacks or
-   * a single callback. It decides whether to call the callback and, if
-   * not or if the callback returns nothing, it calls the default
-   * LaTeX implementation of the node (_toTex).
    *
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * This function can get an object of the following form:
+   * {
+   *    handler: //This can be a callback function of the form
+   *             // "function callback(node, options)"or
+   *             // a map that maps function names (used in FunctionNodes)
+   *             // to callbacks
+   *    parenthesis: "keep" //the parenthesis option (This is optional)
+   * }
+   *
+   * @param {Object} options
    * @return {String}
    */
-  Node.prototype.toTex = function (localConfig, callback) {
-    if (!localConfig) {
-      localConfig = config;
-    }
-
+  Node.prototype.toTex = function (options) {
     var customTex;
-    switch (typeof callback) {
-      case 'object':
-      case 'undefined':
-        break;
-      case 'function':
-        customTex = callback(this, localConfig, callback);
-        break;
-      default:
-        throw new TypeError('Object or function expected as callback');
+    if (options && typeof options == 'object') {
+      switch (typeof options.handler) {
+        case 'object':
+        case 'undefined':
+          break;
+        case 'function':
+          customTex = options.handler(this, options);
+          break;
+        default:
+          throw new TypeError('Object or function expected as callback');
+      }
     }
 
     if (typeof customTex !== 'undefined') {
       return customTex;
     }
 
-    return this._toTex(localConfig, callback);
+    return this._toTex(options);
   };
 
   /**
    * Internal function to generate the LaTeX output.
    * This has to be implemented by every Node
    *
-   * @param {Object} localConfig
-   * @param {Object|function} callback
+   * @param {Object} options
    * @throws {Error}
    */
-  Node.prototype._toTex = function (localConfig, callback) {
+  Node.prototype._toTex = function (options) {
     //must be implemented by each of the Node implementations
     throw new Error('_toTex not implemented for ' + this.type);
   };

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -219,11 +219,38 @@ function factory (type, config, load, typed) {
   };
 
   /**
-   * Get string representation
+  /**
+   * Get string representation. (wrapper function)
+   * This function gets either an object containing callbacks or
+   * a single callback. It decides whether to call the callback and,
+   * if not or if the callback returns nothing, it calls the default
+   * toString implementation of the Node (_toString).
+   *
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String}
    */
-  Node.prototype.toString = function () {
-    return this._toString();
+  Node.prototype.toString = function (localConfig, callback) {
+    if (!localConfig) {
+      localConfig = config;
+    }
+
+    var customString;
+    switch (typeof callback) {
+      case 'object':
+      case 'undefined':
+        break;
+      case 'function':
+        customString = callback(this, localConfig, callback);
+        break;
+      default:
+        throw new TypeError('Object or function expected as callback');
+    }
+
+    if (typeof customString !== 'undefined') {
+      return customString;
+    }
+    return this._toString(localConfig, callback);
   };
 
   /**

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -234,10 +234,6 @@ function factory (type, config, load, typed) {
    * @throws {Error}
    */
   Node.prototype._toString = function () {
-    if (this.type === 'Node') {
-      //FIXME remove this in v2???
-      return '';
-    }
     //must be implemented by each of the Node implementations
     throw new Error('_toString not implemented for ' + this.type);
   };
@@ -276,14 +272,10 @@ function factory (type, config, load, typed) {
    * Internal function to generate the LaTeX output.
    * This has to be implemented by every Node
    *
-   * @param {Object}|function}
+   * @param {Object|function}
    * @throws {Error}
    */
-  Node.prototype._toTex = function () {
-    if (this.type === 'Node') {
-      //FIXME remove this in v2???
-      return '';
-    }
+  Node.prototype._toTex = function (callback) {
     //must be implemented by each of the Node implementations
     throw new Error('_toTex not implemented for ' + this.type);
   };

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -245,17 +245,22 @@ function factory (type, config, load, typed) {
    * not or if the callback returns nothing, it calls the default
    * LaTeX implementation of the node (_toTex).
    *
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String}
    */
-  Node.prototype.toTex = function (callback) {
+  Node.prototype.toTex = function (localConfig, callback) {
+    if (!localConfig) {
+      localConfig = config;
+    }
+
     var customTex;
     switch (typeof callback) {
       case 'object':
       case 'undefined':
         break;
       case 'function':
-        customTex = callback(this, callback);
+        customTex = callback(this, localConfig, callback);
         break;
       default:
         throw new TypeError('Object or function expected as callback');
@@ -265,17 +270,18 @@ function factory (type, config, load, typed) {
       return customTex;
     }
 
-    return this._toTex(callback);
+    return this._toTex(localConfig, callback);
   };
 
   /**
    * Internal function to generate the LaTeX output.
    * This has to be implemented by every Node
    *
-   * @param {Object|function}
+   * @param {Object} localConfig
+   * @param {Object|function} callback
    * @throws {Error}
    */
-  Node.prototype._toTex = function (callback) {
+  Node.prototype._toTex = function (localConfig, callback) {
     //must be implemented by each of the Node implementations
     throw new Error('_toTex not implemented for ' + this.type);
   };

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -244,8 +244,8 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation. (wrapper function)
-   * This functions get's either an object containing callbacks or
-   * a single callback. It decides whether to call the callback and if
+   * This functions gets either an object containing callbacks or
+   * a single callback. It decides whether to call the callback and, if
    * not or if the callback returns nothing, it calls the default
    * LaTeX implementation of the node (_toTex).
    *
@@ -254,18 +254,15 @@ function factory (type, config, load, typed) {
    */
   Node.prototype.toTex = function (callback) {
     var customTex;
-    if (typeof callback === 'object') {
-      if ((this.type === 'FunctionNode') && callback.hasOwnProperty(this.name)) {
-        //if callback is a map of callback functions and this is a FunctionNode
-        customTex = callback[this.name](this, callback);
-      }
-    }
-    else if (typeof callback === 'function') {
-      //if callback is a function
-      customTex = callback(this, callback);
-    }
-    else if (typeof callback !== 'undefined') {
-      throw new TypeError('Object or function expected as callback');
+    switch (typeof callback) {
+      case 'object':
+      case 'undefined':
+        break;
+      case 'function':
+        customTex = callback(this, callback);
+        break;
+      default:
+        throw new TypeError('Object or function expected as callback');
     }
 
     if (typeof customTex !== 'undefined') {

--- a/lib/expression/node/Node.js
+++ b/lib/expression/node/Node.js
@@ -221,36 +221,39 @@ function factory (type, config, load, typed) {
   /**
   /**
    * Get string representation. (wrapper function)
-   * This function gets either an object containing callbacks or
-   * a single callback. It decides whether to call the callback and,
-   * if not or if the callback returns nothing, it calls the default
-   * toString implementation of the Node (_toString).
    *
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * This function can get an object of the following form:
+   * {
+   *    handler: //This can be a callback function of the form
+   *             // "function callback(node, options)"or
+   *             // a map that maps function names (used in FunctionNodes)
+   *             // to callbacks
+   *    parenthesis: "keep" //the parenthesis option (This is optional)
+   * }
+   *
+   * @param {Object} options
    * @return {String}
    */
-  Node.prototype.toString = function (localConfig, callback) {
-    if (!localConfig) {
-      localConfig = config;
-    }
-
+  Node.prototype.toString = function (options) {
     var customString;
-    switch (typeof callback) {
-      case 'object':
-      case 'undefined':
-        break;
-      case 'function':
-        customString = callback(this, localConfig, callback);
-        break;
-      default:
-        throw new TypeError('Object or function expected as callback');
+    if (options && typeof options == "object") {
+        switch (typeof options.handler) {
+          case 'object':
+          case 'undefined':
+            break;
+          case 'function':
+            customString = options.handler(this, options);
+            break;
+          default:
+            throw new TypeError('Object or function expected as callback');
+        }
     }
 
     if (typeof customString !== 'undefined') {
       return customString;
     }
-    return this._toString(localConfig, callback);
+
+    return this._toString(options);
   };
 
   /**

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -111,11 +111,12 @@ function factory (type, config, load, typed, math) {
    * @private
    */
   function calculateNecessaryParentheses(root, localConfig, args, latex) {
+    var parenthesis = (localConfig && localConfig.parenthesis) ? localConfig.parenthesis : 'keep';
     //precedence of the root OperatorNode
-    var precedence = operators.getPrecedence(root, localConfig);
-    var associativity = operators.getAssociativity(root, localConfig);
+    var precedence = operators.getPrecedence(root, {parenthesis: parenthesis});
+    var associativity = operators.getAssociativity(root, {parenthesis: parenthesis});
 
-    if ((localConfig.parenthesis === 'all') || (args.length > 2)) {
+    if ((parenthesis === 'all') || (args.length > 2)) {
       var parens = [];
       args.forEach(function (arg) {
         switch (arg.getContent().type) { //Nodes that don't need extra parentheses
@@ -137,13 +138,13 @@ function factory (type, config, load, typed, math) {
         return [];
       case 1: //unary operators
               //precedence of the operand
-        var operandPrecedence = operators.getPrecedence(args[0], localConfig);
+        var operandPrecedence = operators.getPrecedence(args[0], {parenthesis: parenthesis});
 
         //handle special cases for LaTeX, where some of the parentheses aren't needed
         if (latex && (operandPrecedence !== null)) {
           var operandIdentifier;
           var rootIdentifier;
-          if (localConfig.parenthesis === 'keep') {
+          if (parenthesis === 'keep') {
             operandIdentifier = args[0].getIdentifier();
             rootIdentifier = root.getIdentifier();
           }
@@ -177,9 +178,9 @@ function factory (type, config, load, typed, math) {
       case 2: //binary operators
         var lhsParens; //left hand side needs parenthesis?
         //precedence of the left hand side
-        var lhsPrecedence = operators.getPrecedence(args[0], localConfig);
+        var lhsPrecedence = operators.getPrecedence(args[0], {parenthesis: parenthesis});
         //is the root node associative with the left hand side
-        var assocWithLhs = operators.isAssociativeWith(root, args[0], localConfig);
+        var assocWithLhs = operators.isAssociativeWith(root, args[0], {parenthesis: parenthesis});
 
         if (lhsPrecedence === null) {
           //if the left hand side has no defined precedence, no parens are needed
@@ -202,9 +203,9 @@ function factory (type, config, load, typed, math) {
 
         var rhsParens; //right hand side needs parenthesis?
         //precedence of the right hand side
-        var rhsPrecedence = operators.getPrecedence(args[1], localConfig);
+        var rhsPrecedence = operators.getPrecedence(args[1], {parenthesis: parenthesis});
         //is the root node associative with the right hand side?
-        var assocWithRhs = operators.isAssociativeWith(root, args[1], localConfig);
+        var assocWithRhs = operators.isAssociativeWith(root, args[1], {parenthesis: parenthesis});
 
         if (rhsPrecedence === null) {
           //if the right hand side has no defined precedence, no parens are needed
@@ -230,7 +231,7 @@ function factory (type, config, load, typed, math) {
           var rootIdentifier;
           var lhsIdentifier;
           var rhsIdentifier;
-          if (localConfig.parenthesis === 'keep') {
+          if (parenthesis === 'keep') {
             rootIdentifier = root.getIdentifier();
             lhsIdentifier = root.args[0].getIdentifier();
             rhsIdentifier = root.args[1].getIdentifier();
@@ -269,19 +270,19 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get string representation.
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  OperatorNode.prototype._toString = function (localConfig, callback) {
+  OperatorNode.prototype._toString = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, localConfig, args, false);
+    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis}, args, false);
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this, localConfig);
+        var assoc = operators.getAssociativity(this, {parenthesis: parenthesis});
 
-        var operand = args[0].toString();
+        var operand = args[0].toString(options);
         if (parens[0]) {
           operand = '(' + operand + ')';
         }
@@ -297,8 +298,8 @@ function factory (type, config, load, typed, math) {
         return operand + this.op;
 
       case 2:
-        var lhs = args[0].toString(); //left hand side
-        var rhs = args[1].toString(); //right hand side
+        var lhs = args[0].toString(options); //left hand side
+        var rhs = args[1].toString(options); //right hand side
         if (parens[0]) { //left hand side in parenthesis?
           lhs = '(' + lhs + ')';
         }

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -104,17 +104,16 @@ function factory (type, config, load, typed, math) {
    * has to be enclosed in parentheses whereas 'false' means the opposite.
    *
    * @param {OperatorNode} root
-   * @param {Object} localConfig
+   * @param {String} parenthesis
    * @param {Node[]} arguments
    * @param {bool}
    * @return {bool[]}
    * @private
    */
-  function calculateNecessaryParentheses(root, localConfig, args, latex) {
-    var parenthesis = (localConfig && localConfig.parenthesis) ? localConfig.parenthesis : 'keep';
+  function calculateNecessaryParentheses(root, parenthesis, args, latex) {
     //precedence of the root OperatorNode
-    var precedence = operators.getPrecedence(root, {parenthesis: parenthesis});
-    var associativity = operators.getAssociativity(root, {parenthesis: parenthesis});
+    var precedence = operators.getPrecedence(root, parenthesis);
+    var associativity = operators.getAssociativity(root, parenthesis);
 
     if ((parenthesis === 'all') || (args.length > 2)) {
       var parens = [];
@@ -138,7 +137,7 @@ function factory (type, config, load, typed, math) {
         return [];
       case 1: //unary operators
               //precedence of the operand
-        var operandPrecedence = operators.getPrecedence(args[0], {parenthesis: parenthesis});
+        var operandPrecedence = operators.getPrecedence(args[0], parenthesis);
 
         //handle special cases for LaTeX, where some of the parentheses aren't needed
         if (latex && (operandPrecedence !== null)) {
@@ -178,9 +177,9 @@ function factory (type, config, load, typed, math) {
       case 2: //binary operators
         var lhsParens; //left hand side needs parenthesis?
         //precedence of the left hand side
-        var lhsPrecedence = operators.getPrecedence(args[0], {parenthesis: parenthesis});
+        var lhsPrecedence = operators.getPrecedence(args[0], parenthesis);
         //is the root node associative with the left hand side
-        var assocWithLhs = operators.isAssociativeWith(root, args[0], {parenthesis: parenthesis});
+        var assocWithLhs = operators.isAssociativeWith(root, args[0], parenthesis);
 
         if (lhsPrecedence === null) {
           //if the left hand side has no defined precedence, no parens are needed
@@ -203,9 +202,9 @@ function factory (type, config, load, typed, math) {
 
         var rhsParens; //right hand side needs parenthesis?
         //precedence of the right hand side
-        var rhsPrecedence = operators.getPrecedence(args[1], {parenthesis: parenthesis});
+        var rhsPrecedence = operators.getPrecedence(args[1], parenthesis);
         //is the root node associative with the right hand side?
-        var assocWithRhs = operators.isAssociativeWith(root, args[1], {parenthesis: parenthesis});
+        var assocWithRhs = operators.isAssociativeWith(root, args[1], parenthesis);
 
         if (rhsPrecedence === null) {
           //if the right hand side has no defined precedence, no parens are needed
@@ -276,11 +275,11 @@ function factory (type, config, load, typed, math) {
   OperatorNode.prototype._toString = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis}, args, false);
+    var parens = calculateNecessaryParentheses(this, parenthesis, args, false);
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this, {parenthesis: parenthesis});
+        var assoc = operators.getAssociativity(this, parenthesis);
 
         var operand = args[0].toString(options);
         if (parens[0]) {
@@ -323,13 +322,13 @@ function factory (type, config, load, typed, math) {
   OperatorNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis}, args, true);
+    var parens = calculateNecessaryParentheses(this, parenthesis, args, true);
     var op = latex.operators[this.fn];
     op = typeof op === 'undefined' ? this.op : op; //fall back to using this.op
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this, {parenthesis: parenthesis});
+        var assoc = operators.getAssociativity(this, parenthesis);
 
         var operand = args[0].toTex(options);
         if (parens[0]) {

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -269,15 +269,17 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get string representation.
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  OperatorNode.prototype._toString = function () {
+  OperatorNode.prototype._toString = function (localConfig, callback) {
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, config, args, false);
+    var parens = calculateNecessaryParentheses(this, localConfig, args, false);
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this, config);
+        var assoc = operators.getAssociativity(this, localConfig);
 
         var operand = args[0].toString();
         if (parens[0]) {

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -104,17 +104,18 @@ function factory (type, config, load, typed, math) {
    * has to be enclosed in parentheses whereas 'false' means the opposite.
    *
    * @param {OperatorNode} root
+   * @param {Object} localConfig
    * @param {Node[]} arguments
    * @param {bool}
    * @return {bool[]}
    * @private
    */
-  function calculateNecessaryParentheses(root, args, latex) {
+  function calculateNecessaryParentheses(root, localConfig, args, latex) {
     //precedence of the root OperatorNode
-    var precedence = operators.getPrecedence(root, config);
-    var associativity = operators.getAssociativity(root, config);
+    var precedence = operators.getPrecedence(root, localConfig);
+    var associativity = operators.getAssociativity(root, localConfig);
 
-    if ((config.parenthesis === 'all') || (args.length > 2)) {
+    if ((localConfig.parenthesis === 'all') || (args.length > 2)) {
       var parens = [];
       args.forEach(function (arg) {
         switch (arg.getContent().type) { //Nodes that don't need extra parentheses
@@ -136,13 +137,13 @@ function factory (type, config, load, typed, math) {
         return [];
       case 1: //unary operators
               //precedence of the operand
-        var operandPrecedence = operators.getPrecedence(args[0], config);
+        var operandPrecedence = operators.getPrecedence(args[0], localConfig);
 
         //handle special cases for LaTeX, where some of the parentheses aren't needed
         if (latex && (operandPrecedence !== null)) {
           var operandIdentifier;
           var rootIdentifier;
-          if (config.parenthesis === 'keep') {
+          if (localConfig.parenthesis === 'keep') {
             operandIdentifier = args[0].getIdentifier();
             rootIdentifier = root.getIdentifier();
           }
@@ -176,9 +177,9 @@ function factory (type, config, load, typed, math) {
       case 2: //binary operators
         var lhsParens; //left hand side needs parenthesis?
         //precedence of the left hand side
-        var lhsPrecedence = operators.getPrecedence(args[0], config);
+        var lhsPrecedence = operators.getPrecedence(args[0], localConfig);
         //is the root node associative with the left hand side
-        var assocWithLhs = operators.isAssociativeWith(root, args[0], config);
+        var assocWithLhs = operators.isAssociativeWith(root, args[0], localConfig);
 
         if (lhsPrecedence === null) {
           //if the left hand side has no defined precedence, no parens are needed
@@ -201,9 +202,9 @@ function factory (type, config, load, typed, math) {
 
         var rhsParens; //right hand side needs parenthesis?
         //precedence of the right hand side
-        var rhsPrecedence = operators.getPrecedence(args[1], config);
+        var rhsPrecedence = operators.getPrecedence(args[1], localConfig);
         //is the root node associative with the right hand side?
-        var assocWithRhs = operators.isAssociativeWith(root, args[1], config);
+        var assocWithRhs = operators.isAssociativeWith(root, args[1], localConfig);
 
         if (rhsPrecedence === null) {
           //if the right hand side has no defined precedence, no parens are needed
@@ -229,7 +230,7 @@ function factory (type, config, load, typed, math) {
           var rootIdentifier;
           var lhsIdentifier;
           var rhsIdentifier;
-          if (config.parenthesis === 'keep') {
+          if (localConfig.parenthesis === 'keep') {
             rootIdentifier = root.getIdentifier();
             lhsIdentifier = root.args[0].getIdentifier();
             rhsIdentifier = root.args[1].getIdentifier();
@@ -272,7 +273,7 @@ function factory (type, config, load, typed, math) {
    */
   OperatorNode.prototype._toString = function () {
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, args, false);
+    var parens = calculateNecessaryParentheses(this, config, args, false);
 
     switch (args.length) {
       case 1: //unary operators
@@ -313,20 +314,21 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    */
-  OperatorNode.prototype._toTex = function (callbacks) {
+  OperatorNode.prototype._toTex = function (localConfig, callbacks) {
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, args, true);
+    var parens = calculateNecessaryParentheses(this, localConfig, args, true);
     var op = latex.operators[this.fn];
     op = typeof op === 'undefined' ? this.op : op; //fall back to using this.op
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this, config);
+        var assoc = operators.getAssociativity(this, localConfig);
 
-        var operand = args[0].toTex(callbacks);
+        var operand = args[0].toTex(localConfig, callbacks);
         if (parens[0]) {
           operand = '\\left(' + operand + '\\right)';
         }
@@ -343,20 +345,20 @@ function factory (type, config, load, typed, math) {
 
       case 2: //binary operators
         var lhs = args[0]; //left hand side
-        var lhsTex = lhs.toTex(callbacks);
+        var lhsTex = lhs.toTex(localConfig, callbacks);
         if (parens[0]) {
           lhsTex = '\\left(' + lhsTex + '\\right)';
         }
 
         var rhs = args[1]; //right hand side
-        var rhsTex = rhs.toTex(callbacks);
+        var rhsTex = rhs.toTex(localConfig, callbacks);
         if (parens[1]) {
           rhsTex = '\\left(' + rhsTex + '\\right)';
         }
 
         //handle some exceptions (due to the way LaTeX works)
         var lhsIdentifier;
-        if (config.parenthesis === 'keep') {
+        if (localConfig.parenthesis === 'keep') {
           lhsIdentifier = lhs.getIdentifier();
         }
         else {
@@ -384,7 +386,7 @@ function factory (type, config, load, typed, math) {
         //fancy function names
         return '\\mathrm{' + this.fn + '}\\left('
             + args.map(function (arg) {
-              return arg.toTex(callbacks);
+              return arg.toTex(localConfig, callbacks);
             }).join(',') + '\\right)';
     }
   };

--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -317,21 +317,21 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  OperatorNode.prototype._toTex = function (localConfig, callbacks) {
+  OperatorNode.prototype._toTex = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
     var args = this.args;
-    var parens = calculateNecessaryParentheses(this, localConfig, args, true);
+    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis}, args, true);
     var op = latex.operators[this.fn];
     op = typeof op === 'undefined' ? this.op : op; //fall back to using this.op
 
     switch (args.length) {
       case 1: //unary operators
-        var assoc = operators.getAssociativity(this, localConfig);
+        var assoc = operators.getAssociativity(this, {parenthesis: parenthesis});
 
-        var operand = args[0].toTex(localConfig, callbacks);
+        var operand = args[0].toTex(options);
         if (parens[0]) {
           operand = '\\left(' + operand + '\\right)';
         }
@@ -348,20 +348,20 @@ function factory (type, config, load, typed, math) {
 
       case 2: //binary operators
         var lhs = args[0]; //left hand side
-        var lhsTex = lhs.toTex(localConfig, callbacks);
+        var lhsTex = lhs.toTex(options);
         if (parens[0]) {
           lhsTex = '\\left(' + lhsTex + '\\right)';
         }
 
         var rhs = args[1]; //right hand side
-        var rhsTex = rhs.toTex(localConfig, callbacks);
+        var rhsTex = rhs.toTex(options);
         if (parens[1]) {
           rhsTex = '\\left(' + rhsTex + '\\right)';
         }
 
         //handle some exceptions (due to the way LaTeX works)
         var lhsIdentifier;
-        if (localConfig.parenthesis === 'keep') {
+        if (parenthesis === 'keep') {
           lhsIdentifier = lhs.getIdentifier();
         }
         else {
@@ -389,7 +389,7 @@ function factory (type, config, load, typed, math) {
         //fancy function names
         return '\\mathrm{' + this.fn + '}\\left('
             + args.map(function (arg) {
-              return arg.toTex(localConfig, callbacks);
+              return arg.toTex(options);
             }).join(',') + '\\right)';
     }
   };

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -91,15 +91,16 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    * @override
    */
-  ParenthesisNode.prototype._toTex = function(callbacks) {
-    if (config.parenthesis === 'keep') {
-      return '\\left(' + this.content.toTex(callbacks) + '\\right)';
+  ParenthesisNode.prototype._toTex = function(localConfig, callbacks) {
+    if (localConfig.parenthesis === 'keep') {
+      return '\\left(' + this.content.toTex(localConfig, callbacks) + '\\right)';
     }
-    return this.content.toTex(callbacks);
+    return this.content.toTex(localConfig, callbacks);
   };
 
   return ParenthesisNode;

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -79,16 +79,15 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  ParenthesisNode.prototype._toString = function(localConfig, callback) {
-    if (localConfig.parenthesis === 'keep') {
-      return '(' + this.content.toString(localConfig, callback) + ')';
+  ParenthesisNode.prototype._toString = function(options) {
+    if ((!options) || (options && options.parenthesis === 'keep')) {
+      return '(' + this.content.toString(options) + ')';
     }
-    return this.content.toString(localConfig, callback);
+    return this.content.toString(options);
   };
 
   /**

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -92,16 +92,15 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  ParenthesisNode.prototype._toTex = function(localConfig, callbacks) {
-    if (localConfig.parenthesis === 'keep') {
-      return '\\left(' + this.content.toTex(localConfig, callbacks) + '\\right)';
+  ParenthesisNode.prototype._toTex = function(options) {
+    if ((!options) || (options && options.parenthesis === 'keep')) {
+      return '\\left(' + this.content.toTex(options) + '\\right)';
     }
-    return this.content.toTex(localConfig, callbacks);
+    return this.content.toTex(options);
   };
 
   return ParenthesisNode;

--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -79,14 +79,16 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    * @override
    */
-  ParenthesisNode.prototype._toString = function() {
-    if (config.parenthesis === 'keep') {
-      return '(' + this.content.toString() + ')';
+  ParenthesisNode.prototype._toString = function(localConfig, callback) {
+    if (localConfig.parenthesis === 'keep') {
+      return '(' + this.content.toString(localConfig, callback) + ')';
     }
-    return this.content.toString();
+    return this.content.toString(localConfig, callback);
   };
 
   /**

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -150,27 +150,27 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @params {Object} localConfig
-   * @params {Object|function} callback(s)
+   * @params {Object} options
    * @return {String} str
    */
-  RangeNode.prototype._toTex = function (localConfig, callbacks) {
-    var parens = calculateNecessaryParentheses(this, localConfig);
+  RangeNode.prototype._toTex = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis});
 
-    var str = this.start.toTex(localConfig, callbacks);
+    var str = this.start.toTex(options);
     if (parens.start) {
       str = '\\left(' + str + '\\right)';
     }
 
     if (this.step) {
-      var step = this.step.toTex(localConfig, callbacks);
+      var step = this.step.toTex(options);
       if (parens.step) {
         step = '\\left(' + step + '\\right)';
       }
       str += ':' + step;
     }
 
-    var end = this.end.toTex(localConfig, callbacks);
+    var end = this.end.toTex(options);
     if (parens.end) {
       end = '\\left(' + end + '\\right)';
     }

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -115,31 +115,31 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    */
-  RangeNode.prototype._toString = function (localConfig, callback) {
-    var parens = calculateNecessaryParentheses(this, localConfig);
+  RangeNode.prototype._toString = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis});
 
     //format string as start:step:stop
     var str;
 
-    var start = this.start.toString(localConfig, callback);
+    var start = this.start.toString(options);
     if (parens.start) {
       start = '(' + start + ')';
     }
     str = start;
 
     if (this.step) {
-      var step = this.step.toString(localConfig, callback);
+      var step = this.step.toString(options);
       if (parens.step) {
         step = '(' + step + ')';
       }
       str += ':' + step;
     }
 
-    var end = this.end.toString(localConfig, callback);
+    var end = this.end.toString(options);
     if (parens.end) {
       end = '(' + end + ')';
     }

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -115,29 +115,31 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    */
-  RangeNode.prototype._toString = function () {
-    var parens = calculateNecessaryParentheses(this, config);
+  RangeNode.prototype._toString = function (localConfig, callback) {
+    var parens = calculateNecessaryParentheses(this, localConfig);
 
     //format string as start:step:stop
     var str;
 
-    var start = this.start.toString();
+    var start = this.start.toString(localConfig, callback);
     if (parens.start) {
       start = '(' + start + ')';
     }
     str = start;
 
     if (this.step) {
-      var step = this.step.toString();
+      var step = this.step.toString(localConfig, callback);
       if (parens.step) {
         step = '(' + step + ')';
       }
       str += ':' + step;
     }
 
-    var end = this.end.toString();
+    var end = this.end.toString(localConfig, callback);
     if (parens.end) {
       end = '(' + end + ')';
     }

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -88,27 +88,27 @@ function factory (type, config, load, typed) {
   /**
    * Calculate the necessary parentheses
    * @param {Node} node
-   * @param {Object} localConfig
+   * @param {String} parenthesis
    * @return {Object} parentheses
    * @private
    */
-  function calculateNecessaryParentheses(node, localConfig) {
-    var precedence = operators.getPrecedence(node, localConfig);
+  function calculateNecessaryParentheses(node, parenthesis) {
+    var precedence = operators.getPrecedence(node, parenthesis);
     var parens = {};
 
-    var startPrecedence = operators.getPrecedence(node.start, localConfig);
+    var startPrecedence = operators.getPrecedence(node.start, parenthesis);
     parens.start = ((startPrecedence !== null) && (startPrecedence <= precedence))
-      || (localConfig.parenthesis === 'all');
+      || (parenthesis === 'all');
 
     if (node.step) {
-      var stepPrecedence = operators.getPrecedence(node.step, localConfig);
+      var stepPrecedence = operators.getPrecedence(node.step, parenthesis);
       parens.step = ((stepPrecedence !== null) && (stepPrecedence <= precedence))
-        || (localConfig.parenthesis === 'all');
+        || (parenthesis === 'all');
     }
 
-    var endPrecedence = operators.getPrecedence(node.end, localConfig);
+    var endPrecedence = operators.getPrecedence(node.end, parenthesis);
     parens.end = ((endPrecedence !== null) && (endPrecedence <= precedence))
-      || (localConfig.parenthesis === 'all');
+      || (parenthesis === 'all');
 
     return parens;
   }
@@ -120,7 +120,7 @@ function factory (type, config, load, typed) {
    */
   RangeNode.prototype._toString = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis});
+    var parens = calculateNecessaryParentheses(this, parenthesis);
 
     //format string as start:step:stop
     var str;
@@ -155,7 +155,7 @@ function factory (type, config, load, typed) {
    */
   RangeNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var parens = calculateNecessaryParentheses(this, {parenthesis: parenthesis});
+    var parens = calculateNecessaryParentheses(this, parenthesis);
 
     var str = this.start.toTex(options);
     if (parens.start) {

--- a/lib/expression/node/RangeNode.js
+++ b/lib/expression/node/RangeNode.js
@@ -88,26 +88,27 @@ function factory (type, config, load, typed) {
   /**
    * Calculate the necessary parentheses
    * @param {Node} node
+   * @param {Object} localConfig
    * @return {Object} parentheses
    * @private
    */
-  function calculateNecessaryParentheses(node) {
-    var precedence = operators.getPrecedence(node, config);
+  function calculateNecessaryParentheses(node, localConfig) {
+    var precedence = operators.getPrecedence(node, localConfig);
     var parens = {};
 
-    var startPrecedence = operators.getPrecedence(node.start, config);
+    var startPrecedence = operators.getPrecedence(node.start, localConfig);
     parens.start = ((startPrecedence !== null) && (startPrecedence <= precedence))
-      || (config.parenthesis === 'all');
+      || (localConfig.parenthesis === 'all');
 
     if (node.step) {
-      var stepPrecedence = operators.getPrecedence(node.step, config);
+      var stepPrecedence = operators.getPrecedence(node.step, localConfig);
       parens.step = ((stepPrecedence !== null) && (stepPrecedence <= precedence))
-        || (config.parenthesis === 'all');
+        || (localConfig.parenthesis === 'all');
     }
 
-    var endPrecedence = operators.getPrecedence(node.end, config);
+    var endPrecedence = operators.getPrecedence(node.end, localConfig);
     parens.end = ((endPrecedence !== null) && (endPrecedence <= precedence))
-      || (config.parenthesis === 'all');
+      || (localConfig.parenthesis === 'all');
 
     return parens;
   }
@@ -117,7 +118,7 @@ function factory (type, config, load, typed) {
    * @return {String} str
    */
   RangeNode.prototype._toString = function () {
-    var parens = calculateNecessaryParentheses(this);
+    var parens = calculateNecessaryParentheses(this, config);
 
     //format string as start:step:stop
     var str;
@@ -147,26 +148,27 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @params {Object} localConfig
    * @params {Object|function} callback(s)
    * @return {String} str
    */
-  RangeNode.prototype._toTex = function (callbacks) {
-    var parens = calculateNecessaryParentheses(this);
+  RangeNode.prototype._toTex = function (localConfig, callbacks) {
+    var parens = calculateNecessaryParentheses(this, localConfig);
 
-    var str = this.start.toTex(callbacks);
+    var str = this.start.toTex(localConfig, callbacks);
     if (parens.start) {
       str = '\\left(' + str + '\\right)';
     }
 
     if (this.step) {
-      var step = this.step.toTex(callbacks);
+      var step = this.step.toTex(localConfig, callbacks);
       if (parens.step) {
         step = '\\left(' + step + '\\right)';
       }
       str += ':' + step;
     }
 
-    var end = this.end.toTex(callbacks);
+    var end = this.end.toTex(localConfig, callbacks);
     if (parens.end) {
       end = '\\left(' + end + '\\right)';
     }

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -98,10 +98,12 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String} str
    * @override
    */
-  SymbolNode.prototype._toString = function() {
+  SymbolNode.prototype._toString = function(localConfig, callback) {
     return this.name;
   };
 

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -107,11 +107,12 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String} str
    * @override
    */
-  SymbolNode.prototype._toTex = function(callbacks) {
+  SymbolNode.prototype._toTex = function(localConfig, callbacks) {
     var isUnit = false;
     if ((typeof math[this.name] === 'undefined') && Unit.isValuelessUnit(this.name)) {
       isUnit = true;

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -108,12 +108,11 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  SymbolNode.prototype._toTex = function(localConfig, callbacks) {
+  SymbolNode.prototype._toTex = function(options) {
     var isUnit = false;
     if ((typeof math[this.name] === 'undefined') && Unit.isValuelessUnit(this.name)) {
       isUnit = true;

--- a/lib/expression/node/SymbolNode.js
+++ b/lib/expression/node/SymbolNode.js
@@ -98,12 +98,11 @@ function factory (type, config, load, typed, math) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String} str
    * @override
    */
-  SymbolNode.prototype._toString = function(localConfig, callback) {
+  SymbolNode.prototype._toString = function(options) {
     return this.name;
   };
 

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -84,16 +84,15 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String}
    */
-  UpdateNode.prototype._toString = function (localConfig, callback) {
-    var expr = this.expr.toString(localConfig, callback);
-    if (localConfig.parenthesis === 'all') {
+  UpdateNode.prototype._toString = function (options) {
+    var expr = this.expr.toString(options);
+    if (options && options.parenthesis === 'all') {
       expr = '(' + expr + ')';
     }
-    return this.index.toString(localConfig, callback) + ' = ' + expr;
+    return this.index.toString(options) + ' = ' + expr;
   };
 
   /**

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -97,16 +97,15 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
-   * @param {Object} localConfig
-   * @param {Object|function} callback(s)
+   * @param {Object} options
    * @return {String}
    */
-  UpdateNode.prototype._toTex = function (localConfig, callbacks) {
-    var expr = this.expr.toTex(localConfig, callbacks);
-    if (localConfig.parenthesis === 'all') {
+  UpdateNode.prototype._toTex = function (options) {
+    var expr = this.expr.toTex(options);
+    if (options && options.parenthesis === 'all') {
       expr = '\\left(' + expr + '\\right)';
     }
-    return this.index.toTex(localConfig, callbacks) + ':=' + expr;
+    return this.index.toTex(options) + ':=' + expr;
   };
 
   return UpdateNode;

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -96,15 +96,16 @@ function factory (type, config, load, typed) {
 
   /**
    * Get LaTeX representation
+   * @param {Object} localConfig
    * @param {Object|function} callback(s)
    * @return {String}
    */
-  UpdateNode.prototype._toTex = function (callbacks) {
-    var expr = this.expr.toTex();
-    if (config.parenthesis === 'all') {
+  UpdateNode.prototype._toTex = function (localConfig, callbacks) {
+    var expr = this.expr.toTex(localConfig, callbacks);
+    if (localConfig.parenthesis === 'all') {
       expr = '\\left(' + expr + '\\right)';
     }
-    return this.index.toTex(callbacks) + ':=' + expr;
+    return this.index.toTex(localConfig, callbacks) + ':=' + expr;
   };
 
   return UpdateNode;

--- a/lib/expression/node/UpdateNode.js
+++ b/lib/expression/node/UpdateNode.js
@@ -84,14 +84,16 @@ function factory (type, config, load, typed) {
 
   /**
    * Get string representation
+   * @param {Object} localConfig
+   * @param {Object|function} callback(s)
    * @return {String}
    */
-  UpdateNode.prototype._toString = function () {
-    var expr = this.expr.toString();
-    if (config.parenthesis === 'all') {
+  UpdateNode.prototype._toString = function (localConfig, callback) {
+    var expr = this.expr.toString(localConfig, callback);
+    if (localConfig.parenthesis === 'all') {
       expr = '(' + expr + ')';
     }
-    return this.index.toString() + ' = ' + expr;
+    return this.index.toString(localConfig, callback) + ' = ' + expr;
   };
 
   /**

--- a/lib/expression/operators.js
+++ b/lib/expression/operators.js
@@ -212,11 +212,12 @@ var properties = [
  * Returns null if the precedence is undefined.
  *
  * @param {Node}
+ * @param {String} parenthesis
  * @return {Number|null}
  */
-function getPrecedence (_node, config) {
+function getPrecedence (_node, parenthesis) {
   var node = _node;
-  if (config.parenthesis !== 'keep') {
+  if (parenthesis !== 'keep') {
     //ParenthesisNodes are only ignored when not in 'keep' mode
     node = _node.getContent();
   }
@@ -235,17 +236,18 @@ function getPrecedence (_node, config) {
  * the associativity is not defined.
  *
  * @param {Node}
+ * @param {String} parenthesis
  * @return {String|null}
  * @throws {Error}
  */
-function getAssociativity (_node, config) {
+function getAssociativity (_node, parenthesis) {
   var node = _node;
-  if (config.parenthesis !== 'keep') {
+  if (parenthesis !== 'keep') {
     //ParenthesisNodes are only ignored when not in 'keep' mode
     node = _node.getContent();
   }
   var identifier = node.getIdentifier();
-  var index = getPrecedence(node, config);
+  var index = getPrecedence(node, parenthesis);
   if (index === null) {
     //node isn't in the list
     return null;
@@ -274,20 +276,20 @@ function getAssociativity (_node, config) {
  *
  * @param {Node} nodeA
  * @param {Node} nodeB
- * @param {bool} doGetContent
+ * @param {String} parenthesis
  * @return {bool|null}
  */
-function isAssociativeWith (nodeA, nodeB, config) {
+function isAssociativeWith (nodeA, nodeB, parenthesis) {
   var a = nodeA;
   var b = nodeB;
-  if (config.parenthesis !== 'keep') {
+  if (parenthesis !== 'keep') {
     //ParenthesisNodes are only ignored when not in 'keep' mode
     var a = nodeA.getContent();
     var b = nodeB.getContent();
   }
   var identifierA = a.getIdentifier();
   var identifierB = b.getIdentifier();
-  var index = getPrecedence(a, config);
+  var index = getPrecedence(a, parenthesis);
   if (index === null) {
     //node isn't in the list
     return null;

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -74,14 +74,6 @@ exports.operators = {
   'or': '\\vee'
 };
 
-
-//create a comma separated list of function arguments
-function functionArgs(args, config, callbacks) {
-  return args.map( function (arg) {
-    return arg.toTex(config, callbacks);
-  }).join(',');
-}
-
 var defaultTemplate = '\\mathrm{%name%}\\left(%*%\\right)';
 
 /*

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -329,21 +329,21 @@ exports.toSymbol = function (name, isUnit) {
 
 //returns the latex output for a given function
 //TODO: this doesn't yet use the different parenthesis options
-exports.toFunction = function (node, config, callbacks, name) {
+exports.toFunction = function (node, options, name) {
   var latexConverter = functions[name];
   var args = node.args.map(function (arg) { //get LaTeX of the arguments
-    return arg.toTex(config, callbacks);
+    return arg.toTex(options);
   });
 
   switch (typeof latexConverter) {
     case 'function': //a callback function
-      return latexConverter(node, callbacks);
+      return latexConverter(node, options);
     case 'string': //a template string
       return expandTemplate(latexConverter, name, args);
     case 'object': //an object with different "converters" for different numbers of arguments
       switch (typeof latexConverter[args.length]) {
         case 'function':
-          return latexConverter[args.length](node, callbacks);
+          return latexConverter[args.length](node, options);
         case 'string':
           return expandTemplate(latexConverter[args.length], name, args);
       }

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -76,9 +76,9 @@ exports.operators = {
 
 
 //create a comma separated list of function arguments
-function functionArgs(args, callbacks) {
+function functionArgs(args, config, callbacks) {
   return args.map( function (arg) {
-    return arg.toTex(callbacks);
+    return arg.toTex(config, callbacks);
   }).join(',');
 }
 
@@ -337,10 +337,10 @@ exports.toSymbol = function (name, isUnit) {
 
 //returns the latex output for a given function
 //TODO: this doesn't yet use the different parenthesis options
-exports.toFunction = function (node, callbacks, name) {
+exports.toFunction = function (node, config, callbacks, name) {
   var latexConverter = functions[name];
   var args = node.args.map(function (arg) { //get LaTeX of the arguments
-    return arg.toTex(callbacks);
+    return arg.toTex(config, callbacks);
   });
 
   switch (typeof latexConverter) {

--- a/test/expression/node/ArrayNode.test.js
+++ b/test/expression/node/ArrayNode.test.js
@@ -244,11 +244,11 @@ describe('ArrayNode', function() {
 
   it ('should LaTeX an ArrayNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'ArrayNode') {
         var latex = '\\left[';
         node.nodes.forEach(function (node) {
-          latex += node.toTex(callback) + ', ';
+          latex += node.toTex(config, callback) + ', ';
         });
 
         latex += '\\right]';
@@ -264,7 +264,7 @@ describe('ArrayNode', function() {
 
     var n = new ArrayNode([a, b]);
 
-    assert.equal(n.toTex(customFunction), '\\left[const\\left(1, number\\right), const\\left(2, number\\right), \\right]');
+    assert.equal(n.toTex({}, customFunction), '\\left[const\\left(1, number\\right), const\\left(2, number\\right), \\right]');
   });
 
 });

--- a/test/expression/node/ArrayNode.test.js
+++ b/test/expression/node/ArrayNode.test.js
@@ -230,6 +230,31 @@ describe('ArrayNode', function() {
     assert.equal(n.toString(), '[1, 2, 3, 4]');
   });
 
+  it ('should stringify an ArrayNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'ArrayNode') {
+        var string = '[';
+        node.nodes.forEach(function (node) {
+          string += node.toString(config, callback) + ', ';
+        });
+
+        string += ']';
+        return string;
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new ArrayNode([a, b]);
+
+    assert.equal(n.toString({}, customFunction), '[const(1, number), const(2, number), ]');
+  });
+
   it ('should LaTeX an ArrayNode', function () {
     var a = new ConstantNode(1);
     var b = new ConstantNode(2);

--- a/test/expression/node/ArrayNode.test.js
+++ b/test/expression/node/ArrayNode.test.js
@@ -269,11 +269,11 @@ describe('ArrayNode', function() {
 
   it ('should LaTeX an ArrayNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ArrayNode') {
         var latex = '\\left[';
         node.nodes.forEach(function (node) {
-          latex += node.toTex(config, callback) + ', ';
+          latex += node.toTex(options) + ', ';
         });
 
         latex += '\\right]';
@@ -289,7 +289,7 @@ describe('ArrayNode', function() {
 
     var n = new ArrayNode([a, b]);
 
-    assert.equal(n.toTex({}, customFunction), '\\left[const\\left(1, number\\right), const\\left(2, number\\right), \\right]');
+    assert.equal(n.toTex({handler: customFunction}), '\\left[const\\left(1, number\\right), const\\left(2, number\\right), \\right]');
   });
 
 });

--- a/test/expression/node/ArrayNode.test.js
+++ b/test/expression/node/ArrayNode.test.js
@@ -232,11 +232,11 @@ describe('ArrayNode', function() {
 
   it ('should stringify an ArrayNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ArrayNode') {
         var string = '[';
         node.nodes.forEach(function (node) {
-          string += node.toString(config, callback) + ', ';
+          string += node.toString(options) + ', ';
         });
 
         string += ']';
@@ -252,7 +252,7 @@ describe('ArrayNode', function() {
 
     var n = new ArrayNode([a, b]);
 
-    assert.equal(n.toString({}, customFunction), '[const(1, number), const(2, number), ]');
+    assert.equal(n.toString({handler: customFunction}), '[const(1, number), const(2, number), ]');
   });
 
   it ('should LaTeX an ArrayNode', function () {

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -240,9 +240,9 @@ describe('AssignmentNode', function() {
 
   it ('should LaTeX an AssignmentNode with custom toTex', function () {
     //Also checks if custom funcions get passed to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'AssignmentNode') {
-        return node.name + '\\mbox{equals}' + node.expr.toTex(callback);
+        return node.name + '\\mbox{equals}' + node.expr.toTex(config, callback);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -253,7 +253,7 @@ describe('AssignmentNode', function() {
 
     var n = new AssignmentNode('a', a);
 
-    assert.equal(n.toTex(customFunction), 'a\\mbox{equals}const\\left(1, number\\right)');
+    assert.equal(n.toTex({}, customFunction), 'a\\mbox{equals}const\\left(1, number\\right)');
   });
 
 });

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -199,11 +199,9 @@ describe('AssignmentNode', function() {
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    var expr = allMath.parse('a=1');
+    var expr = math.parse('a=1');
     assert.equal(expr.toString({parenthesis: 'all'}), 'a = (1)');
-    assert.equal(expr.toTex(), 'a:=\\left(1\\right)');
+    assert.equal(expr.toTex({parenthesis: 'all'}), 'a:=\\left(1\\right)');
   });
 
   it ('should stringify a AssignmentNode', function () {
@@ -258,9 +256,9 @@ describe('AssignmentNode', function() {
 
   it ('should LaTeX an AssignmentNode with custom toTex', function () {
     //Also checks if custom funcions get passed to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'AssignmentNode') {
-        return node.name + '\\mbox{equals}' + node.expr.toTex(config, callback);
+        return node.name + '\\mbox{equals}' + node.expr.toTex(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -271,7 +269,7 @@ describe('AssignmentNode', function() {
 
     var n = new AssignmentNode('a', a);
 
-    assert.equal(n.toTex({}, customFunction), 'a\\mbox{equals}const\\left(1, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), 'a\\mbox{equals}const\\left(1, number\\right)');
   });
 
 });

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -202,7 +202,7 @@ describe('AssignmentNode', function() {
     var allMath = math.create({parenthesis: 'all'});
 
     var expr = allMath.parse('a=1');
-    assert.equal(expr.toString(), 'a = (1)');
+    assert.equal(expr.toString({parenthesis: 'all'}), 'a = (1)');
     assert.equal(expr.toTex(), 'a:=\\left(1\\right)');
   });
 
@@ -224,9 +224,9 @@ describe('AssignmentNode', function() {
 
   it ('should stringify an AssignmentNode with custom toString', function () {
     //Also checks if custom funcions get passed to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'AssignmentNode') {
-        return node.name + ' equals ' + node.expr.toString(config, callback);
+        return node.name + ' equals ' + node.expr.toString(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const(' + node.value + ', ' + node.valueType + ')'
@@ -237,7 +237,7 @@ describe('AssignmentNode', function() {
 
     var n = new AssignmentNode('a', a);
 
-    assert.equal(n.toString({}, customFunction), 'a equals const(1, number)');
+    assert.equal(n.toString({handler: customFunction}), 'a equals const(1, number)');
   });
 
   it ('should LaTeX a AssignmentNode', function () {

--- a/test/expression/node/AssignmentNode.test.js
+++ b/test/expression/node/AssignmentNode.test.js
@@ -222,6 +222,24 @@ describe('AssignmentNode', function() {
     assert.equal(n.toString(), 'b = (a = 2)');
   });
 
+  it ('should stringify an AssignmentNode with custom toString', function () {
+    //Also checks if custom funcions get passed to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'AssignmentNode') {
+        return node.name + ' equals ' + node.expr.toString(config, callback);
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+
+    var n = new AssignmentNode('a', a);
+
+    assert.equal(n.toString({}, customFunction), 'a equals const(1, number)');
+  });
+
   it ('should LaTeX a AssignmentNode', function () {
     var b = new ConstantNode(3);
     var n = new AssignmentNode('b', b);

--- a/test/expression/node/BlockNode.test.js
+++ b/test/expression/node/BlockNode.test.js
@@ -263,11 +263,11 @@ describe('BlockNode', function() {
 
   it ('should LaTeX a BlockNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'BlockNode') {
         var latex = '';
         node.blocks.forEach(function (block) {
-          latex += block.node.toTex(callback) + '; ';
+          latex += block.node.toTex(config, callback) + '; ';
         });
 
         return latex;
@@ -282,7 +282,7 @@ describe('BlockNode', function() {
 
     var n = new BlockNode([{node: a}, {node: b}]);
 
-    assert.equal(n.toTex(customFunction), 'const\\left(1, number\\right); const\\left(2, number\\right); ');
+    assert.equal(n.toTex({}, customFunction), 'const\\left(1, number\\right); const\\left(2, number\\right); ');
   });
 
 });

--- a/test/expression/node/BlockNode.test.js
+++ b/test/expression/node/BlockNode.test.js
@@ -253,11 +253,11 @@ describe('BlockNode', function() {
 
   it ('should stringify a BlockNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'BlockNode') {
         var string = '';
         node.blocks.forEach(function (block) {
-          string += block.node.toString(config, callback) + '; ';
+          string += block.node.toString(options) + '; ';
         });
 
         return string;
@@ -272,7 +272,7 @@ describe('BlockNode', function() {
 
     var n = new BlockNode([{node: a}, {node: b}]);
 
-    assert.equal(n.toString({}, customFunction), 'const(1, number); const(2, number); ');
+    assert.equal(n.toString({handler: customFunction}), 'const(1, number); const(2, number); ');
   });
 
   it ('should LaTeX a BlockNode', function () {

--- a/test/expression/node/BlockNode.test.js
+++ b/test/expression/node/BlockNode.test.js
@@ -287,11 +287,11 @@ describe('BlockNode', function() {
 
   it ('should LaTeX a BlockNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'BlockNode') {
         var latex = '';
         node.blocks.forEach(function (block) {
-          latex += block.node.toTex(config, callback) + '; ';
+          latex += block.node.toTex(options) + '; ';
         });
 
         return latex;
@@ -306,7 +306,7 @@ describe('BlockNode', function() {
 
     var n = new BlockNode([{node: a}, {node: b}]);
 
-    assert.equal(n.toTex({}, customFunction), 'const\\left(1, number\\right); const\\left(2, number\\right); ');
+    assert.equal(n.toTex({handler: customFunction}), 'const\\left(1, number\\right); const\\left(2, number\\right); ');
   });
 
 });

--- a/test/expression/node/BlockNode.test.js
+++ b/test/expression/node/BlockNode.test.js
@@ -251,6 +251,30 @@ describe('BlockNode', function() {
     assert.equal(n.toString(), '5\nfoo = 3;\nfoo');
   });
 
+  it ('should stringify a BlockNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'BlockNode') {
+        var string = '';
+        node.blocks.forEach(function (block) {
+          string += block.node.toString(config, callback) + '; ';
+        });
+
+        return string;
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new BlockNode([{node: a}, {node: b}]);
+
+    assert.equal(n.toString({}, customFunction), 'const(1, number); const(2, number); ');
+  });
+
   it ('should LaTeX a BlockNode', function () {
     var n = new BlockNode([
       {node: new ConstantNode(5), visible:true},

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -254,9 +254,7 @@ describe('ConditionalNode', function() {
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    assert.equal(allMath.parse('a?b:c').toString(), '(a) ? (b) : (c)');
+    assert.equal(math.parse('a?b:c').toString({parenthesis: 'all'}), '(a) ? (b) : (c)');
   });
 
   it ('should stringify a ConditionalNode', function () {
@@ -267,11 +265,11 @@ describe('ConditionalNode', function() {
 
   it ('should stringify a ConditionalNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ConditionalNode') {
-        return 'if ' + node.condition.toString(config, callback)
-          + ' then ' + node.trueExpr.toString(config, callback)
-          + ' else ' + node.falseExpr.toString(config, callback);
+        return 'if ' + node.condition.toString(options)
+          + ' then ' + node.trueExpr.toString(options)
+          + ' else ' + node.falseExpr.toString(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const(' + node.value + ', ' + node.valueType + ')'
@@ -284,7 +282,7 @@ describe('ConditionalNode', function() {
 
     var n = new ConditionalNode(a, b, c);
 
-    assert.equal(n.toTex({}, customFunction), 'if const(1, number) then const(2, number) else const(3, number)');
+    assert.equal(n.toString({handler: customFunction}), 'if const(1, number) then const(2, number) else const(3, number)');
   });
 
   it ('should LaTeX a ConditionalNode', function () {

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -293,11 +293,11 @@ describe('ConditionalNode', function() {
 
   it ('should LaTeX a ConditionalNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ConditionalNode') {
-        return 'if ' + node.condition.toTex(config, callback)
-          + ' then ' + node.trueExpr.toTex(config, callback)
-          + ' else ' + node.falseExpr.toTex(config, callback);
+        return 'if ' + node.condition.toTex(options)
+          + ' then ' + node.trueExpr.toTex(options)
+          + ' else ' + node.falseExpr.toTex(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -310,7 +310,7 @@ describe('ConditionalNode', function() {
 
     var n = new ConditionalNode(a, b, c);
 
-    assert.equal(n.toTex({}, customFunction), 'if const\\left(1, number\\right) then const\\left(2, number\\right) else const\\left(3, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), 'if const\\left(1, number\\right) then const\\left(2, number\\right) else const\\left(3, number\\right)');
   });
 
 });

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -273,11 +273,11 @@ describe('ConditionalNode', function() {
 
   it ('should LaTeX a ConditionalNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'ConditionalNode') {
-        return 'if ' + node.condition.toTex(callback)
-          + ' then ' + node.trueExpr.toTex(callback)
-          + ' else ' + node.falseExpr.toTex(callback);
+        return 'if ' + node.condition.toTex(config, callback)
+          + ' then ' + node.trueExpr.toTex(config, callback)
+          + ' else ' + node.falseExpr.toTex(config, callback);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -290,7 +290,7 @@ describe('ConditionalNode', function() {
 
     var n = new ConditionalNode(a, b, c);
 
-    assert.equal(n.toTex(customFunction), 'if const\\left(1, number\\right) then const\\left(2, number\\right) else const\\left(3, number\\right)');
+    assert.equal(n.toTex({}, customFunction), 'if const\\left(1, number\\right) then const\\left(2, number\\right) else const\\left(3, number\\right)');
   });
 
 });

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -265,6 +265,28 @@ describe('ConditionalNode', function() {
     assert.equal(n.toString(), 'true ? (a = 2) : (b = 3)');
   });
 
+  it ('should stringify a ConditionalNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'ConditionalNode') {
+        return 'if ' + node.condition.toString(config, callback)
+          + ' then ' + node.trueExpr.toString(config, callback)
+          + ' else ' + node.falseExpr.toString(config, callback);
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(3);
+
+    var n = new ConditionalNode(a, b, c);
+
+    assert.equal(n.toTex({}, customFunction), 'if const(1, number) then const(2, number) else const(3, number)');
+  });
+
   it ('should LaTeX a ConditionalNode', function () {
     var n = new ConditionalNode(condition, a, b);
 

--- a/test/expression/node/ConstantNode.test.js
+++ b/test/expression/node/ConstantNode.test.js
@@ -151,7 +151,7 @@ describe('ConstantNode', function() {
 
   it ('should LaTeX a ConstantNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
       }
@@ -159,7 +159,7 @@ describe('ConstantNode', function() {
 
     var n = new ConstantNode(1);
 
-    assert.equal(n.toTex(customFunction), 'const\\left(1, number\\right)');
+    assert.equal(n.toTex({}, customFunction), 'const\\left(1, number\\right)');
   });
 
 });

--- a/test/expression/node/ConstantNode.test.js
+++ b/test/expression/node/ConstantNode.test.js
@@ -164,7 +164,7 @@ describe('ConstantNode', function() {
 
   it ('should LaTeX a ConstantNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
       }
@@ -172,7 +172,7 @@ describe('ConstantNode', function() {
 
     var n = new ConstantNode(1);
 
-    assert.equal(n.toTex({}, customFunction), 'const\\left(1, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), 'const\\left(1, number\\right)');
   });
 
 });

--- a/test/expression/node/ConstantNode.test.js
+++ b/test/expression/node/ConstantNode.test.js
@@ -136,7 +136,7 @@ describe('ConstantNode', function() {
 
   it ('should stringify a ConstantNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ConstantNode') {
         return 'const(' + node.value + ', ' + node.valueType + ')'
       }
@@ -144,7 +144,7 @@ describe('ConstantNode', function() {
 
     var n = new ConstantNode(1);
 
-    assert.equal(n.toString({}, customFunction), 'const(1, number)');
+    assert.equal(n.toString({handler: customFunction}), 'const(1, number)');
   });
 
   it ('should LaTeX a ConstantNode', function () {

--- a/test/expression/node/ConstantNode.test.js
+++ b/test/expression/node/ConstantNode.test.js
@@ -134,6 +134,19 @@ describe('ConstantNode', function() {
     assert.equal(new ConstantNode('null', 'null').toString(), 'null');
   });
 
+  it ('should stringify a ConstantNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var n = new ConstantNode(1);
+
+    assert.equal(n.toString({}, customFunction), 'const(1, number)');
+  });
+
   it ('should LaTeX a ConstantNode', function () {
     assert.equal(new ConstantNode('3', 'number').toTex(), '3');
     assert.deepEqual(new ConstantNode('3', 'number').toTex(), '3');

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -246,11 +246,9 @@ describe('FunctionAssignmentNode', function() {
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    var expr = allMath.parse('f(x)=x+1');
+    var expr = math.parse('f(x)=x+1');
     assert.equal(expr.toString({parenthesis: 'all'}), 'function f(x) = (x + 1)');
-    assert.equal(expr.toTex(), '\\mathrm{f}\\left(x\\right):=\\left( x+1\\right)');
+    assert.equal(expr.toTex({parenthesis: 'all'}), '\\mathrm{f}\\left(x\\right):=\\left( x+1\\right)');
   });
 
   it ('should stringify a FunctionAssignmentNode', function () {
@@ -316,14 +314,14 @@ describe('FunctionAssignmentNode', function() {
 
   it ('should LaTeX a FunctionAssignmentNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'FunctionAssignmentNode') {
         var latex = '\\mbox{' + node.name + '}\\left(';
         node.params.forEach(function (param) {
           latex += param + ', ';
         });
 
-        latex += '\\right)=' + node.expr.toTex(config, callback);
+        latex += '\\right)=' + node.expr.toTex(options);
         return latex;
       }
       else if (node.type === 'ConstantNode') {
@@ -335,7 +333,7 @@ describe('FunctionAssignmentNode', function() {
 
     var n = new FunctionAssignmentNode('func', ['x'], a);
 
-    assert.equal(n.toTex({}, customFunction), '\\mbox{func}\\left(x, \\right)=const\\left(1, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), '\\mbox{func}\\left(x, \\right)=const\\left(1, number\\right)');
   });
 
 });

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -271,6 +271,30 @@ describe('FunctionAssignmentNode', function() {
     assert.equal(n.toString(), 'function f(x) = (a = 2)');
   });
 
+  it ('should stringify a FunctionAssignmentNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'FunctionAssignmentNode') {
+        var string = '[' + node.name + '](';
+        node.params.forEach(function (param) {
+          string += param + ', ';
+        });
+
+        string += ')=' + node.expr.toString(config, callback);
+        return string;
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+
+    var n = new FunctionAssignmentNode('func', ['x'], a);
+
+    assert.equal(n.toString({}, customFunction), '[func](x, )=const(1, number)');
+  });
+
   it ('should LaTeX a FunctionAssignmentNode', function() {
     var a = new ConstantNode(2);
     var x = new SymbolNode('x');

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -249,7 +249,7 @@ describe('FunctionAssignmentNode', function() {
     var allMath = math.create({parenthesis: 'all'});
 
     var expr = allMath.parse('f(x)=x+1');
-    assert.equal(expr.toString(), 'function f(x) = (x + 1)');
+    assert.equal(expr.toString({parenthesis: 'all'}), 'function f(x) = (x + 1)');
     assert.equal(expr.toTex(), '\\mathrm{f}\\left(x\\right):=\\left( x+1\\right)');
   });
 
@@ -273,14 +273,14 @@ describe('FunctionAssignmentNode', function() {
 
   it ('should stringify a FunctionAssignmentNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'FunctionAssignmentNode') {
         var string = '[' + node.name + '](';
         node.params.forEach(function (param) {
           string += param + ', ';
         });
 
-        string += ')=' + node.expr.toString(config, callback);
+        string += ')=' + node.expr.toString(options);
         return string;
       }
       else if (node.type === 'ConstantNode') {
@@ -292,7 +292,7 @@ describe('FunctionAssignmentNode', function() {
 
     var n = new FunctionAssignmentNode('func', ['x'], a);
 
-    assert.equal(n.toString({}, customFunction), '[func](x, )=const(1, number)');
+    assert.equal(n.toString({handler: customFunction}), '[func](x, )=const(1, number)');
   });
 
   it ('should LaTeX a FunctionAssignmentNode', function() {

--- a/test/expression/node/FunctionAssignmentNode.test.js
+++ b/test/expression/node/FunctionAssignmentNode.test.js
@@ -292,14 +292,14 @@ describe('FunctionAssignmentNode', function() {
 
   it ('should LaTeX a FunctionAssignmentNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'FunctionAssignmentNode') {
         var latex = '\\mbox{' + node.name + '}\\left(';
         node.params.forEach(function (param) {
           latex += param + ', ';
         });
 
-        latex += '\\right)=' + node.expr.toTex(callback);
+        latex += '\\right)=' + node.expr.toTex(config, callback);
         return latex;
       }
       else if (node.type === 'ConstantNode') {
@@ -311,7 +311,7 @@ describe('FunctionAssignmentNode', function() {
 
     var n = new FunctionAssignmentNode('func', ['x'], a);
 
-    assert.equal(n.toTex(customFunction), '\\mbox{func}\\left(x, \\right)=const\\left(1, number\\right)');
+    assert.equal(n.toTex({}, customFunction), '\\mbox{func}\\left(x, \\right)=const\\left(1, number\\right)');
   });
 
 });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -271,6 +271,50 @@ describe('FunctionNode', function() {
     assert.equal(n.toString(), 'sqrt(4)');
   });
 
+  it ('should stringify a FunctionNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'FunctionNode') {
+        var string = '[' + node.name + '](';
+        node.args.forEach(function (arg) {
+          string += arg.toString(config, callback) + ', ';
+        });
+        string += ')';
+        return string;
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n1 = new FunctionNode('add', [a, b]);
+    var n2 = new FunctionNode('subtract', [a, b]);
+
+    assert.equal(n1.toString({}, customFunction), '[add](const(1, number), const(2, number), )');
+    assert.equal(n2.toString({}, customFunction), '[subtract](const(1, number), const(2, number), )');
+  });
+
+  it ('should stringify a FunctionNode with custom toString for a single function', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = {
+      'add': function (node, config, callbacks) {
+        return node.args[0].toString(config, callbacks) 
+          + ' ' + node.name + ' ' 
+          + node.args[1].toString(config, callbacks);
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new FunctionNode('add', [a, b]);
+
+    assert.equal(n.toString({}, customFunction), '1 add 2');
+  });
+
   it ('should LaTeX a FunctionNode', function () {
     var c1 = new ConstantNode(4);
     var c2 = new ConstantNode(5);

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -296,11 +296,11 @@ describe('FunctionNode', function() {
 
   it ('should LaTeX a FunctionNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'FunctionNode') {
         var latex = '\\mbox{' + node.name + '}\\left(';
         node.args.forEach(function (arg) {
-          latex += arg.toTex(callback) + ', ';
+          latex += arg.toTex(config, callback) + ', ';
         });
         latex += '\\right)';
         return latex;
@@ -316,17 +316,17 @@ describe('FunctionNode', function() {
     var n1 = new FunctionNode('add', [a, b]);
     var n2 = new FunctionNode('subtract', [a, b]);
 
-    assert.equal(n1.toTex(customFunction), '\\mbox{add}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
-    assert.equal(n2.toTex(customFunction), '\\mbox{subtract}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
+    assert.equal(n1.toTex({}, customFunction), '\\mbox{add}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
+    assert.equal(n2.toTex({}, customFunction), '\\mbox{subtract}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
   });
 
   it ('should LaTeX a FunctionNode with custom toTex for a single function', function () {
     //Also checks if the custom functions get passed on to the children
     var customFunction = {
-      'add': function (node, callbacks) {
-        return node.args[0].toTex(callbacks) 
+      'add': function (node, config, callbacks) {
+        return node.args[0].toTex(config, callbacks) 
           + ' ' + node.name + ' ' 
-          + node.args[1].toTex(callbacks);
+          + node.args[1].toTex(config, callbacks);
       }
     };
 
@@ -335,7 +335,7 @@ describe('FunctionNode', function() {
 
     var n = new FunctionNode('add', [a, b]);
 
-    assert.equal(n.toTex(customFunction), '1 add 2');
+    assert.equal(n.toTex({}, customFunction), '1 add 2');
   });
 
 });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -340,11 +340,11 @@ describe('FunctionNode', function() {
 
   it ('should LaTeX a FunctionNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'FunctionNode') {
         var latex = '\\mbox{' + node.name + '}\\left(';
         node.args.forEach(function (arg) {
-          latex += arg.toTex(config, callback) + ', ';
+          latex += arg.toTex(options) + ', ';
         });
         latex += '\\right)';
         return latex;
@@ -360,17 +360,17 @@ describe('FunctionNode', function() {
     var n1 = new FunctionNode('add', [a, b]);
     var n2 = new FunctionNode('subtract', [a, b]);
 
-    assert.equal(n1.toTex({}, customFunction), '\\mbox{add}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
-    assert.equal(n2.toTex({}, customFunction), '\\mbox{subtract}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
+    assert.equal(n1.toTex({handler: customFunction}), '\\mbox{add}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
+    assert.equal(n2.toTex({handler: customFunction}), '\\mbox{subtract}\\left(const\\left(1, number\\right), const\\left(2, number\\right), \\right)');
   });
 
   it ('should LaTeX a FunctionNode with custom toTex for a single function', function () {
     //Also checks if the custom functions get passed on to the children
     var customFunction = {
-      'add': function (node, config, callbacks) {
-        return node.args[0].toTex(config, callbacks) 
+      'add': function (node, options) {
+        return node.args[0].toTex(options) 
           + ' ' + node.name + ' ' 
-          + node.args[1].toTex(config, callbacks);
+          + node.args[1].toTex(options);
       }
     };
 
@@ -379,7 +379,7 @@ describe('FunctionNode', function() {
 
     var n = new FunctionNode('add', [a, b]);
 
-    assert.equal(n.toTex({}, customFunction), '1 add 2');
+    assert.equal(n.toTex({handler: customFunction}), '1 add 2');
   });
 
 });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -273,11 +273,11 @@ describe('FunctionNode', function() {
 
   it ('should stringify a FunctionNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'FunctionNode') {
         var string = '[' + node.name + '](';
         node.args.forEach(function (arg) {
-          string += arg.toString(config, callback) + ', ';
+          string += arg.toString(options) + ', ';
         });
         string += ')';
         return string;
@@ -293,17 +293,17 @@ describe('FunctionNode', function() {
     var n1 = new FunctionNode('add', [a, b]);
     var n2 = new FunctionNode('subtract', [a, b]);
 
-    assert.equal(n1.toString({}, customFunction), '[add](const(1, number), const(2, number), )');
-    assert.equal(n2.toString({}, customFunction), '[subtract](const(1, number), const(2, number), )');
+    assert.equal(n1.toString({handler: customFunction}), '[add](const(1, number), const(2, number), )');
+    assert.equal(n2.toString({handler: customFunction}), '[subtract](const(1, number), const(2, number), )');
   });
 
   it ('should stringify a FunctionNode with custom toString for a single function', function () {
     //Also checks if the custom functions get passed on to the children
     var customFunction = {
-      'add': function (node, config, callbacks) {
-        return node.args[0].toString(config, callbacks) 
+      'add': function (node, options) {
+        return node.args[0].toString(options) 
           + ' ' + node.name + ' ' 
-          + node.args[1].toString(config, callbacks);
+          + node.args[1].toString(options);
       }
     };
 
@@ -312,7 +312,7 @@ describe('FunctionNode', function() {
 
     var n = new FunctionNode('add', [a, b]);
 
-    assert.equal(n.toString({}, customFunction), '1 add 2');
+    assert.equal(n.toString({handler: customFunction}), '1 add 2');
   });
 
   it ('should LaTeX a FunctionNode', function () {

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -277,6 +277,31 @@ describe('IndexNode', function() {
     assert.equal(n2.toString(), 'a[]')
   });
 
+  it ('should stringigy an IndexNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'IndexNode') {
+        var string = node.object.toString(config, callback) + ' at ';
+        node.ranges.forEach(function (range) {
+          string += range.toTex(config, callback) + ', ';
+        });
+
+        return string;
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new SymbolNode('a');
+    var b = new ConstantNode(1);
+    var c = new ConstantNode(2);
+
+    var n = new IndexNode(a, [b, c]);
+
+    assert.equal(n.toString({}, customFunction), 'a at const(1, number), const(2, number), ');
+  });
+
   it ('should LaTeX an IndexNode', function () {
     var a = new SymbolNode('a');
     var ranges = [

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -293,11 +293,11 @@ describe('IndexNode', function() {
 
   it ('should LaTeX an IndexNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'IndexNode') {
-        var latex = node.object.toTex(callback) + ' at ';
+        var latex = node.object.toTex(config, callback) + ' at ';
         node.ranges.forEach(function (range) {
-          latex += range.toTex(callback) + ', ';
+          latex += range.toTex(config, callback) + ', ';
         });
 
         return latex;
@@ -313,7 +313,7 @@ describe('IndexNode', function() {
 
     var n = new IndexNode(a, [b, c]);
 
-    assert.equal(n.toTex(customFunction), ' a at const\\left(1, number\\right), const\\left(2, number\\right), ');
+    assert.equal(n.toTex({}, customFunction), ' a at const\\left(1, number\\right), const\\left(2, number\\right), ');
   });
 
 });

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -318,11 +318,11 @@ describe('IndexNode', function() {
 
   it ('should LaTeX an IndexNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'IndexNode') {
-        var latex = node.object.toTex(config, callback) + ' at ';
+        var latex = node.object.toTex(options) + ' at ';
         node.ranges.forEach(function (range) {
-          latex += range.toTex(config, callback) + ', ';
+          latex += range.toTex(options) + ', ';
         });
 
         return latex;
@@ -338,7 +338,7 @@ describe('IndexNode', function() {
 
     var n = new IndexNode(a, [b, c]);
 
-    assert.equal(n.toTex({}, customFunction), ' a at const\\left(1, number\\right), const\\left(2, number\\right), ');
+    assert.equal(n.toTex({handler: customFunction}), ' a at const\\left(1, number\\right), const\\left(2, number\\right), ');
   });
 
 });

--- a/test/expression/node/IndexNode.test.js
+++ b/test/expression/node/IndexNode.test.js
@@ -279,11 +279,11 @@ describe('IndexNode', function() {
 
   it ('should stringigy an IndexNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'IndexNode') {
-        var string = node.object.toString(config, callback) + ' at ';
+        var string = node.object.toString(options) + ' at ';
         node.ranges.forEach(function (range) {
-          string += range.toTex(config, callback) + ', ';
+          string += range.toString(options) + ', ';
         });
 
         return string;
@@ -299,7 +299,7 @@ describe('IndexNode', function() {
 
     var n = new IndexNode(a, [b, c]);
 
-    assert.equal(n.toString({}, customFunction), 'a at const(1, number), const(2, number), ');
+    assert.equal(n.toString({handler: customFunction}), 'a at const(1, number), const(2, number), ');
   });
 
   it ('should LaTeX an IndexNode', function () {

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -82,6 +82,23 @@ describe('Node', function() {
     }, /_toTex not implemented for Node/);
   });
 
+  it ('should ignore custom toString if it returns nothing', function () {
+    var callback1 = function (node, callback) {};
+    var callback2 = {
+      bla: function (node, callbacks) {}
+    };
+    var mymath = math.create();
+    mymath.expression.node.Node.prototype._toString = function () {
+      return 'default';
+    };
+    var n1 = new mymath.expression.node.Node();
+    var n2 = new mymath.expression.node.FunctionNode('bla', []);
+    
+    assert.equal(n1.toString(callback1), 'default');
+    assert.equal(n2.toString(callback2), 'bla()');
+  });
+
+
   it ('should ignore custom toTex if it returns nothing', function () {
     var callback1 = function (node, callback) {};
     var callback2 = {

--- a/test/expression/node/Node.test.js
+++ b/test/expression/node/Node.test.js
@@ -68,18 +68,18 @@ describe('Node', function() {
     }, /Cannot clone a Node interface/);
   });
 
-  it ('should stringify a Node', function () {
-    var node = new Node();
-    assert.equal(node.toString(), '');
+  it ('should throw an error when stringifying a Node interface', function () {
+    assert.throws(function () {
+      var node = new Node();
+      node.toString();
+    }, /_toString not implemented for Node/);
   });
 
   it ('should throw an error when calling _toTex', function () {
     assert.throws(function () {
       var node = new Node();
-      node.type = 'SpecialNode';  //this is necessary because toTex
-                                  //returns '' for a Node
       node._toTex();
-    }, /_toTex not implemented for SpecialNode/);
+    }, /_toTex not implemented for Node/);
   });
 
   it ('should ignore custom toTex if it returns nothing', function () {

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -235,38 +235,32 @@ describe('OperatorNode', function() {
     });
 
     it ('should stringify left associative OperatorNodes that are associative with another Node', function () {
-      var autoMath = math.create({parenthesis: 'auto'});
+      assert.equal(math.parse('(a+b)+c').toString({parenthesis: 'auto'}), 'a + b + c');
+      assert.equal(math.parse('a+(b+c)').toString({parenthesis: 'auto'}), 'a + b + c');
+      assert.equal(math.parse('(a+b)-c').toString({parenthesis: 'auto'}), 'a + b - c');
+      assert.equal(math.parse('a+(b-c)').toString({parenthesis: 'auto'}), 'a + b - c');
 
-      assert.equal(autoMath.parse('(a+b)+c').toString(), 'a + b + c');
-      assert.equal(autoMath.parse('a+(b+c)').toString(), 'a + b + c');
-      assert.equal(autoMath.parse('(a+b)-c').toString(), 'a + b - c');
-      assert.equal(autoMath.parse('a+(b-c)').toString(), 'a + b - c');
-
-      assert.equal(autoMath.parse('(a*b)*c').toString(), 'a * b * c');
-      assert.equal(autoMath.parse('a*(b*c)').toString(), 'a * b * c');
-      assert.equal(autoMath.parse('(a*b)/c').toString(), 'a * b / c');
-      assert.equal(autoMath.parse('a*(b/c)').toString(), 'a * b / c');
+      assert.equal(math.parse('(a*b)*c').toString({parenthesis: 'auto'}), 'a * b * c');
+      assert.equal(math.parse('a*(b*c)').toString({parenthesis: 'auto'}), 'a * b * c');
+      assert.equal(math.parse('(a*b)/c').toString({parenthesis: 'auto'}), 'a * b / c');
+      assert.equal(math.parse('a*(b/c)').toString({parenthesis: 'auto'}), 'a * b / c');
     });
 
     it ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
-      var autoMath = math.create({parenthesis: 'auto'});
+      assert.equal(math.parse('(a-b)-c').toString({parenthesis: 'auto'}), 'a - b - c');
+      assert.equal(math.parse('a-(b-c)').toString({parenthesis: 'auto'}), 'a - (b - c)');
+      assert.equal(math.parse('(a-b)+c').toString({parenthesis: 'auto'}), 'a - b + c');
+      assert.equal(math.parse('a-(b+c)').toString({parenthesis: 'auto'}), 'a - (b + c)');
 
-      assert.equal(autoMath.parse('(a-b)-c').toString(), 'a - b - c');
-      assert.equal(autoMath.parse('a-(b-c)').toString(), 'a - (b - c)');
-      assert.equal(autoMath.parse('(a-b)+c').toString(), 'a - b + c');
-      assert.equal(autoMath.parse('a-(b+c)').toString(), 'a - (b + c)');
-
-      assert.equal(autoMath.parse('(a/b)/c').toString(), 'a / b / c');
-      assert.equal(autoMath.parse('a/(b/c)').toString(), 'a / (b / c)');
-      assert.equal(autoMath.parse('(a/b)*c').toString(), 'a / b * c');
-      assert.equal(autoMath.parse('a/(b*c)').toString(), 'a / (b * c)');
+      assert.equal(math.parse('(a/b)/c').toString({parenthesis: 'auto'}), 'a / b / c');
+      assert.equal(math.parse('a/(b/c)').toString({parenthesis: 'auto'}), 'a / (b / c)');
+      assert.equal(math.parse('(a/b)*c').toString({parenthesis: 'auto'}), 'a / b * c');
+      assert.equal(math.parse('a/(b*c)').toString({parenthesis: 'auto'}), 'a / (b * c)');
     });
 
     it ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
-      var autoMath = math.create({parenthesis: 'auto'});
-
-      assert.equal(autoMath.parse('(a^b)^c').toString(), '(a ^ b) ^ c');
-      assert.equal(autoMath.parse('a^(b^c)').toString(), 'a ^ b ^ c');
+      assert.equal(math.parse('(a^b)^c').toString({parenthesis: 'auto'}), '(a ^ b) ^ c');
+      assert.equal(math.parse('a^(b^c)').toString({parenthesis: 'auto'}), 'a ^ b ^ c');
     });
 
     it ('should stringify unary OperatorNodes containing a binary OperatorNode', function () {
@@ -276,21 +270,19 @@ describe('OperatorNode', function() {
     });
 
     it ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
-      var autoMath = math.create({parenthesis: 'auto'});
-
-      assert.equal(autoMath.parse('(-a)!').toString(), '(-a)!');
-      assert.equal(autoMath.parse('-(a!)').toString(), '-a!');
-      assert.equal(autoMath.parse('-(-a)').toString(), '-(-a)');
+      assert.equal(math.parse('(-a)!').toString({parenthesis: 'auto'}), '(-a)!');
+      assert.equal(math.parse('-(a!)').toString({parenthesis: 'auto'}), '-a!');
+      assert.equal(math.parse('-(-a)').toString({parenthesis: 'auto'}), '-(-a)');
     });
   });
 
   it ('should stringify an OperatorNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'OperatorNode') {
         return node.op + node.fn + '(' 
-          + node.args[0].toString(config, callback)
-          + ', ' +  node.args[1].toString(config, callback) + ')';
+          + node.args[0].toString(options)
+          + ', ' +  node.args[1].toString(options) + ')';
       }
       else if (node.type === 'ConstantNode') {
         return 'const(' + node.value + ', ' + node.valueType + ')'
@@ -303,17 +295,17 @@ describe('OperatorNode', function() {
     var n1 = new OperatorNode('+', 'add', [a, b]);
 	var n2 = new OperatorNode('-', 'subtract', [a, b]);
 
-    assert.equal(n1.toString({}, customFunction), '+add(const(1, number), const(2, number))');
-    assert.equal(n2.toString({}, customFunction), '-subtract(const(1, number), const(2, number))');
+    assert.equal(n1.toString({handler: customFunction}), '+add(const(1, number), const(2, number))');
+    assert.equal(n2.toString({handler: customFunction}), '-subtract(const(1, number), const(2, number))');
   });
 
   it ('should stringify an OperatorNode with custom toString for a single operator', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
-        return node.args[0].toString(config, callback)
+        return node.args[0].toString(options)
           + node.op + node.fn + node.op + 
-          node.args[1].toString(config, callback);
+          node.args[1].toString(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const(' + node.value + ', ' + node.valueType + ')'
@@ -325,13 +317,13 @@ describe('OperatorNode', function() {
 
     var n = new OperatorNode('+', 'add', [a, b]);
 
-    assert.equal(n.toString({}, customFunction), 'const(1, number)+add+const(2, number)');
+    assert.equal(n.toString({handler: customFunction}), 'const(1, number)+add+const(2, number)');
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
     var allMath = math.create({parenthesis: 'all'});
 
-    assert.equal(allMath.parse('1+1+1').toString(), '(1 + 1) + 1' );
+    assert.equal(allMath.parse('1+1+1').toString({parenthesis: 'all'}), '(1 + 1) + 1' );
     assert.equal(allMath.parse('1+1+1').toTex(), '\\left(1+1\\right)+1' );
   });
 

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -416,11 +416,11 @@ describe('OperatorNode', function() {
 
   it ('should LaTeX an OperatorNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'OperatorNode') {
         return node.op + node.fn + '(' 
-          + node.args[0].toTex(callback)
-          + ', ' +  node.args[1].toTex(callback) + ')';
+          + node.args[0].toTex(config, callback)
+          + ', ' +  node.args[1].toTex(config, callback) + ')';
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -433,17 +433,17 @@ describe('OperatorNode', function() {
     var n1 = new OperatorNode('+', 'add', [a, b]);
 	var n2 = new OperatorNode('-', 'subtract', [a, b]);
 
-    assert.equal(n1.toTex(customFunction), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
-    assert.equal(n2.toTex(customFunction), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
+    assert.equal(n1.toTex({}, customFunction), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
+    assert.equal(n2.toTex({}, customFunction), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
   });
 
   it ('should LaTeX an OperatorNode with custom toTex for a single operator', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
-        return node.args[0].toTex(callback)
+        return node.args[0].toTex(config, callback)
           + node.op + node.fn + node.op + 
-          node.args[1].toTex(callback);
+          node.args[1].toTex(config, callback);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -455,7 +455,7 @@ describe('OperatorNode', function() {
 
     var n = new OperatorNode('+', 'add', [a, b]);
 
-    assert.equal(n.toTex(customFunction), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
+    assert.equal(n.toTex({}, customFunction), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
   });
 
   it ('should LaTeX powers of fractions with parentheses', function () {

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -321,16 +321,12 @@ describe('OperatorNode', function() {
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    assert.equal(allMath.parse('1+1+1').toString({parenthesis: 'all'}), '(1 + 1) + 1' );
-    assert.equal(allMath.parse('1+1+1').toTex(), '\\left(1+1\\right)+1' );
+    assert.equal(math.parse('1+1+1').toString({parenthesis: 'all'}), '(1 + 1) + 1' );
+    assert.equal(math.parse('1+1+1').toTex({parenthesis: 'all'}), '\\left(1+1\\right)+1' );
   });
 
   it ('should correctly LaTeX fractions in \'all\' parenthesis mode', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    assert.equal(allMath.parse('1/2/3').toTex(), '\\frac{\\left(\\frac{1}{2}\\right)}{3}');
+    assert.equal(math.parse('1/2/3').toTex({parenthesis: 'all'}), '\\frac{\\left(\\frac{1}{2}\\right)}{3}');
   });
 
   it ('should LaTeX an OperatorNode', function () {
@@ -452,11 +448,11 @@ describe('OperatorNode', function() {
 
   it ('should LaTeX an OperatorNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'OperatorNode') {
         return node.op + node.fn + '(' 
-          + node.args[0].toTex(config, callback)
-          + ', ' +  node.args[1].toTex(config, callback) + ')';
+          + node.args[0].toTex(options)
+          + ', ' +  node.args[1].toTex(options) + ')';
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -469,17 +465,17 @@ describe('OperatorNode', function() {
     var n1 = new OperatorNode('+', 'add', [a, b]);
 	var n2 = new OperatorNode('-', 'subtract', [a, b]);
 
-    assert.equal(n1.toTex({}, customFunction), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
-    assert.equal(n2.toTex({}, customFunction), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
+    assert.equal(n1.toTex({handler: customFunction}), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
+    assert.equal(n2.toTex({handler: customFunction}), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
   });
 
   it ('should LaTeX an OperatorNode with custom toTex for a single operator', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
-        return node.args[0].toTex(config, callback)
+        return node.args[0].toTex(options)
           + node.op + node.fn + node.op + 
-          node.args[1].toTex(config, callback);
+          node.args[1].toTex(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -491,7 +487,7 @@ describe('OperatorNode', function() {
 
     var n = new OperatorNode('+', 'add', [a, b]);
 
-    assert.equal(n.toTex({}, customFunction), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
   });
 
   it ('should LaTeX powers of fractions with parentheses', function () {
@@ -511,10 +507,8 @@ describe('OperatorNode', function() {
   });
 
   it ('should LaTeX simple expressions in \'auto\' mode', function () {
-    var autoMath = math.create({parenthesis: 'auto'});
-
     //this covers a bug that was triggered previously
-    assert.equal(autoMath.parse('1+(1+1)').toTex(), '1+1+1');
+    assert.equal(math.parse('1+(1+1)').toTex({parenthesis: 'auto'}), '1+1+1');
   });
 
 });

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -284,6 +284,50 @@ describe('OperatorNode', function() {
     });
   });
 
+  it ('should stringify an OperatorNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'OperatorNode') {
+        return node.op + node.fn + '(' 
+          + node.args[0].toString(config, callback)
+          + ', ' +  node.args[1].toString(config, callback) + ')';
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n1 = new OperatorNode('+', 'add', [a, b]);
+	var n2 = new OperatorNode('-', 'subtract', [a, b]);
+
+    assert.equal(n1.toString({}, customFunction), '+add(const(1, number), const(2, number))');
+    assert.equal(n2.toString({}, customFunction), '-subtract(const(1, number), const(2, number))');
+  });
+
+  it ('should stringify an OperatorNode with custom toString for a single operator', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
+        return node.args[0].toString(config, callback)
+          + node.op + node.fn + node.op + 
+          node.args[1].toString(config, callback);
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    assert.equal(n.toString({}, customFunction), 'const(1, number)+add+const(2, number)');
+  });
+
   it ('should respect the \'all\' parenthesis option', function () {
     var allMath = math.create({parenthesis: 'all'});
 

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -145,6 +145,19 @@ describe('ParenthesisNode', function() {
     assert.equal(autoP.toString(), '1');
   });
 
+  it ('should stringify a ParenthesisNode with custom toString', function () {
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'ParenthesisNode') {
+        return '[' + node.content.toString(config, callback) + ']';
+      }
+    };
+
+    var c = new math.expression.node.ConstantNode(1);
+    var n = new math.expression.node.ParenthesisNode(c);
+
+    assert.equal(n.toString({}, customFunction), '[1]');
+  });
+
   it ('should LaTeX a ParenthesisNode', function () {
     var a = new ConstantNode(1);
     var n = new ParenthesisNode(a);
@@ -164,5 +177,18 @@ describe('ParenthesisNode', function() {
 
     assert.equal(allP.toTex(), '1');
     assert.equal(autoP.toTex(), '1');
+  });
+
+  it ('should LaTeX a ParenthesisNode with custom toTex', function () {
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'ParenthesisNode') {
+        return '\\left[' + node.content.toTex(config, callback) + '\\right]';
+      }
+    };
+
+    var c = new math.expression.node.ConstantNode(1);
+    var n = new math.expression.node.ParenthesisNode(c);
+
+    assert.equal(n.toTex({}, customFunction), '\\left[1\\right]');
   });
 });

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -132,30 +132,25 @@ describe('ParenthesisNode', function() {
   });
 
   it ('should stringify a ParenthesisNode when not in keep mode', function () {
-    var allMath = math.create({parenthesis: 'all'});
-    var autoMath = math.create({parenthesis: 'auto'});
+    var c = new math.expression.node.ConstantNode(1);
 
-    var allC = new allMath.expression.node.ConstantNode(1);
-    var autoC = new autoMath.expression.node.ConstantNode(1);
+    var p = new math.expression.node.ParenthesisNode(c);
 
-    var allP = new allMath.expression.node.ParenthesisNode(allC);
-    var autoP = new autoMath.expression.node.ParenthesisNode(autoC);
-
-    assert.equal(allP.toString(), '1');
-    assert.equal(autoP.toString(), '1');
+    assert.equal(p.toString({parenthesis: 'all'}), '1');
+    assert.equal(p.toString({parenthesis: 'auto'}), '1');
   });
 
   it ('should stringify a ParenthesisNode with custom toString', function () {
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ParenthesisNode') {
-        return '[' + node.content.toString(config, callback) + ']';
+        return '[' + node.content.toString(options) + ']';
       }
     };
 
     var c = new math.expression.node.ConstantNode(1);
     var n = new math.expression.node.ParenthesisNode(c);
 
-    assert.equal(n.toString({}, customFunction), '[1]');
+    assert.equal(n.toString({handler: customFunction}), '[1]');
   });
 
   it ('should LaTeX a ParenthesisNode', function () {

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -161,29 +161,24 @@ describe('ParenthesisNode', function() {
   });
 
   it ('should LaTeX a ParenthesisNode when not in keep mode', function () {
-    var allMath = math.create({parenthesis: 'all'});
-    var autoMath = math.create({parenthesis: 'auto'});
+    var c = new math.expression.node.ConstantNode(1);
 
-    var allC = new allMath.expression.node.ConstantNode(1);
-    var autoC = new autoMath.expression.node.ConstantNode(1);
+    var p = new math.expression.node.ParenthesisNode(c);
 
-    var allP = new allMath.expression.node.ParenthesisNode(allC);
-    var autoP = new autoMath.expression.node.ParenthesisNode(autoC);
-
-    assert.equal(allP.toTex(), '1');
-    assert.equal(autoP.toTex(), '1');
+    assert.equal(p.toTex({parenthesis: 'all'}), '1');
+    assert.equal(p.toTex({parenthesis: 'auto'}), '1');
   });
 
   it ('should LaTeX a ParenthesisNode with custom toTex', function () {
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'ParenthesisNode') {
-        return '\\left[' + node.content.toTex(config, callback) + '\\right]';
+        return '\\left[' + node.content.toTex(options) + '\\right]';
       }
     };
 
     var c = new math.expression.node.ConstantNode(1);
     var n = new math.expression.node.ParenthesisNode(c);
 
-    assert.equal(n.toTex({}, customFunction), '\\left[1\\right]');
+    assert.equal(n.toTex({handler: customFunction}), '\\left[1\\right]');
   });
 });

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -303,10 +303,8 @@ describe('RangeNode', function() {
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    assert.equal(allMath.parse('1:2:3').toString({parenthesis: 'all'}), '(1):(2):(3)');
-    assert.equal(allMath.parse('1:2:3').toTex(), '\\left(1\\right):\\left(2\\right):\\left(3\\right)');
+    assert.equal(math.parse('1:2:3').toString({parenthesis: 'all'}), '(1):(2):(3)');
+    assert.equal(math.parse('1:2:3').toTex({parenthesis: 'all'}), '\\left(1\\right):\\left(2\\right):\\left(3\\right)');
   });
 
   it ('should LaTeX a RangeNode without step', function () {
@@ -328,11 +326,11 @@ describe('RangeNode', function() {
 
   it ('should LaTeX a RangeNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'RangeNode') {
-        return 'from ' + node.start.toTex(config, callback)
-          + ' to ' + node.end.toTex(config, callback)
-          + ' with steps of ' + node.step.toTex(config, callback);
+        return 'from ' + node.start.toTex(options)
+          + ' to ' + node.end.toTex(options)
+          + ' with steps of ' + node.step.toTex(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -345,7 +343,7 @@ describe('RangeNode', function() {
 
     var n = new RangeNode(a, b, c);
 
-    assert.equal(n.toTex({}, customFunction), 'from const\\left(1, number\\right) to const\\left(2, number\\right) with steps of const\\left(3, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), 'from const\\left(1, number\\right) to const\\left(2, number\\right) with steps of const\\left(3, number\\right)');
   });
 
 });

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -306,11 +306,11 @@ describe('RangeNode', function() {
 
   it ('should LaTeX a RangeNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'RangeNode') {
-        return 'from ' + node.start.toTex(callback)
-          + ' to ' + node.end.toTex(callback)
-          + ' with steps of ' + node.step.toTex(callback);
+        return 'from ' + node.start.toTex(config, callback)
+          + ' to ' + node.end.toTex(config, callback)
+          + ' with steps of ' + node.step.toTex(config, callback);
       }
       else if (node.type === 'ConstantNode') {
         return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
@@ -323,7 +323,7 @@ describe('RangeNode', function() {
 
     var n = new RangeNode(a, b, c);
 
-    assert.equal(n.toTex(customFunction), 'from const\\left(1, number\\right) to const\\left(2, number\\right) with steps of const\\left(3, number\\right)');
+    assert.equal(n.toTex({}, customFunction), 'from const\\left(1, number\\right) to const\\left(2, number\\right) with steps of const\\left(3, number\\right)');
   });
 
 });

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -282,11 +282,11 @@ describe('RangeNode', function() {
 
   it ('should stringify a RangeNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'RangeNode') {
-        return 'from ' + node.start.toString(config, callback)
-          + ' to ' + node.end.toString(config, callback)
-          + ' with steps of ' + node.step.toString(config, callback);
+        return 'from ' + node.start.toString(options)
+          + ' to ' + node.end.toString(options)
+          + ' with steps of ' + node.step.toString(options);
       }
       else if (node.type === 'ConstantNode') {
         return 'const(' + node.value + ', ' + node.valueType + ')'
@@ -299,13 +299,13 @@ describe('RangeNode', function() {
 
     var n = new RangeNode(a, b, c);
 
-    assert.equal(n.toString({}, customFunction), 'from const(1, number) to const(2, number) with steps of const(3, number)');
+    assert.equal(n.toString({handler: customFunction}), 'from const(1, number) to const(2, number) with steps of const(3, number)');
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
     var allMath = math.create({parenthesis: 'all'});
 
-    assert.equal(allMath.parse('1:2:3').toString(), '(1):(2):(3)');
+    assert.equal(allMath.parse('1:2:3').toString({parenthesis: 'all'}), '(1):(2):(3)');
     assert.equal(allMath.parse('1:2:3').toTex(), '\\left(1\\right):\\left(2\\right):\\left(3\\right)');
   });
 

--- a/test/expression/node/RangeNode.test.js
+++ b/test/expression/node/RangeNode.test.js
@@ -280,6 +280,28 @@ describe('RangeNode', function() {
     assert.equal(n.toString(), '(0:10):2:100');
   });
 
+  it ('should stringify a RangeNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'RangeNode') {
+        return 'from ' + node.start.toString(config, callback)
+          + ' to ' + node.end.toString(config, callback)
+          + ' with steps of ' + node.step.toString(config, callback);
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(3);
+
+    var n = new RangeNode(a, b, c);
+
+    assert.equal(n.toString({}, customFunction), 'from const(1, number) to const(2, number) with steps of const(3, number)');
+  });
+
   it ('should respect the \'all\' parenthesis option', function () {
     var allMath = math.create({parenthesis: 'all'});
 

--- a/test/expression/node/SymbolNode.test.js
+++ b/test/expression/node/SymbolNode.test.js
@@ -128,7 +128,7 @@ describe('SymbolNode', function() {
 
   it ('should LaTeX a SymbolNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'SymbolNode') {
         return 'symbol(' + node.name + ')';
       }
@@ -136,7 +136,7 @@ describe('SymbolNode', function() {
 
     var n = new SymbolNode('a');
 
-    assert.equal(n.toTex({}, customFunction), 'symbol(a)');
+    assert.equal(n.toTex({handler: customFunction}), 'symbol(a)');
   });
 
   it ('should LaTeX a SymbolNode without breaking \\cdot', function () {

--- a/test/expression/node/SymbolNode.test.js
+++ b/test/expression/node/SymbolNode.test.js
@@ -109,7 +109,7 @@ describe('SymbolNode', function() {
 
   it ('should stringigy a SymbolNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'SymbolNode') {
         return 'symbol(' + node.name + ')';
       }
@@ -117,7 +117,7 @@ describe('SymbolNode', function() {
 
     var n = new SymbolNode('a');
 
-    assert.equal(n.toString({}, customFunction), 'symbol(a)');
+    assert.equal(n.toString({handler: customFunction}), 'symbol(a)');
   });
 
   it ('should LaTeX a SymbolNode', function () {

--- a/test/expression/node/SymbolNode.test.js
+++ b/test/expression/node/SymbolNode.test.js
@@ -115,7 +115,7 @@ describe('SymbolNode', function() {
 
   it ('should LaTeX a SymbolNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'SymbolNode') {
         return 'symbol(' + node.name + ')';
       }
@@ -123,7 +123,7 @@ describe('SymbolNode', function() {
 
     var n = new SymbolNode('a');
 
-    assert.equal(n.toTex(customFunction), 'symbol(a)');
+    assert.equal(n.toTex({}, customFunction), 'symbol(a)');
   });
 
   it ('should LaTeX a SymbolNode without breaking \\cdot', function () {

--- a/test/expression/node/SymbolNode.test.js
+++ b/test/expression/node/SymbolNode.test.js
@@ -107,6 +107,19 @@ describe('SymbolNode', function() {
     assert.equal(s.toString(), 'foo');
   });
 
+  it ('should stringigy a SymbolNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'SymbolNode') {
+        return 'symbol(' + node.name + ')';
+      }
+    };
+
+    var n = new SymbolNode('a');
+
+    assert.equal(n.toString({}, customFunction), 'symbol(a)');
+  });
+
   it ('should LaTeX a SymbolNode', function () {
     var s = new SymbolNode('foo');
 

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -322,10 +322,8 @@ describe('UpdateNode', function() {
   });
 
   it ('should respect the \'all\' parenthesis option', function () {
-    var allMath = math.create({parenthesis: 'all'});
-
-    assert.equal(allMath.parse('a[1]=2').toString({parenthesis: 'all'}), 'a[1] = (2)' );
-    assert.equal(allMath.parse('a[1]=2').toTex(), ' a_{1}:=\\left(2\\right)' );
+    assert.equal(math.parse('a[1]=2').toString({parenthesis: 'all'}), 'a[1] = (2)' );
+    assert.equal(math.parse('a[1]=2').toTex({parenthesis: 'all'}), ' a_{1}:=\\left(2\\right)' );
   });
 
   it ('should LaTeX an UpdateNode', function () {
@@ -372,14 +370,14 @@ describe('UpdateNode', function() {
 
   it ('should LaTeX an UpdateNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'UpdateNode') {
-        return node.index.toTex(config, callback) + ' equals ' + node.expr.toTex(config, callback);
+        return node.index.toTex(options) + ' equals ' + node.expr.toTex(options);
       }
       else if (node.type === 'IndexNode') {
-        var latex = node.object.toTex(config, callback) + ' at ';
+        var latex = node.object.toTex(options) + ' at ';
         node.ranges.forEach(function (range) {
-          latex += range.toTex(config, callback) + ', ';
+          latex += range.toTex(options) + ', ';
         });
         return latex;
       }
@@ -397,7 +395,7 @@ describe('UpdateNode', function() {
 
     var n = new UpdateNode(new IndexNode(a, ranges), v);
 
-    assert.equal(n.toTex({}, customFunction), ' a at const\\left(2, number\\right), const\\left(1, number\\right),  equals const\\left(5, number\\right)');
+    assert.equal(n.toTex({handler: customFunction}), ' a at const\\left(2, number\\right), const\\left(1, number\\right),  equals const\\left(5, number\\right)');
   });
 
 });

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -340,6 +340,36 @@ describe('UpdateNode', function() {
     assert.equal(n.toTex(), ' a_{2,1}:=5');
   });
 
+  it ('should stringify an UpdateNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, config, callback) {
+      if (node.type === 'UpdateNode') {
+        return node.index.toString(config, callback) + ' equals ' + node.expr.toString(config, callback);
+      }
+      else if (node.type === 'IndexNode') {
+        var string = node.object.toString(config, callback) + ' at ';
+        node.ranges.forEach(function (range) {
+          string += range.toTex(config, callback) + ', ';
+        });
+        return string;
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new SymbolNode('a');
+    var ranges = [
+      new ConstantNode(2),
+      new ConstantNode(1)
+    ];
+    var v = new ConstantNode(5);
+
+    var n = new UpdateNode(new IndexNode(a, ranges), v);
+
+    assert.equal(n.toString({}, customFunction), 'a at const(2, number), const(1, number),  equals const(5, number)');
+  });
+
   it ('should LaTeX an UpdateNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
     var customFunction = function (node, config, callback) {

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -324,7 +324,7 @@ describe('UpdateNode', function() {
   it ('should respect the \'all\' parenthesis option', function () {
     var allMath = math.create({parenthesis: 'all'});
 
-    assert.equal(allMath.parse('a[1]=2').toString(), 'a[1] = (2)' );
+    assert.equal(allMath.parse('a[1]=2').toString({parenthesis: 'all'}), 'a[1] = (2)' );
     assert.equal(allMath.parse('a[1]=2').toTex(), ' a_{1}:=\\left(2\\right)' );
   });
 
@@ -342,14 +342,14 @@ describe('UpdateNode', function() {
 
   it ('should stringify an UpdateNode with custom toString', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, config, callback) {
+    var customFunction = function (node, options) {
       if (node.type === 'UpdateNode') {
-        return node.index.toString(config, callback) + ' equals ' + node.expr.toString(config, callback);
+        return node.index.toString(options) + ' equals ' + node.expr.toString(options);
       }
       else if (node.type === 'IndexNode') {
-        var string = node.object.toString(config, callback) + ' at ';
+        var string = node.object.toString(options) + ' at ';
         node.ranges.forEach(function (range) {
-          string += range.toTex(config, callback) + ', ';
+          string += range.toString(options) + ', ';
         });
         return string;
       }
@@ -367,7 +367,7 @@ describe('UpdateNode', function() {
 
     var n = new UpdateNode(new IndexNode(a, ranges), v);
 
-    assert.equal(n.toString({}, customFunction), 'a at const(2, number), const(1, number),  equals const(5, number)');
+    assert.equal(n.toString({handler: customFunction}), 'a at const(2, number), const(1, number),  equals const(5, number)');
   });
 
   it ('should LaTeX an UpdateNode with custom toTex', function () {

--- a/test/expression/node/UpdateNode.test.js
+++ b/test/expression/node/UpdateNode.test.js
@@ -342,14 +342,14 @@ describe('UpdateNode', function() {
 
   it ('should LaTeX an UpdateNode with custom toTex', function () {
     //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, callback) {
+    var customFunction = function (node, config, callback) {
       if (node.type === 'UpdateNode') {
-        return node.index.toTex(callback) + ' equals ' + node.expr.toTex(callback);
+        return node.index.toTex(config, callback) + ' equals ' + node.expr.toTex(config, callback);
       }
       else if (node.type === 'IndexNode') {
-        var latex = node.object.toTex(callback) + ' at ';
+        var latex = node.object.toTex(config, callback) + ' at ';
         node.ranges.forEach(function (range) {
-          latex += range.toTex(callback) + ', ';
+          latex += range.toTex(config, callback) + ', ';
         });
         return latex;
       }
@@ -367,7 +367,7 @@ describe('UpdateNode', function() {
 
     var n = new UpdateNode(new IndexNode(a, ranges), v);
 
-    assert.equal(n.toTex(customFunction), ' a at const\\left(2, number\\right), const\\left(1, number\\right),  equals const\\left(5, number\\right)');
+    assert.equal(n.toTex({}, customFunction), ' a at const\\left(2, number\\right), const\\left(1, number\\right),  equals const\\left(5, number\\right)');
   });
 
 });

--- a/test/expression/operators.test.js
+++ b/test/expression/operators.test.js
@@ -8,8 +8,6 @@ var ConstantNode = math.expression.node.ConstantNode;
 var Node = math.expression.node.Node;
 var ParenthesisNode = math.expression.node.ParenthesisNode;
 
-var config = {parenthesis: 'keep'};
-
 describe('operators', function () {
   it('should return the precedence of a node', function () {
     var a = new ConstantNode(1);
@@ -18,14 +16,14 @@ describe('operators', function () {
     var n1 = new AssignmentNode('a', a);
     var n2 = new OperatorNode('or', 'or', [a, b]);
 
-    assert.equal(operators.getPrecedence(n1, config), 0);
-    assert.equal(operators.getPrecedence(n2, config), 2);
+    assert.equal(operators.getPrecedence(n1, 'keep'), 0);
+    assert.equal(operators.getPrecedence(n2, 'keep'), 2);
   });
 
   it('should return null if precedence is not defined for a node', function () {
     var n = new Node();
 
-    assert.equal(operators.getPrecedence(n, config), null);
+    assert.equal(operators.getPrecedence(n, 'keep'), null);
   });
 
   it ('should return the precedence of a ParenthesisNode', function () {
@@ -35,9 +33,9 @@ describe('operators', function () {
 
     var p = new ParenthesisNode(op);
 
-    assert.equal(operators.getPrecedence(p, {parenthesis: 'all'}), operators.getPrecedence(op, config));
-    assert.equal(operators.getPrecedence(p, {parenthesis: 'auto'}), operators.getPrecedence(op, config));
-    assert.equal(operators.getPrecedence(p, config), null);
+    assert.equal(operators.getPrecedence(p, 'all'), operators.getPrecedence(op, 'all'));
+    assert.equal(operators.getPrecedence(p, 'auto'), operators.getPrecedence(op, 'all'));
+    assert.equal(operators.getPrecedence(p, 'keep'), null);
   });
 
   it('should return the associativity of a node', function () {
@@ -48,10 +46,10 @@ describe('operators', function () {
     var n3 = new OperatorNode('-', 'unaryMinus', [a]);
     var n4 = new OperatorNode('!', 'factorial', [a]);
 
-    assert.equal(operators.getAssociativity(n1, config), 'left');
-    assert.equal(operators.getAssociativity(n2, config), 'right');
-    assert.equal(operators.getAssociativity(n3, config), 'right');
-    assert.equal(operators.getAssociativity(n4, config), 'left');
+    assert.equal(operators.getAssociativity(n1, 'keep'), 'left');
+    assert.equal(operators.getAssociativity(n2, 'keep'), 'right');
+    assert.equal(operators.getAssociativity(n3, 'keep'), 'right');
+    assert.equal(operators.getAssociativity(n4, 'keep'), 'left');
   });
 
   it ('should return the associativity of a ParenthesisNode', function () {
@@ -61,9 +59,9 @@ describe('operators', function () {
 
     var p = new ParenthesisNode(op);
 
-    assert.equal(operators.getAssociativity(p, {parenthesis: 'all'}), operators.getAssociativity(op, config));
-    assert.equal(operators.getAssociativity(p, {parenthesis: 'auto'}), operators.getAssociativity(op, config));
-    assert.equal(operators.getAssociativity(p, config), null);
+    assert.equal(operators.getAssociativity(p, 'all'), operators.getAssociativity(op, 'keep'));
+    assert.equal(operators.getAssociativity(p, 'auto'), operators.getAssociativity(op, 'keep'));
+    assert.equal(operators.getAssociativity(p, 'keep'), null);
   });
 
   it('should return null if associativity is not defined for a node', function () {
@@ -72,8 +70,8 @@ describe('operators', function () {
     var n1 = new Node();
     var n2 = new AssignmentNode('a', a);
 
-    assert.equal(operators.getAssociativity(n1, config), null);
-    assert.equal(operators.getAssociativity(n2, config), null);
+    assert.equal(operators.getAssociativity(n1, 'keep'), null);
+    assert.equal(operators.getAssociativity(n2, 'keep'), null);
   });
 
   it('should return if a Node is associative with another Node', function () {
@@ -82,10 +80,10 @@ describe('operators', function () {
     var n1 = new OperatorNode('+', 'add', [a, a]);
     var n2 = new OperatorNode('-', 'subtract', [a, a]);
 
-    assert.equal(operators.isAssociativeWith(n1, n1, config), true);
-    assert.equal(operators.isAssociativeWith(n1, n2, config), true);
-    assert.equal(operators.isAssociativeWith(n2, n2, config), false);
-    assert.equal(operators.isAssociativeWith(n2, n1, config), false);
+    assert.equal(operators.isAssociativeWith(n1, n1, 'keep'), true);
+    assert.equal(operators.isAssociativeWith(n1, n2, 'keep'), true);
+    assert.equal(operators.isAssociativeWith(n2, n2, 'keep'), false);
+    assert.equal(operators.isAssociativeWith(n2, n1, 'keep'), false);
   });
 
   it('should return null if the associativity between two Nodes is not defined', function () {
@@ -94,10 +92,10 @@ describe('operators', function () {
     var n1 = new Node();
     var n2 = new AssignmentNode('a', a);
 
-    assert.equal(operators.isAssociativeWith(n1, n1, config), null);
-    assert.equal(operators.isAssociativeWith(n1, n2, config), null);
-    assert.equal(operators.isAssociativeWith(n2, n2, config), null);
-    assert.equal(operators.isAssociativeWith(n2, n1, config), null);
+    assert.equal(operators.isAssociativeWith(n1, n1, 'keep'), null);
+    assert.equal(operators.isAssociativeWith(n1, n2, 'keep'), null);
+    assert.equal(operators.isAssociativeWith(n2, n2, 'keep'), null);
+    assert.equal(operators.isAssociativeWith(n2, n1, 'keep'), null);
   });
 
   it ('should return if a ParenthesisNode is associative with another Node', function () {
@@ -108,8 +106,8 @@ describe('operators', function () {
 
     var p = new ParenthesisNode(add);
 
-    assert.equal(operators.isAssociativeWith(p, sub, {parenthesis: 'all'}), true);
-    assert.equal(operators.isAssociativeWith(p, sub, {parenthesis: 'auto'}), true);
-    assert.equal(operators.isAssociativeWith(p, sub, config), null);
+    assert.equal(operators.isAssociativeWith(p, sub, 'all'), true);
+    assert.equal(operators.isAssociativeWith(p, sub, 'auto'), true);
+    assert.equal(operators.isAssociativeWith(p, sub, 'keep'), null);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,6 @@ describe('factory', function() {
       number: 'number',
       precision: 64,
       epsilon: 1e-14,
-      parenthesis: 'keep'
     });
   });
 
@@ -26,8 +25,7 @@ describe('factory', function() {
       matrix: 'array',
       number: 'bignumber',
       precision: 64,
-      epsilon: 1e-14,
-      parenthesis: 'keep'
+      epsilon: 1e-14
     });
   });
 
@@ -59,23 +57,6 @@ describe('factory', function() {
       number: 'number',
       precision: 64,
       epsilon: 1e-14,
-      parenthesis: 'keep'
-    });
-
-    math1.config({
-      matrix: 'array',
-      number: 'bignumber',
-      precision: 32,
-      epsilon: 1e-7,
-      parenthesis: 'auto'
-    });
-
-    assert.deepEqual(math1.config(), {
-      matrix: 'array',
-      number: 'bignumber',
-      precision: 32,
-      epsilon: 1e-7,
-      parenthesis: 'auto'
     });
 
     // restore the original config


### PR DESCRIPTION
As mentioned in my last pull request, this adds the possibility to pass configuration directly to `toString` and `toTex` and enables callbacks for `toString` like they are already available for `toTex`.

The configuration will be merged with the global configuration.

This is the last API breaking change, so I won't be blocking v2 any longer. The next thing to come is the possibility to attach `toString` and `toTex` callbacks to imported functions, but that's not API breaking any more, only extending.

**Update:**
I will still be changing the LaTeX output though, but this shouldn't be considered part of the API.