### PR TITLE
Attach 'toTex' to functions

### DIFF
--- a/docs/expressions/customization.md
+++ b/docs/expressions/customization.md
@@ -140,6 +140,46 @@ math.eval('myFunction(2 + 3, sqrt(4))');
 // returns 'arguments: 2 + 3, sqrt(4), evaluated: 5, 2'
 ```
 
+## Attaching LaTeX handlers to functions
+
+You can attach a `toTex` property to your custom functions before importing them to define their LaTeX output. This
+`toTex` property can be a handler in the format described in the next section 'Custom LaTeX and String conversion'
+or a template string similar to ES6 templates.
+
+### Template syntax
+* `${name}`: Get's replaced by the name of the function
+* `${args}`: Get's replaced by a comma separated list of the arguments of the function.
+* `${args[0]}`: Get's replaced by the first argument of a function
+* `$$`: Get's replaced by `$`
+
+#### Example
+
+```js
+var customFunctions = {
+  plus: function (a, b) {
+    return a + b;
+  },
+  minus: function (a, b) {
+    return a - b;
+  },
+  binom: function (n, k) {
+    return 1;
+  }
+};
+
+customFunctions.plus.toTex = '${args[0]}+${args[1]}'; //template string
+customFunctions.binom.toTex = '\\mathrm{${name}}\\left(${args}\\right)'; //template string
+customFunctions.minus.toTex = function (node, options) { //handler function
+  return node.args[0].toTex(options) + node.name + node.args[1].toTex(options);
+};
+
+math.import(customFunctions);
+
+math.parse('plus(1,2)').toTex();    //'1+2'
+math.parse('binom(1,2)').toTex();   // '\\mathrm{binom}\\left(1,2\\right)'
+math.parse('minus(1,2)').toTex();   // '1minus2'
+```
+
 ## Custom LaTeX and String conversion
 
 You can pass the `toTex` and `toString` functions an object to change their behaviour. This object is of the following form:
@@ -161,6 +201,7 @@ There's two ways of passing callbacks:
 1. Pass an object that maps function names to callbacks. Those callbacks will be used for FunctionNodes with 
 functions of that name.
 2. Pass a function to `toTex`. This function will then be used for every node.
+
 ```js
 var expression = math.parse('(1+1+1)');
 

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -145,6 +145,34 @@ function factory (type, config, load, typed, math) {
     return this.name + '(' + this.args.join(', ') + ')';
   };
 
+  /* Return the latex output for a given function
+   * TODO: Make use of the different parenthesis options
+   * @private
+   */
+  function latexToFunction(node, options) {
+    var latexConverter = latex.functions[node.name];
+    var args = node.args.map(function (arg) { //get LaTeX of the arguments
+      return arg.toTex(options);
+    });
+
+    switch (typeof latexConverter) {
+      case 'function': //a callback function
+        return latexConverter(node, options);
+      case 'string': //a template string
+        return latex.expandTemplate(latexConverter, node.name, args);
+      case 'object': //an object with different "converters" for different numbers of arguments
+        switch (typeof latexConverter[args.length]) {
+          case 'function':
+            return latexConverter[args.length](node, options);
+          case 'string':
+            return latex.expandTemplate(latexConverter[args.length], node.name, args);
+        }
+        //no break here! That's intentional.
+      default:
+        return latex.expandTemplate(latex.defaultTemplate, node.name, args);
+    }
+  }
+
   //backup Node's toTex function
   //@private
   var nodeToTex = FunctionNode.prototype.toTex;
@@ -186,7 +214,7 @@ function factory (type, config, load, typed, math) {
    */
   FunctionNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    return latex.toFunction(this, options, this.name);
+    return latexToFunction(this, options, this.name);
   };
 
   /**

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -145,6 +145,34 @@ function factory (type, config, load, typed, math) {
     return this.name + '(' + this.args.join(', ') + ')';
   };
 
+  /*
+   * Expand a LaTeX template
+   *
+   * @param {string} template
+   * @param {string} name of the function
+   * @param {Array} arguments of the function ( Strings )
+   * @private
+   **/
+  function expandTemplate(template, name, args) {
+    //replace %name% with the variable 'name'
+    template = template.replace(/%name%/g, name);
+
+    //replace %0%, %1% .... with the arguments in args
+    args.forEach(function (arg, index) {
+      template = template.replace(RegExp('%' + index + '%', 'g'), arg);
+    });
+
+    //replace %*% with a comma separated list of all arguments
+    template = template.replace('%*%', args.map(function (arg) {
+        return arg;
+      }).join(','));
+
+    //replace %% with %, this comes in handy when you need a % in your LaTeX string
+    template = template.replace('%%', '%');
+
+    return template;
+  }
+
   /* Return the latex output for a given function
    * TODO: Make use of the different parenthesis options
    * @private
@@ -159,17 +187,17 @@ function factory (type, config, load, typed, math) {
       case 'function': //a callback function
         return latexConverter(node, options);
       case 'string': //a template string
-        return latex.expandTemplate(latexConverter, node.name, args);
+        return expandTemplate(latexConverter, node.name, args);
       case 'object': //an object with different "converters" for different numbers of arguments
         switch (typeof latexConverter[args.length]) {
           case 'function':
             return latexConverter[args.length](node, options);
           case 'string':
-            return latex.expandTemplate(latexConverter[args.length], node.name, args);
+            return expandTemplate(latexConverter[args.length], node.name, args);
         }
         //no break here! That's intentional.
       default:
-        return latex.expandTemplate(latex.defaultTemplate, node.name, args);
+        return expandTemplate(latex.defaultTemplate, node.name, args);
     }
   }
 

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -218,7 +218,7 @@ function factory (type, config, load, typed, math) {
 
     var latexConverter;
 
-    if (math[this.name] && (typeof math[this.name].toTex === 'function')) {
+    if (math[this.name] && ((typeof math[this.name].toTex === 'function') || (typeof math[this.name].toTex === 'object') || (typeof math[this.name].toTex === 'string'))) {
       //.toTex is a callback function
       latexConverter = math[this.name].toTex;
     }

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -173,34 +173,6 @@ function factory (type, config, load, typed, math) {
     return template;
   }
 
-  /* Return the latex output for a given function
-   * TODO: Make use of the different parenthesis options
-   * @private
-   */
-  function latexToFunction(node, options) {
-    var latexConverter = latex.functions[node.name];
-    var args = node.args.map(function (arg) { //get LaTeX of the arguments
-      return arg.toTex(options);
-    });
-
-    switch (typeof latexConverter) {
-      case 'function': //a callback function
-        return latexConverter(node, options);
-      case 'string': //a template string
-        return expandTemplate(latexConverter, node.name, args);
-      case 'object': //an object with different "converters" for different numbers of arguments
-        switch (typeof latexConverter[args.length]) {
-          case 'function':
-            return latexConverter[args.length](node, options);
-          case 'string':
-            return expandTemplate(latexConverter[args.length], node.name, args);
-        }
-        //no break here! That's intentional.
-      default:
-        return expandTemplate(latex.defaultTemplate, node.name, args);
-    }
-  }
-
   //backup Node's toTex function
   //@private
   var nodeToTex = FunctionNode.prototype.toTex;
@@ -239,17 +211,45 @@ function factory (type, config, load, typed, math) {
   FunctionNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
 
-    var customToTex;
+
+    var args = this.args.map(function (arg) { //get LaTeX of the arguments
+      return arg.toTex(options);
+    });
+
+    var latexConverter;
+
     if (math[this.name] && (typeof math[this.name].toTex === 'function')) {
       //.toTex is a callback function
-      customToTex = math[this.name].toTex(this, options);
+      latexConverter = math[this.name].toTex;
+    }
+    else {
+      latexConverter = latex.functions[this.name];
+    }
+
+    var customToTex;
+    switch (typeof latexConverter) {
+      case 'function': //a callback function
+        customToTex = latexConverter(this, options);
+        break;
+      case 'string': //a template string
+        customToTex = expandTemplate(latexConverter, this.name, args);
+        break;
+      case 'object': //an object with different "converters" for different numbers of arguments
+        switch (typeof latexConverter[args.length]) {
+          case 'function':
+            customToTex = latexConverter[args.length](this, options);
+            break;
+          case 'string':
+            customToTex = expandTemplate(latexConverter[args.length], this.name, args);
+            break;
+        }
     }
 
     if (typeof customToTex !== 'undefined') {
       return customToTex;
     }
 
-    return latexToFunction(this, options, this.name);
+    return expandTemplate(latex.defaultTemplate, this.name, args);
   };
 
   /**

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -222,10 +222,6 @@ function factory (type, config, load, typed, math) {
       //callback is a map of callback functions
       customTex = options.handler[this.name](this, options);
     }
-    else if (math[this.name] && (typeof math[this.name].toTex === 'function')) {
-      //.toTex is a callback function
-      customTex = math[this.name].toTex(this, options);
-    }
 
     if (typeof customTex !== 'undefined') {
       return customTex;
@@ -242,6 +238,17 @@ function factory (type, config, load, typed, math) {
    */
   FunctionNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+
+    var customToTex;
+    if (math[this.name] && (typeof math[this.name].toTex === 'function')) {
+      //.toTex is a callback function
+      customToTex = math[this.name].toTex(this, options);
+    }
+
+    if (typeof customToTex !== 'undefined') {
+      return customToTex;
+    }
+
     return latexToFunction(this, options, this.name);
   };
 

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -149,28 +149,73 @@ function factory (type, config, load, typed, math) {
    * Expand a LaTeX template
    *
    * @param {string} template
-   * @param {string} name of the function
-   * @param {Array} arguments of the function ( Strings )
+   * @param {Node} node
+   * @param {Object} options
    * @private
    **/
-  function expandTemplate(template, name, args) {
-    //replace %name% with the variable 'name'
-    template = template.replace(/%name%/g, name);
+  function expandTemplate(template, node, options) {
+    var latex = '';
 
-    //replace %0%, %1% .... with the arguments in args
-    args.forEach(function (arg, index) {
-      template = template.replace(RegExp('%' + index + '%', 'g'), arg);
-    });
+    // Match everything of the form ${identifier} or ${identifier[2]} or $$
+    // while submatching identifier and 2 (in the second case)
+    var regex = new RegExp('\\$(?:\\{([a-z_][a-z_0-9]*)(?:\\[([0-9]+)\\])?\\}|\\$)', 'ig');
 
-    //replace %*% with a comma separated list of all arguments
-    template = template.replace('%*%', args.map(function (arg) {
-        return arg;
-      }).join(','));
+    var inputPos = 0;   //position in the input string
+    var match;
+    while ((match = regex.exec(template)) !== null) {   //go through all matches
+      // add everything in front of the match to the LaTeX string
+      latex += template.substring(inputPos, match.index);
+      inputPos = match.index;
 
-    //replace %% with %, this comes in handy when you need a % in your LaTeX string
-    template = template.replace('%%', '%');
+      if (match[0] === '$$') { // escaped dollar sign
+        latex += '$';
+        inputPos++;
+      }
+      else { // template parameter
+        inputPos += match[0].length;
+        var property = node[match[1]];
+        if (!property) {
+          throw new ReferenceError('Template: Property ' + match[1] + ' does not exist.');
+        }
+        if (match[2] === undefined) { //no square brackets
+          switch (typeof property) {
+            case 'string':
+              latex += property;
+              break;
+            case 'object':
+              if (property.isNode) {
+                latex += property.toTex(options);
+              }
+              else if (Array.isArray(property)) {
+                //make array of Nodes into comma separated list
+                latex += property.map(function (arg, index) {
+                  if (arg && arg.isNode) {
+                    return arg.toTex(options);
+                  }
+                  throw new TypeError('Template: ' + match[1] + '[' + index + '] is not a Node.');
+                }).join(',');
+              }
+              else {
+                throw new TypeError('Template: ' + match[1] + ' has to be a Node, String or array of Nodes');
+              }
+              break;
+            default:
+              throw new TypeError('Template: ' + match[1] + ' has to be a Node, String or array of Nodes');
+          }
+        }
+        else { //with square brackets
+          if (property[match[2]] && property[match[2]].isNode) {
+            latex += property[match[2]].toTex(options);
+          }
+          else {
+            throw new TypeError('Template: ' + match[1] + '[' + match[2] + '] is not a Node.');
+          }
+        }
+      }
+    }
+    latex += template.slice(inputPos);  //append rest of the template
 
-    return template;
+    return latex;
   }
 
   //backup Node's toTex function
@@ -232,7 +277,7 @@ function factory (type, config, load, typed, math) {
         customToTex = latexConverter(this, options);
         break;
       case 'string': //a template string
-        customToTex = expandTemplate(latexConverter, this.name, args);
+        customToTex = expandTemplate(latexConverter, this, options);
         break;
       case 'object': //an object with different "converters" for different numbers of arguments
         switch (typeof latexConverter[args.length]) {
@@ -240,7 +285,7 @@ function factory (type, config, load, typed, math) {
             customToTex = latexConverter[args.length](this, options);
             break;
           case 'string':
-            customToTex = expandTemplate(latexConverter[args.length], this.name, args);
+            customToTex = expandTemplate(latexConverter[args.length], this, options);
             break;
         }
     }
@@ -249,7 +294,7 @@ function factory (type, config, load, typed, math) {
       return customToTex;
     }
 
-    return expandTemplate(latex.defaultTemplate, this.name, args);
+    return expandTemplate(latex.defaultTemplate, this, options);
   };
 
   /**

--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -166,6 +166,10 @@ function factory (type, config, load, typed, math) {
       //callback is a map of callback functions
       customTex = options.handler[this.name](this, options);
     }
+    else if (math[this.name] && (typeof math[this.name].toTex === 'function')) {
+      //.toTex is a callback function
+      customTex = math[this.name].toTex(this, options);
+    }
 
     if (typeof customTex !== 'undefined') {
       return customTex;

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -76,33 +76,6 @@ exports.operators = {
 
 exports.defaultTemplate = '\\mathrm{%name%}\\left(%*%\\right)';
 
-/*
- * expand a template
- *
- * @param {string} template
- * @param {string} name of the function
- * @param {Array} arguments of the function ( Strings )
- **/
-exports.expandTemplate = function (template, name, args) {
-  //replace %name% with the variable 'name'
-  template = template.replace(/%name%/g, name);
-
-  //replace %0%, %1% .... with the arguments in args
-  args.forEach(function (arg, index) {
-    template = template.replace(RegExp('%' + index + '%', 'g'), arg);
-  });
-
-  //replace %*% with a comma separated list of all arguments
-  template = template.replace('%*%', args.map(function (arg) {
-      return arg;
-    }).join(','));
-
-  //replace %% with %, this comes in handy when you need a % in your LaTeX string
-  template = template.replace('%%', '%');
-
-  return template;
-}
-
 //this is a map containing all the latex converters for all the functions
 exports.functions = {
   //arithmetic

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -83,7 +83,7 @@ var defaultTemplate = '\\mathrm{%name%}\\left(%*%\\right)';
  * @param {string} name of the function
  * @param {Array} arguments of the function ( Strings )
  **/
-function expandTemplate(template, name, args) {
+exports.expandTemplate = function (template, name, args) {
   //replace %name% with the variable 'name'
   template = template.replace(/%name%/g, name);
 
@@ -344,16 +344,16 @@ exports.toFunction = function (node, options, name) {
     case 'function': //a callback function
       return latexConverter(node, options);
     case 'string': //a template string
-      return expandTemplate(latexConverter, name, args);
+      return exports.expandTemplate(latexConverter, name, args);
     case 'object': //an object with different "converters" for different numbers of arguments
       switch (typeof latexConverter[args.length]) {
         case 'function':
           return latexConverter[args.length](node, options);
         case 'string':
-          return expandTemplate(latexConverter[args.length], name, args);
+          return exports.expandTemplate(latexConverter[args.length], name, args);
       }
       //no break here! That's intentionally
     default:
-      return expandTemplate(defaultTemplate, name, args);
+      return exports.expandTemplate(defaultTemplate, name, args);
   }
 }

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -74,105 +74,105 @@ exports.operators = {
   'or': '\\vee'
 };
 
-exports.defaultTemplate = '\\mathrm{%name%}\\left(%*%\\right)';
+exports.defaultTemplate = '\\mathrm{${name}}\\left(${args}\\right)';
 
 //this is a map containing all the latex converters for all the functions
 exports.functions = {
   //arithmetic
-  'abs': '\\left|%0%\\right|',
-  'add': '\\left(%0%+%1%\\right)',
-  'ceil': '\\left\\lceil%0%\\right\\rceil',
-  'cube': '\\left(%0%\\right)^3',
-  'divide': '\\frac{%0%}{%1%}',
-  'dotDivide': '\\left(%0%' + exports.operators['dotDivide'] + '%1%\\right)',
-  'dotMultiply': '\\left(%0%' + exports.operators['dotMultiply'] + '%1%\\right)',
-  'dotPow': '\\left(%0%' + exports.operators['dotPow'] + '%1%\\right)',
-  'exp': '\\exp\\left(%0%\\right)',
+  'abs': '\\left|${args[0]}\\right|',
+  'add': '\\left(${args[0]}+${args[1]}\\right)',
+  'ceil': '\\left\\lceil${args[0]}\\right\\rceil',
+  'cube': '\\left(${args[0]}\\right)^3',
+  'divide': '\\frac{${args[0]}}{${args[1]}}',
+  'dotDivide': '\\left(${args[0]}' + exports.operators['dotDivide'] + '${args[1]}\\right)',
+  'dotMultiply': '\\left(${args[0]}' + exports.operators['dotMultiply'] + '${args[1]}\\right)',
+  'dotPow': '\\left(${args[0]}' + exports.operators['dotPow'] + '${args[1]}\\right)',
+  'exp': '\\exp\\left(${args[0]}\\right)',
   'fix': exports.defaultTemplate,
-  'floor': '\\left\\lfloor%0%\\right\\rfloor',
-  'gcd': '\\gcd\\left(%*%\\right)',
+  'floor': '\\left\\lfloor${args[0]}\\right\\rfloor',
+  'gcd': '\\gcd\\left(${args}\\right)',
   'lcm': exports.defaultTemplate,
-  'log10': '\\log_{10}\\left(%0%\\right)',
+  'log10': '\\log_{10}\\left(${args[0]}\\right)',
   'log': {
-    1: '\\ln\\left(%0%\\right)',
-    2: '\\log_{%1%}\\left(%0%\\right)'
+    1: '\\ln\\left(${args[0]}\\right)',
+    2: '\\log_{${args[1]}}\\left(${args[0]}\\right)'
   },
-  'mod': '\\left(%0%' + exports.operators['mod'] + '%1%\\right)',
-  'multiply': '\\left(%0%' + exports.operators['multiply'] + '%1%\\right)',
+  'mod': '\\left(${args[0]}' + exports.operators['mod'] + '${args[1]}\\right)',
+  'multiply': '\\left(${args[0]}' + exports.operators['multiply'] + '${args[1]}\\right)',
   'norm': {
-    1: '\\left\\|%0%\\right\\|',
+    1: '\\left\\|${args[0]}\\right\\|',
     2: exports.defaultTemplate
   },
-  'nthRoot': '\\sqrt[%1%]{%0%}',
-  'pow': '\\left(%0%\\right)' + exports.operators['pow'] + '{%1%}',
+  'nthRoot': '\\sqrt[${args[1]}]{${args[0]}}',
+  'pow': '\\left(${args[0]}\\right)' + exports.operators['pow'] + '{${args[1]}}',
   'round': {
-    1: '\\left\\lfloor%0%\\right\\rceil',
+    1: '\\left\\lfloor${args[0]}\\right\\rceil',
     2: exports.defaultTemplate
   },
   'sign': exports.defaultTemplate,
-  'sqrt': '\\sqrt{%0%}',
-  'square': '\\left(%0%\\right)^2',
-  'subtract': '\\left(%0%' + exports.operators['subtract'] + '%1%\\right)',
-  'unaryMinus': exports.operators['unaryMinus'] + '\\left(%0%\\right)',
-  'unaryPlus': exports.operators['unaryPlus'] + '\\left(%0%\\right)',
+  'sqrt': '\\sqrt{${args[0]}}',
+  'square': '\\left(${args[0]}\\right)^2',
+  'subtract': '\\left(${args[0]}' + exports.operators['subtract'] + '${args[1]}\\right)',
+  'unaryMinus': exports.operators['unaryMinus'] + '\\left(${args[0]}\\right)',
+  'unaryPlus': exports.operators['unaryPlus'] + '\\left(${args[0]}\\right)',
   'xgcd': exports.defaultTemplate,
 
   //bitwise
-  'bitAnd': '\\left(%0%' + exports.operators['bitAnd'] + '%1%\\right)',
-  'bitOr': '\\left(%0%' + exports.operators['bitOr'] + '%1%\\right)',
-  'bitXor': '\\left(%0%' + exports.operators['bitXor'] + '%1%\\right)',
-  'bitNot': exports.operators['bitNot'] + '\\left(%0%\\right)',
-  'leftShift': '\\left(%0%' + exports.operators['leftShift'] + '%1%\\right)',
-  'rightArithShift': '\\left(%0%' + exports.operators['rightArithShift'] + '%1%\\right)',
-  'rightLogShift': '\\left(%0%' + exports.operators['rightLogShift'] + '%1%\\right)',
+  'bitAnd': '\\left(${args[0]}' + exports.operators['bitAnd'] + '${args[1]}\\right)',
+  'bitOr': '\\left(${args[0]}' + exports.operators['bitOr'] + '${args[1]}\\right)',
+  'bitXor': '\\left(${args[0]}' + exports.operators['bitXor'] + '${args[1]}\\right)',
+  'bitNot': exports.operators['bitNot'] + '\\left(${args[0]}\\right)',
+  'leftShift': '\\left(${args[0]}' + exports.operators['leftShift'] + '${args[1]}\\right)',
+  'rightArithShift': '\\left(${args[0]}' + exports.operators['rightArithShift'] + '${args[1]}\\right)',
+  'rightLogShift': '\\left(${args[0]}' + exports.operators['rightLogShift'] + '${args[1]}\\right)',
 
   //complex
-  'arg': '\\arg\\left(%0%\\right)',
-  'conj': '\\left(%0%\\right)^*',
-  'im': '\\Im\\left\\lbrace%0%\\right\\rbrace',
-  're': '\\Re\\left\\lbrace%0%\\right\\rbrace',
+  'arg': '\\arg\\left(${args[0]}\\right)',
+  'conj': '\\left(${args[0]}\\right)^*',
+  'im': '\\Im\\left\\lbrace${args[0]}\\right\\rbrace',
+  're': '\\Re\\left\\lbrace${args[0]}\\right\\rbrace',
 
   //combinatorics
-  'stirlingS2': '\\mathrm{S}\\left(%0%,%1%\\right)',
-  'bellNumbers': '\\mathrm{B}_{%0%}',
+  'stirlingS2': '\\mathrm{S}\\left(${args[0]},${args[1]}\\right)',
+  'bellNumbers': '\\mathrm{B}_{${args[0]}}',
   'composition': exports.defaultTemplate,
 
   //construction
   'bignumber': {
     0: '0',
-    1: '\\left(%0%\\right)'
+    1: '\\left(${args[0]}\\right)'
   },
   'boolean': exports.defaultTemplate,
   'chain': exports.defaultTemplate,
   'complex': {
     0: '0',
-    1: '\\left(%0%\\right)',
-    2: '\\left(\\left(%0%\\right)+'
-      + exports.symbols['i'] + '\\cdot\\left(%1%\\right)\\right)',
+    1: '\\left(${args[0]}\\right)',
+    2: '\\left(\\left(${args[0]}\\right)+'
+      + exports.symbols['i'] + '\\cdot\\left(${args[1]}\\right)\\right)',
   },
   'index': exports.defaultTemplate,
   'matrix': {
     0: '\\begin{bmatrix}\\end{bmatrix}',
-    1: '\\left(%0%\\right)',
-    2: '\\left(%0%\\right)'
+    1: '\\left(${args[0]}\\right)',
+    2: '\\left(${args[0]}\\right)'
   },
   'number': {
     0: '0',
-    1: '\\left(%0%\\right)',
-    2: '\\left(\\left(%0%\\right)%1%\\right)'
+    1: '\\left(${args[0]}\\right)',
+    2: '\\left(\\left(${args[0]}\\right)${args[1]}\\right)'
   },
   'parser': exports.defaultTemplate,
   'sparse': {
     0: '\\begin{bsparse}\\end{bsparse}',
-    1: '\\left(%0%\\right)'
+    1: '\\left(${args[0]}\\right)'
   },
   'string': {
     0: '\\mathtt{""}',
-    1: '\\mathrm{string}\\left(%0%\\right)'
+    1: '\\mathrm{string}\\left(${args[0]}\\right)'
   },
   'unit': {
-    1: '\\left(%0%\\right)',
-    2: '\\left(\\left(%0%\\right)%1%\\right)'
+    1: '\\left(${args[0]}\\right)',
+    2: '\\left(\\left(${args[0]}\\right)${args[1]}\\right)'
   },
 
   //expression TODO does the default even work in this case? (.toTex on the args)
@@ -182,35 +182,35 @@ exports.functions = {
   'parse': exports.defaultTemplate,
 
   //logical
-  'and': '\\left(%0%' + exports.operators['and'] + '%1%\\right)',
-  'not': exports.operators['not'] + '\\left(%0%\\right)',
-  'or': '\\left(%0%' + exports.operators['or'] + '%1%\\right)',
-  'xor': '\\left(%0%' + exports.operators['xor'] + '%1%\\right)',
+  'and': '\\left(${args[0]}' + exports.operators['and'] + '${args[1]}\\right)',
+  'not': exports.operators['not'] + '\\left(${args[0]}\\right)',
+  'or': '\\left(${args[0]}' + exports.operators['or'] + '${args[1]}\\right)',
+  'xor': '\\left(${args[0]}' + exports.operators['xor'] + '${args[1]}\\right)',
 
   //matrix
   'concat': exports.defaultTemplate,
-  'cross': '\\left(%0%\\right)\\times\\left(%1%\\right)',
-  'det': '\\det\\left(%0%\\right)',
+  'cross': '\\left(${args[0]}\\right)\\times\\left(${args[1]}\\right)',
+  'det': '\\det\\left(${args[0]}\\right)',
   'diag': exports.defaultTemplate,
-  'dot': '\\left(%0%\\cdot%1%\\right)',
+  'dot': '\\left(${args[0]}\\cdot${args[1]}\\right)',
   'eye': exports.defaultTemplate,
   'flatten': exports.defaultTemplate,
-  'inv': '\\left(%0%\\right)^{-1}',
+  'inv': '\\left(${args[0]}\\right)^{-1}',
   'ones': exports.defaultTemplate,
   'range': exports.defaultTemplate,
   'resize': exports.defaultTemplate,
   'size': exports.defaultTemplate,
   'squeeze': exports.defaultTemplate,
   'subset': exports.defaultTemplate,
-  'trace': '\\mathrm{tr}\\left(%0%\\right)',
-  'transpose': '\\left(%0%\\right)' + exports.operators['transpose'],
+  'trace': '\\mathrm{tr}\\left(${args[0]}\\right)',
+  'transpose': '\\left(${args[0]}\\right)' + exports.operators['transpose'],
   'zeros': exports.defaultTemplate,
 
   //probability
-  'combinations': '\\binom{%0%}{%1%}',
+  'combinations': '\\binom{${args[0]}}{${args[1]}}',
   'distribution': exports.defaultTemplate,
-  'factorial': '\\left(%0%\\right)' + exports.operators['factorial'],
-  'gamma': '\\Gamma\\left(%0%\\right)',
+  'factorial': '\\left(${args[0]}\\right)' + exports.operators['factorial'],
+  'gamma': '\\Gamma\\left(${args[0]}\\right)',
   'permutations': exports.defaultTemplate,
   'pickRandom': exports.defaultTemplate,
   'randomInt': exports.defaultTemplate,
@@ -219,52 +219,52 @@ exports.functions = {
   //relational
   'compare': exports.defaultTemplate,
   'deepEqual': exports.defaultTemplate,
-  'equal': '\\left(%0%' + exports.operators['equal'] + '%1%\\right)',
-  'largerEq': '\\left(%0%' + exports.operators['largerEq'] + '%1%\\right)',
-  'larger': '\\left(%0%' + exports.operators['larger'] + '%1%\\right)',
-  'smallerEq': '\\left(%0%' + exports.operators['smallerEq'] + '%1%\\right)',
-  'smaller': '\\left(%0%' + exports.operators['smaller'] + '%1%\\right)',
-  'unequal': '\\left(%0%' + exports.operators['unequal'] + '%1%\\right)',
+  'equal': '\\left(${args[0]}' + exports.operators['equal'] + '${args[1]}\\right)',
+  'largerEq': '\\left(${args[0]}' + exports.operators['largerEq'] + '${args[1]}\\right)',
+  'larger': '\\left(${args[0]}' + exports.operators['larger'] + '${args[1]}\\right)',
+  'smallerEq': '\\left(${args[0]}' + exports.operators['smallerEq'] + '${args[1]}\\right)',
+  'smaller': '\\left(${args[0]}' + exports.operators['smaller'] + '${args[1]}\\right)',
+  'unequal': '\\left(${args[0]}' + exports.operators['unequal'] + '${args[1]}\\right)',
 
   //statistics
-  'max': '\\max\\left(%*%\\right)',
+  'max': '\\max\\left(${args}\\right)',
   'mean': exports.defaultTemplate,
   'median': exports.defaultTemplate,
-  'min': '\\min\\left(%*%\\right)',
+  'min': '\\min\\left(${args}\\right)',
   'prod': exports.defaultTemplate,
   'std': exports.defaultTemplate,
   'sum': exports.defaultTemplate,
-  'var': '\\mathrm{Var}\\left(%*%\\right)',
+  'var': '\\mathrm{Var}\\left(${args}\\right)',
 
   //trigonometry
-  'acosh': '\\cosh^{-1}\\left(%0%\\right)',
-  'acos': '\\cos^{-1}\\left(%0%\\right)',
-  'acoth': '\\coth^{-1}\\left(%0%\\right)',
-  'acot': '\\cot^{-1}\\left(%0%\\right)',
-  'acsch': '\\mathrm{csch}^{-1}\\left(%0%\\right)',
-  'acsc': '\\csc^{-1}\\left(%0%\\right)',
-  'asech': '\\mathrm{sech}^{-1}\\left(%0%\\right)',
-  'asec': '\\sec^{-1}\\left(%0%\\right)',
-  'asinh': '\\sinh^{-1}\\left(%0%\\right)',
-  'asin': '\\sin^{-1}\\left(%0%\\right)',
-  'atan2': '\\mathrm{atan2}\\left(%*%\\right)',
-  'atanh': '\\tanh^{-1}\\left(%0%\\right)',
-  'atan': '\\tan^{-1}\\left(%0%\\right)',
-  'cosh': '\\cosh\\left(%0%\\right)',
-  'cos': '\\cos\\left(%0%\\right)',
-  'coth': '\\coth\\left(%0%\\right)',
-  'cot': '\\cot\\left(%0%\\right)',
-  'csch': '\\mathrm{csch}\\left(%0%\\right)',
-  'csc': '\\csc\\left(%0%\\right)',
-  'sech': '\\mathrm{sech}\\left(%0%\\right)',
-  'sec': '\\sec\\left(%0%\\right)',
-  'sinh': '\\sinh\\left(%0%\\right)',
-  'sin': '\\sin\\left(%0%\\right)',
-  'tanh': '\\tanh\\left(%0%\\right)',
-  'tan': '\\tan\\left(%0%\\right)',
+  'acosh': '\\cosh^{-1}\\left(${args[0]}\\right)',
+  'acos': '\\cos^{-1}\\left(${args[0]}\\right)',
+  'acoth': '\\coth^{-1}\\left(${args[0]}\\right)',
+  'acot': '\\cot^{-1}\\left(${args[0]}\\right)',
+  'acsch': '\\mathrm{csch}^{-1}\\left(${args[0]}\\right)',
+  'acsc': '\\csc^{-1}\\left(${args[0]}\\right)',
+  'asech': '\\mathrm{sech}^{-1}\\left(${args[0]}\\right)',
+  'asec': '\\sec^{-1}\\left(${args[0]}\\right)',
+  'asinh': '\\sinh^{-1}\\left(${args[0]}\\right)',
+  'asin': '\\sin^{-1}\\left(${args[0]}\\right)',
+  'atan2': '\\mathrm{atan2}\\left(${args}\\right)',
+  'atanh': '\\tanh^{-1}\\left(${args[0]}\\right)',
+  'atan': '\\tan^{-1}\\left(${args[0]}\\right)',
+  'cosh': '\\cosh\\left(${args[0]}\\right)',
+  'cos': '\\cos\\left(${args[0]}\\right)',
+  'coth': '\\coth\\left(${args[0]}\\right)',
+  'cot': '\\cot\\left(${args[0]}\\right)',
+  'csch': '\\mathrm{csch}\\left(${args[0]}\\right)',
+  'csc': '\\csc\\left(${args[0]}\\right)',
+  'sech': '\\mathrm{sech}\\left(${args[0]}\\right)',
+  'sec': '\\sec\\left(${args[0]}\\right)',
+  'sinh': '\\sinh\\left(${args[0]}\\right)',
+  'sin': '\\sin\\left(${args[0]}\\right)',
+  'tanh': '\\tanh\\left(${args[0]}\\right)',
+  'tan': '\\tan\\left(${args[0]}\\right)',
 
   //units
-  'to': '\\left(%0%' + exports.operators['to'] + '%1%\\right)',
+  'to': '\\left(${args[0]}' + exports.operators['to'] + '${args[1]}\\right)',
 
   //utils
   'clone': exports.defaultTemplate,

--- a/lib/util/latex.js
+++ b/lib/util/latex.js
@@ -74,7 +74,7 @@ exports.operators = {
   'or': '\\vee'
 };
 
-var defaultTemplate = '\\mathrm{%name%}\\left(%*%\\right)';
+exports.defaultTemplate = '\\mathrm{%name%}\\left(%*%\\right)';
 
 /*
  * expand a template
@@ -104,7 +104,7 @@ exports.expandTemplate = function (template, name, args) {
 }
 
 //this is a map containing all the latex converters for all the functions
-var functions = {
+exports.functions = {
   //arithmetic
   'abs': '\\left|%0%\\right|',
   'add': '\\left(%0%+%1%\\right)',
@@ -115,10 +115,10 @@ var functions = {
   'dotMultiply': '\\left(%0%' + exports.operators['dotMultiply'] + '%1%\\right)',
   'dotPow': '\\left(%0%' + exports.operators['dotPow'] + '%1%\\right)',
   'exp': '\\exp\\left(%0%\\right)',
-  'fix': defaultTemplate,
+  'fix': exports.defaultTemplate,
   'floor': '\\left\\lfloor%0%\\right\\rfloor',
   'gcd': '\\gcd\\left(%*%\\right)',
-  'lcm': defaultTemplate,
+  'lcm': exports.defaultTemplate,
   'log10': '\\log_{10}\\left(%0%\\right)',
   'log': {
     1: '\\ln\\left(%0%\\right)',
@@ -128,21 +128,21 @@ var functions = {
   'multiply': '\\left(%0%' + exports.operators['multiply'] + '%1%\\right)',
   'norm': {
     1: '\\left\\|%0%\\right\\|',
-    2: defaultTemplate
+    2: exports.defaultTemplate
   },
   'nthRoot': '\\sqrt[%1%]{%0%}',
   'pow': '\\left(%0%\\right)' + exports.operators['pow'] + '{%1%}',
   'round': {
     1: '\\left\\lfloor%0%\\right\\rceil',
-    2: defaultTemplate
+    2: exports.defaultTemplate
   },
-  'sign': defaultTemplate,
+  'sign': exports.defaultTemplate,
   'sqrt': '\\sqrt{%0%}',
   'square': '\\left(%0%\\right)^2',
   'subtract': '\\left(%0%' + exports.operators['subtract'] + '%1%\\right)',
   'unaryMinus': exports.operators['unaryMinus'] + '\\left(%0%\\right)',
   'unaryPlus': exports.operators['unaryPlus'] + '\\left(%0%\\right)',
-  'xgcd': defaultTemplate,
+  'xgcd': exports.defaultTemplate,
 
   //bitwise
   'bitAnd': '\\left(%0%' + exports.operators['bitAnd'] + '%1%\\right)',
@@ -162,22 +162,22 @@ var functions = {
   //combinatorics
   'stirlingS2': '\\mathrm{S}\\left(%0%,%1%\\right)',
   'bellNumbers': '\\mathrm{B}_{%0%}',
-  'composition': defaultTemplate,
+  'composition': exports.defaultTemplate,
 
   //construction
   'bignumber': {
     0: '0',
     1: '\\left(%0%\\right)'
   },
-  'boolean': defaultTemplate,
-  'chain': defaultTemplate,
+  'boolean': exports.defaultTemplate,
+  'chain': exports.defaultTemplate,
   'complex': {
     0: '0',
     1: '\\left(%0%\\right)',
     2: '\\left(\\left(%0%\\right)+'
       + exports.symbols['i'] + '\\cdot\\left(%1%\\right)\\right)',
   },
-  'index': defaultTemplate,
+  'index': exports.defaultTemplate,
   'matrix': {
     0: '\\begin{bmatrix}\\end{bmatrix}',
     1: '\\left(%0%\\right)',
@@ -188,7 +188,7 @@ var functions = {
     1: '\\left(%0%\\right)',
     2: '\\left(\\left(%0%\\right)%1%\\right)'
   },
-  'parser': defaultTemplate,
+  'parser': exports.defaultTemplate,
   'sparse': {
     0: '\\begin{bsparse}\\end{bsparse}',
     1: '\\left(%0%\\right)'
@@ -203,10 +203,10 @@ var functions = {
   },
 
   //expression TODO does the default even work in this case? (.toTex on the args)
-  'compile': defaultTemplate,
-  'eval': defaultTemplate,
-  'help': defaultTemplate,
-  'parse': defaultTemplate,
+  'compile': exports.defaultTemplate,
+  'eval': exports.defaultTemplate,
+  'help': exports.defaultTemplate,
+  'parse': exports.defaultTemplate,
 
   //logical
   'and': '\\left(%0%' + exports.operators['and'] + '%1%\\right)',
@@ -215,37 +215,37 @@ var functions = {
   'xor': '\\left(%0%' + exports.operators['xor'] + '%1%\\right)',
 
   //matrix
-  'concat': defaultTemplate,
+  'concat': exports.defaultTemplate,
   'cross': '\\left(%0%\\right)\\times\\left(%1%\\right)',
   'det': '\\det\\left(%0%\\right)',
-  'diag': defaultTemplate,
+  'diag': exports.defaultTemplate,
   'dot': '\\left(%0%\\cdot%1%\\right)',
-  'eye': defaultTemplate,
-  'flatten': defaultTemplate,
+  'eye': exports.defaultTemplate,
+  'flatten': exports.defaultTemplate,
   'inv': '\\left(%0%\\right)^{-1}',
-  'ones': defaultTemplate,
-  'range': defaultTemplate,
-  'resize': defaultTemplate,
-  'size': defaultTemplate,
-  'squeeze': defaultTemplate,
-  'subset': defaultTemplate,
+  'ones': exports.defaultTemplate,
+  'range': exports.defaultTemplate,
+  'resize': exports.defaultTemplate,
+  'size': exports.defaultTemplate,
+  'squeeze': exports.defaultTemplate,
+  'subset': exports.defaultTemplate,
   'trace': '\\mathrm{tr}\\left(%0%\\right)',
   'transpose': '\\left(%0%\\right)' + exports.operators['transpose'],
-  'zeros': defaultTemplate,
+  'zeros': exports.defaultTemplate,
 
   //probability
   'combinations': '\\binom{%0%}{%1%}',
-  'distribution': defaultTemplate,
+  'distribution': exports.defaultTemplate,
   'factorial': '\\left(%0%\\right)' + exports.operators['factorial'],
   'gamma': '\\Gamma\\left(%0%\\right)',
-  'permutations': defaultTemplate,
-  'pickRandom': defaultTemplate,
-  'randomInt': defaultTemplate,
-  'random': defaultTemplate,
+  'permutations': exports.defaultTemplate,
+  'pickRandom': exports.defaultTemplate,
+  'randomInt': exports.defaultTemplate,
+  'random': exports.defaultTemplate,
 
   //relational
-  'compare': defaultTemplate,
-  'deepEqual': defaultTemplate,
+  'compare': exports.defaultTemplate,
+  'deepEqual': exports.defaultTemplate,
   'equal': '\\left(%0%' + exports.operators['equal'] + '%1%\\right)',
   'largerEq': '\\left(%0%' + exports.operators['largerEq'] + '%1%\\right)',
   'larger': '\\left(%0%' + exports.operators['larger'] + '%1%\\right)',
@@ -255,12 +255,12 @@ var functions = {
 
   //statistics
   'max': '\\max\\left(%*%\\right)',
-  'mean': defaultTemplate,
-  'median': defaultTemplate,
+  'mean': exports.defaultTemplate,
+  'median': exports.defaultTemplate,
   'min': '\\min\\left(%*%\\right)',
-  'prod': defaultTemplate,
-  'std': defaultTemplate,
-  'sum': defaultTemplate,
+  'prod': exports.defaultTemplate,
+  'std': exports.defaultTemplate,
+  'sum': exports.defaultTemplate,
   'var': '\\mathrm{Var}\\left(%*%\\right)',
 
   //trigonometry
@@ -294,15 +294,15 @@ var functions = {
   'to': '\\left(%0%' + exports.operators['to'] + '%1%\\right)',
 
   //utils
-  'clone': defaultTemplate,
-  'filter': defaultTemplate,
-  'forEach': defaultTemplate,
-  'format': defaultTemplate,
-  'import': defaultTemplate,
-  'map': defaultTemplate,
-  'print': defaultTemplate,
-  'sort': defaultTemplate,
-  'typeof': defaultTemplate
+  'clone': exports.defaultTemplate,
+  'filter': exports.defaultTemplate,
+  'forEach': exports.defaultTemplate,
+  'format': exports.defaultTemplate,
+  'import': exports.defaultTemplate,
+  'map': exports.defaultTemplate,
+  'print': exports.defaultTemplate,
+  'sort': exports.defaultTemplate,
+  'typeof': exports.defaultTemplate
 };
 
 var units = {
@@ -331,29 +331,3 @@ exports.toSymbol = function (name, isUnit) {
   }
   return name;
 };
-
-//returns the latex output for a given function
-//TODO: this doesn't yet use the different parenthesis options
-exports.toFunction = function (node, options, name) {
-  var latexConverter = functions[name];
-  var args = node.args.map(function (arg) { //get LaTeX of the arguments
-    return arg.toTex(options);
-  });
-
-  switch (typeof latexConverter) {
-    case 'function': //a callback function
-      return latexConverter(node, options);
-    case 'string': //a template string
-      return exports.expandTemplate(latexConverter, name, args);
-    case 'object': //an object with different "converters" for different numbers of arguments
-      switch (typeof latexConverter[args.length]) {
-        case 'function':
-          return latexConverter[args.length](node, options);
-        case 'string':
-          return exports.expandTemplate(latexConverter[args.length], name, args);
-      }
-      //no break here! That's intentionally
-    default:
-      return exports.expandTemplate(defaultTemplate, name, args);
-  }
-}

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -393,7 +393,7 @@ describe('FunctionNode', function() {
 
   it ('should LaTeX a FunctionNode with template string attached to the function', function () {
     var customMath = math.create();
-    customMath.add.toTex = '%0% plus %1%';
+    customMath.add.toTex = '${args[0]} plus ${args[1]}';
 
     assert.equal(customMath.parse('add(1,2)').toTex(), '1 plus 2');
   });
@@ -401,7 +401,7 @@ describe('FunctionNode', function() {
   it ('should LaTeX a FunctionNode with object of callbacks attached to the function', function () {
     var customMath = math.create();
     customMath.sum.toTex = {
-      2: "%0%+%1%",
+      2: "${args[0]}+${args[1]}",
       3: function (node, options) {
         return node.args[0] + '+' + node.args[1] + '+' + node.args[2];
       }

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -411,4 +411,54 @@ describe('FunctionNode', function() {
     assert.equal(customMath.parse('sum(1,2,3)').toTex(), '1+2+3');
   });
 
+  it ('should LaTeX templates with string properties', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '${name}';
+
+    assert.equal(customMath.parse('add(1,2)').toTex(), 'add');
+  });
+
+  it ('should LaTeX templates with node properties', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '${args[0]} plus ${args[1]}';
+
+    assert.equal(customMath.parse('add(1,2)').toTex(), '1 plus 2');
+  });
+
+  it ('should LaTeX templates with properties that are arrays of Nodes', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '${args}';
+
+    assert.equal(customMath.parse('add(1,2)').toTex(), '1,2');
+  });
+
+  it ('should throw an Error for templates with properties that don\'t exist', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '${some_property}';
+
+    assert.throws(function () {customMath.parse('add(1,2)').toTex()}, ReferenceError);
+  });
+
+  it ('should throw an Error for templates with properties that aren\'t Nodes or Strings or Arrays of Nodes', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '${some_property}';
+    var tree = customMath.parse('add(1,2)');
+
+    tree.some_property = {};
+    assert.throws(function () {tree.toTex()}, TypeError);
+
+    customMath.add.prototype.some_property = 1;
+    tree.some_property = 1;
+    assert.throws(function () {tree.toTex()}, TypeError);
+  });
+
+  it ('should throw an Error for templates with properties that are arrays of non Nodes', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '${some_property}';
+    var tree = customMath.parse('add(1,2)');
+    tree.some_property = [1,2];
+
+    assert.throws(function () {tree.toTex()}, TypeError);
+  });
+
 });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -382,4 +382,12 @@ describe('FunctionNode', function() {
     assert.equal(n.toTex({handler: customFunction}), '1 add 2');
   });
 
+  it ('should LaTeX a FunctionNode with callback attached to the function', function () {
+    var customMath = math.create();
+    customMath.add.toTex = function (node, options) {
+      return node.args[0].toTex(options) + ' plus ' + node.args[1].toTex(options);
+    };
+
+    assert.equal(customMath.parse('add(1,2)').toTex(), '1 plus 2');
+  });
 });

--- a/test/expression/node/FunctionNode.test.js
+++ b/test/expression/node/FunctionNode.test.js
@@ -390,4 +390,25 @@ describe('FunctionNode', function() {
 
     assert.equal(customMath.parse('add(1,2)').toTex(), '1 plus 2');
   });
+
+  it ('should LaTeX a FunctionNode with template string attached to the function', function () {
+    var customMath = math.create();
+    customMath.add.toTex = '%0% plus %1%';
+
+    assert.equal(customMath.parse('add(1,2)').toTex(), '1 plus 2');
+  });
+
+  it ('should LaTeX a FunctionNode with object of callbacks attached to the function', function () {
+    var customMath = math.create();
+    customMath.sum.toTex = {
+      2: "%0%+%1%",
+      3: function (node, options) {
+        return node.args[0] + '+' + node.args[1] + '+' + node.args[2];
+      }
+    };
+
+    assert.equal(customMath.parse('sum(1,2)').toTex(), '1+2');
+    assert.equal(customMath.parse('sum(1,2,3)').toTex(), '1+2+3');
+  });
+
 });


### PR DESCRIPTION
This enables attaching `toTex` handlers to the different functions. A `toTex` handler can be one of the following (as already used in `util/latex.js`):

* A callback function
* A template string
 * An object cotaining template strings or callback functions for different numbers of arguments.

This is still missing documentation. This will enable moving all of the LaTeX output in `util/latex`'s `exports.functions` to the definitions of the functions themselves later on.
