### PR TITLE
Replaced the sort in median and quantileSeq with a partition-based selection function

### DIFF
--- a/lib/function/statistics/median.js
+++ b/lib/function/statistics/median.js
@@ -45,7 +45,7 @@ module.exports = function (math) {
     if (isCollection(args)) {
       if (arguments.length == 1) {
         // median([a, b, c, d, ...])
-        return _median(args.valueOf());
+        return _median(args.valueOf(), false);
       }
       else if (arguments.length == 2) {
         // median([a, b, c, d, ...], dim)
@@ -59,20 +59,23 @@ module.exports = function (math) {
     }
     else {
       // median(a, b, c, d, ...)
-      return _median(Array.prototype.slice.call(arguments));
+      var argArr = new Array(arguments.length);
+      for (var i = 0; i < argArr.length; ++i) {
+        argArr[i] = arguments[i];
+      }
+      return _median(argArr, true);
     }
   };
 
   /**
    * Recursively calculate the median of an n-dimensional array
    * @param {Array} array
+   * @param {Boolean} isFlat
    * @return {Number} median
    * @private
    */
-  function _median(array) {
-    var flat = flatten(array);
-
-    flat.sort(math.compare);
+  function _median(array, isFlat) {
+    var flat = isFlat ? array : flatten(array);
 
     var num = flat.length;
 
@@ -82,8 +85,16 @@ module.exports = function (math) {
 
     if (num % 2 == 0) {
       // even: return the average of the two middle values
-      var left = flat[num / 2 - 1];
-      var right = flat[num / 2];
+      var mid = num / 2 - 1;
+      var right = math.partitionSelect(flat, mid + 1);
+
+      // flat is now partitioned at mid + 1, take max of left part
+      var left = flat[mid];
+      for (var i = 0; i < mid; ++i) {
+        if (math.compare(flat[i], left) > 0) {
+          left = flat[i];
+        }
+      }
 
       if (!isNumber(left) && !(left instanceof BigNumber) && !(left instanceof Unit)) {
         throw new math.error.UnsupportedTypeError('median', math['typeof'](left));
@@ -96,7 +107,7 @@ module.exports = function (math) {
     }
     else {
       // odd: return the middle value
-      var middle = flat[(num - 1) / 2];
+      var middle = math.partitionSelect(flat, (num - 1) / 2);
 
       if (!isNumber(middle) && !(middle instanceof BigNumber) && !(middle instanceof Unit)) {
         throw new math.error.UnsupportedTypeError('median', math['typeof'](middle));

--- a/lib/function/statistics/quantileSeq.js
+++ b/lib/function/statistics/quantileSeq.js
@@ -104,9 +104,14 @@ module.exports = function (math) {
               throw new Error('N must be a positive integer');
             }
 
+            // largest possible Array length is 2^32-1;
+            // 2^32 < 10^15, thus safe conversion guaranteed
             var intN = probOrN.toNumber();
-            var nPlusOne = new BigNumber(intN + 1);
+            if (intN > 4294967295) {
+              throw new Error('N must be less than or equal to 2^32-1, as that is the maximum length of an Array');
+            }
 
+            var nPlusOne = new BigNumber(intN + 1);
             probArr = new Array(intN);
             for (var i = 0; i < intN;) {
               probArr[i] = _quantileSeq(dataArr, new BigNumber(++i).div(nPlusOne), sorted);
@@ -116,7 +121,7 @@ module.exports = function (math) {
         }
 
         if (isArray(probOrN)) {
-          // quantileSeq([a, b, c, d, ...], [prob][,sorted])
+          // quantileSeq([a, b, c, d, ...], [prob1, prob2, ...][,sorted])
           probArr = new Array(probOrN.length);
           for (var i = 0; i < probArr.length; ++i) {
             var currProb = probOrN[i];
@@ -163,15 +168,11 @@ module.exports = function (math) {
       throw new Error('Cannot calculate quantile of an empty sequence');
     }
 
-    if (!sorted) {
-      flat.sort(math.compare);
-    }
-
     if (isNumber(prob)) {
       var index = prob * (len-1);
       var fracPart = index % 1;
       if (fracPart === 0) {
-        var value = flat[index];
+        var value = sorted ? flat[index] : math.partitionSelect(flat, index);
 
         typecheck(value);
 
@@ -179,18 +180,34 @@ module.exports = function (math) {
       }
 
       var integerPart = Math.floor(index);
-      var left = flat[integerPart];
-      var right = flat[integerPart+1];
+
+      var left, right;
+      if (sorted) {
+        left = flat[integerPart];
+        right = flat[integerPart+1];
+      } else {
+        right = math.partitionSelect(flat, integerPart+1);
+
+        // max of partition is kth largest
+        left = flat[integerPart];
+        for (var i = 0; i < integerPart; ++i) {
+          if (math.compare(flat[i], left) > 0) {
+            left = flat[i];
+          }
+        }
+      }
 
       typecheck(left, right);
 
+      // Q(prob) = (1-f)*A[floor(index)] + f*A[floor(index)+1]
       return add(multiply(left, 1 - fracPart), multiply(right, fracPart));
     }
 
     // If prob is a BigNumber
     var index = prob.times(len-1);
     if (index.isInteger()) {
-      var value = flat[index.toNumber()];
+      index = index.toNumber();
+      var value = sorted ? flat[index] : math.partitionSelect(flat, index);
 
       typecheck(value);
 
@@ -199,13 +216,27 @@ module.exports = function (math) {
 
     var integerPart = index.floor();
     var fracPart = index.minus(integerPart);
-
     var integerPartNumber = integerPart.toNumber();
-    var left = flat[integerPartNumber];
-    var right = flat[integerPartNumber+1];
+
+    var left, right;
+    if (sorted) {
+      left = flat[integerPartNumber];
+      right = flat[integerPartNumber+1];
+    } else {
+      right = math.partitionSelect(flat, integerPartNumber+1);
+
+      // max of partition is kth largest
+      left = flat[integerPartNumber];
+      for (var i = 0; i < integerPartNumber; ++i) {
+        if (math.compare(flat[i], left) > 0) {
+          left = flat[i];
+        }
+      }
+    }
 
     typecheck(left, right);
 
+    // Q(prob) = (1-f)*A[floor(index)] + f*A[floor(index)+1]
     var one = fracPart.constructor.ONE;
     return add(multiply(left, one.minus(fracPart)), multiply(right, fracPart));
   }


### PR DESCRIPTION
This brings the average case down to *O(n)* from *O(nlogn)*.

Also, removed the flatted call in `median` for a sequence (still needed for an Array or Matrix input), and added a few more comments in `quantileSeq`.