### PR TITLE
Documentation fix

### DIFF
--- a/docs/expressions/expression_trees.md
+++ b/docs/expressions/expression_trees.md
@@ -390,7 +390,7 @@ new FunctionNode(name: string, args: Node[])
 
 Properties:
 
-- `symbol: Node`
+- `name: string`
 - `args: Node[]`
 
 Examples:


### PR DESCRIPTION
FunctionNode has `name: string` property instead of `symbol: Node`