### PR TITLE
Removed UPPERCASE OMEGA character (breaks browsers)

### DIFF
--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -911,9 +911,12 @@ function factory (type, config, load, typed) {
           var diff = Math.abs(
               Math.log(absValue / prefix.value) / Math.LN10 - 1.2);
 
-          if (diff < bestDiff) {
-            bestPrefix = prefix;
-            bestDiff = diff;
+          if (diff < bestDiff
+              || (diff === bestDiff && prefix.name.length < bestPrefix.name.length)) {
+                // choose the prefix with the smallest diff, or if equal, choose the one
+                // with the shortest name (can happen with SHORTLONG for example)
+                bestPrefix = prefix;
+                bestDiff = diff;
           }
         }
       }

--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -1072,6 +1072,19 @@ function factory (type, config, load, typed) {
     }
   };
 
+  // Add a prefix list for both short and long prefixes (for ohm in particular, since Mohm and megaohm are both acceptable):
+  PREFIXES.SHORTLONG = {};
+  for (var key in PREFIXES.SHORT) {
+    if(PREFIXES.SHORT.hasOwnProperty(key)) {
+      PREFIXES.SHORTLONG[key] = PREFIXES.SHORT[key];
+    }
+  }
+  for (var key in PREFIXES.LONG) {
+    if(PREFIXES.LONG.hasOwnProperty(key)) {
+      PREFIXES.SHORTLONG[key] = PREFIXES.LONG[key];
+    }
+  }
+
   var PREFIX_NONE = {name: '', value: 1, scientific: true};
 
   /* Internally, each unit is represented by a value and a dimension array. The elements of the dimensions array have the following meaning:
@@ -2109,10 +2122,12 @@ function factory (type, config, load, typed) {
     ohm: {
       name: 'ohm',
       base: BASE_UNITS.ELECTRIC_RESISTANCE,
-      prefixes: PREFIXES.LONG,
+      prefixes: PREFIXES.SHORTLONG,    // Both Mohm and megaohm are acceptable
       value: 1,
       offset: 0
     },
+    /*
+     * Unicode breaks in browsers if charset is not specified
     Ω: {
       name: 'Ω',
       base: BASE_UNITS.ELECTRIC_RESISTANCE,
@@ -2120,6 +2135,7 @@ function factory (type, config, load, typed) {
       value: 1,
       offset: 0
     },
+    */
     // Electric inductance
     henry: {
       name: 'henry',
@@ -2303,7 +2319,7 @@ function factory (type, config, load, typed) {
       ELECTRIC_CHARGE:       {unit: UNITS.C,   prefix: PREFIXES.SHORT['']},
       ELECTRIC_CAPACITANCE:  {unit: UNITS.F,   prefix: PREFIXES.SHORT['']},
       ELECTRIC_POTENTIAL:    {unit: UNITS.V,   prefix: PREFIXES.SHORT['']},
-      ELECTRIC_RESISTANCE:   {unit: UNITS.Ω,   prefix: PREFIXES.SHORT['']},
+      ELECTRIC_RESISTANCE:   {unit: UNITS.ohm, prefix: PREFIXES.SHORT['']},
       ELECTRIC_INDUCTANCE:   {unit: UNITS.H,   prefix: PREFIXES.SHORT['']},
       ELECTRIC_CONDUCTANCE:  {unit: UNITS.S,   prefix: PREFIXES.SHORT['']},
       MAGNETIC_FLUX:         {unit: UNITS.Wb,  prefix: PREFIXES.SHORT['']},

--- a/test/type/unit/Unit.test.js
+++ b/test/type/unit/Unit.test.js
@@ -364,6 +364,7 @@ describe('unit', function() {
       assert.equal(new Unit(500 ,'m').toString(), '500 m');
       assert.equal(new Unit(600 ,'m').toString(), '0.6 km');
       assert.equal(new Unit(1000 ,'m').toString(), '1 km');
+			assert.equal(new Unit(1000 ,'ohm').toString(), '1 kohm');
     });
 
 


### PR DESCRIPTION
I found that by NOT setting the charset in the html file (which I fail to do literally every time), the default symbol for ohm, `U+03A9 Ω` (greek capital letter omega), as a variable name, breaks the entire script. Not to mention it's difficult to type `Ω` on a keyboard.

I removed `Ω` as a unit and created a new prefix list for `ohm` that accepts both short and long prefixes, so both `Mohm` and `megaohm` are acceptable. I <i>think</i> the `_bestPrefix` function will always choose the short prefix over the long one.