### PR TITLE
Some behavioral changes for Unit.parse

### DIFF
--- a/examples/units.js
+++ b/examples/units.js
@@ -90,7 +90,7 @@ print(math.eval('460 V * 20 A * 30 days to kWh'));    // 6624 kWh
 console.log();
 
 console.log('circuit design:');
-print(math.eval('24 V / (6 mA)'));                    // 4 kΩ
+print(math.eval('24 V / (6 mA)'));                    // 4 kohm
 console.log();
 
 console.log('operations on arrays:');

--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -183,11 +183,11 @@ function factory (type, config, load, typed) {
             (code >= 97 && code <= 122)) {
       unitName += c;
       next();
-      var code = text.charCodeAt(index);
+      code = text.charCodeAt(index);
     }
 
     // Must begin with [a-zA-Z]
-    var code = unitName.charCodeAt(0);
+    code = unitName.charCodeAt(0);
     if ((code >= 65 && code <= 90) ||
         (code >= 97 && code <= 122)) {
         return unitName || null;
@@ -220,7 +220,6 @@ function factory (type, config, load, typed) {
 
     if (typeof text !== 'string') {
       throw new TypeError('Invalid argument in Unit.parse. Valid types are {string}.');
-      return null;
     }
 
     var unit = new Unit();
@@ -250,8 +249,8 @@ function factory (type, config, load, typed) {
     skipWhitespace();    // Whitespace is not required here
 
     // Next, we read any number of unit[^number]
-    var powerMultiplier = 1.0;
-    var expectingDenominator = false;
+    var powerMultiplier = 1;
+    var expectingUnit = false;
     while (true) {
       skipWhitespace();
       if(c) {
@@ -271,7 +270,7 @@ function factory (type, config, load, typed) {
         //return null;
         throw new SyntaxError('Unit "' + uStr + '" not found.');
       }
-      var power = 1.0 * powerMultiplier;
+      var power = powerMultiplier;
       // Is there a "^ number"?
       skipWhitespace();
       if (parseCharacter('^')) {
@@ -292,14 +291,23 @@ function factory (type, config, load, typed) {
       for(var i=0; i<BASE_DIMENSIONS.length; i++) {
         unit.dimensions[i] += res.unit.dimensions[i] * power;
       }
-      // Is there a forward slash? If so, all remaining units are in the demoninator.
-      if(powerMultiplier == -1.0) {
-        expectingDenominator = false;
-      }
+      // Is there a forward slash? If so, all remaining units are in the denominator.
+      expectingUnit = false;
       skipWhitespace();
-      if (parseCharacter('/')) {
-        powerMultiplier = -1.0;
-        expectingDenominator = true;
+
+      if (parseCharacter('*')) {
+        // explicit multiplication
+        powerMultiplier = 1;
+        expectingUnit = true;
+      }
+      else if (parseCharacter('/')) {
+        // division
+        powerMultiplier = -1;
+        expectingUnit = true;
+      }
+      else {
+        // implicit multiplication
+        powerMultiplier = 1;
       }
 
       // Replace the unit into the auto unit system
@@ -314,23 +322,20 @@ function factory (type, config, load, typed) {
     skipWhitespace();
     if(c) {
       throw new SyntaxError('Could not parse: "' + str + '"');
-      return null;
     }
 
     // Is there a trailing slash?
-    if(expectingDenominator) {
+    if(expectingUnit) {
       throw new SyntaxError('Trailing characters: "' + str + '"');
-      return null;
     }
 
     if(unit.units.length == 0) {
       throw new SyntaxError('"' + str + '" contains no units');
-      return null;
     }
 
     unit.value = (value != undefined) ? unit._normalize(value) : null;
     return unit;
-  }
+  };
 
   /**
    * create a copy of this unit
@@ -891,7 +896,7 @@ function factory (type, config, load, typed) {
    */
   Unit.prototype._bestPrefix = function () {
     if(this._isDerived()) {
-      throw "Can only compute the best prefix for non-derived units, like kg, s, N, and so forth!";
+      throw new Error("Can only compute the best prefix for non-derived units, like kg, s, N, and so forth!");
     }
 
     // find the best prefix value (resulting in the value of which

--- a/test/type/unit/Unit.test.js
+++ b/test/type/unit/Unit.test.js
@@ -348,7 +348,7 @@ describe('unit', function() {
       assert.equal(new Unit(5, 'kg^1.0e0 m^1.0e0 s^-2.0e0').toString(), '5 (kg m) / s^2');
       assert.equal(new Unit(5, 's^-2').toString(), '5 s^-2');
       assert.equal(new Unit(5, 'm / s ^ 2').toString(), '5 m / s^2');
-      assert.equal(new Unit(null, 'kg m^2 / s^2 mol').toString(), '(kg m^2) / (s^2 mol)');
+      assert.equal(new Unit(null, 'kg m^2 / s^2 / mol').toString(), '(kg m^2) / (s^2 mol)');
     });
 
     it('should render with the best prefix', function() {
@@ -367,7 +367,6 @@ describe('unit', function() {
 			assert.equal(new Unit(1000 ,'ohm').toString(), '1 kohm');
     });
 
-
   });
 
   describe('simplifyUnitListLazy', function() {
@@ -380,7 +379,7 @@ describe('unit', function() {
     });
 
     it('should only simplify units with values', function() {
-      var unit1 = new Unit(null, "kg m mol / s^2 mol");
+      var unit1 = new Unit(null, "kg m mol / s^2 / mol");
       unit1.isUnitListSimplified = false;
       unit1.simplifyUnitListLazy();
       assert.equal(unit1.toString(), "(kg m mol) / (s^2 mol)");
@@ -569,6 +568,13 @@ describe('unit', function() {
       assert.equal(unit1.units[1].power, -2);
       assert.equal(unit1.units[0].prefix.name, 'c');
 
+      unit1 = Unit.parse('981 cm*s^-2');
+      approx.equal(unit1.value, 9.81);
+      assert.equal(unit1.units[0].unit.name, 'm');
+      assert.equal(unit1.units[1].unit.name, 's');
+      assert.equal(unit1.units[1].power, -2);
+      assert.equal(unit1.units[0].prefix.name, 'c');
+
       unit1 = Unit.parse('8.314 kg m^2 / s^2 / K / mol');
       approx.equal(unit1.value, 8.314);
       assert.equal(unit1.units[0].unit.name, 'g');
@@ -583,9 +589,22 @@ describe('unit', function() {
       assert.equal(unit1.units[4].power, -1);
       assert.equal(unit1.units[0].prefix.name, 'k');
 
-    unit1 = Unit.parse('5exabytes');
-    approx.equal(unit1.value, 4e19);
-    assert.equal(unit1.units[0].unit.name, 'bytes');
+      unit1 = Unit.parse('5exabytes');
+      approx.equal(unit1.value, 4e19);
+      assert.equal(unit1.units[0].unit.name, 'bytes');
+    });
+
+    it('should parse units with correct precedence', function() {
+      var unit1 = Unit.parse('1	m^3 / kg s^2'); // implicit multiplication
+
+      approx.equal(unit1.value, 1);
+      assert.equal(unit1.units[0].unit.name, 'm');
+      assert.equal(unit1.units[1].unit.name, 'g');
+      assert.equal(unit1.units[2].unit.name, 's');
+      assert.equal(unit1.units[0].power, 3);
+      assert.equal(unit1.units[1].power, -1);
+      assert.equal(unit1.units[2].power, 2);
+      assert.equal(unit1.units[0].prefix.name, '');
     });
 
     it('should return null (update: throw exception --ericman314) when parsing an invalid unit', function() {


### PR DESCRIPTION
@ericman314 I came across two topics we need to discuss before releasing support for derived units:

- `Unit.parse` did handle precedence of division higher than implicit multiplication, i.e. `1 m / kg s` was parsed as `(1 * m) / (kg * s)`. The precedence of implicit multiplications is ambiguous in mathematics (does `1/2x` mean half x or a half divided by x?). With math.js we choose to handle implicit multiplication with the same precedence as divisions ([see docs](http://mathjs.org/docs/expressions/syntax.html#precedence)), so `1 m / kg s` would be parsed as `((1 * m) / kg) * s`. Both parsers should work consistent. Would it be ok with you if we change `Unit.parse` such that it handles implicit multiplication with the same precedence as division, see this PR?

- `Unit.parse` previously returned `null` when it couldn't parse a string (`Complex.parse` does the same). You changed this to throwing an error and added some comments in the unit tests. There are arguments for both, but I agree it would be safer to throw exceptions by default. If we do that, we should correct the code comments accordingly, change the behavior of `Complex.parse`, and cleanup the unit tests. 

  I *think* we can safely change this without releasing this as a breaking v3, as these parse functions are not part of the public, documented API and only used internally.

In this PR I also added support for explicit multiplication like `5 J*s`.