### PR TITLE
Default Units

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -20,6 +20,9 @@ function factory (type, config, load, typed, math) {
    *                            {string} parenthesis
    *                              How to display parentheses in LaTeX and string
    *                              output.
+   *                            {string} defaultUnits
+   *                              The type of units to use when combining unitless
+   *                              values with non-unitless.
    * @return {Object} Returns the current configuration
    */
   return function _config(options) {

--- a/lib/core/core.js
+++ b/lib/core/core.js
@@ -72,7 +72,10 @@ exports.create = function create (options) {
     // on the input types. When false (default), output type can vary depending
     // on input values. For example `math.sqrt(-2)` returns `NaN` when
     // predictable is false, and returns `complex('2i')` when true.
-    predictable: false
+    predictable: false,
+
+    // type of units to use by default when adding or subtract to Unit values.
+    defaultUnits: undefined
   };
 
   if (options) {

--- a/lib/function/arithmetic/addScalar.js
+++ b/lib/function/arithmetic/addScalar.js
@@ -3,6 +3,24 @@
 function factory(type, config, load, typed) {
 
   /**
+   * Add two Unit values.
+   * @param {Unit} x   First value to add
+   * @param {Unit} y   Second value to add
+   * @return {Unit}    Sum of `x` and `y`
+   * @private
+   */
+  var unitUnitAddScalar = function (x, y) {
+    if (x.value == null) throw new Error('Parameter x contains a unit with undefined value');
+    if (y.value == null) throw new Error('Parameter y contains a unit with undefined value');
+    if (!x.equalBase(y)) throw new Error('Units do not match');
+
+    var res = x.clone();
+    res.value += y.value;
+    res.fixPrefix = false;
+    return res;
+  };
+
+  /**
    * Add two scalar values, `x + y`.
    * This function is meant for internal use: it is used by the public function
    * `add`
@@ -11,8 +29,8 @@ function factory(type, config, load, typed) {
    * not validate the number of of inputs.
    *
    * @param  {number | BigNumber | Fraction | Complex | Unit} x   First value to add
-   * @param  {number | BigNumber | Fraction | Complex} y          Second value to add
-   * @return {number | BigNumber | Fraction | Complex | Unit}                      Sum of `x` and `y`
+   * @param  {number | BigNumber | Fraction | Complex | Unit} y   Second value to add
+   * @return {number | BigNumber | Fraction | Complex | Unit}     Sum of `x` and `y`
    * @private
    */
   return typed('add', {
@@ -36,16 +54,19 @@ function factory(type, config, load, typed) {
       return x.add(y);
     },
 
-    'Unit, Unit': function (x, y) {
-      if (x.value == null) throw new Error('Parameter x contains a unit with undefined value');
-      if (y.value == null) throw new Error('Parameter y contains a unit with undefined value');
-      if (!x.equalBase(y)) throw new Error('Units do not match');
+    'number, Unit': function (x, y) {
+      if (!config['defaultUnits']) throw new TypeError('Can not add a unitless value to one with units.');
+      var z = new type.Unit(x, config['defaultUnits']);
+      return unitUnitAddScalar(z, y);
+    },
 
-      var res = x.clone();
-      res.value += y.value;
-      res.fixPrefix = false;
-      return res;
-    }
+    'Unit, number': function (x, y) {
+      if (!config['defaultUnits']) throw new TypeError('Can not add a unitless value to one with units.');
+      var z = new type.Unit(y, config['defaultUnits']);
+      return unitUnitAddScalar(x, z);
+    },
+
+    'Unit, Unit': unitUnitAddScalar
   });
 }
 

--- a/lib/function/arithmetic/subtract.js
+++ b/lib/function/arithmetic/subtract.js
@@ -89,6 +89,14 @@ function factory (type, config, load, typed) {
 
       return res;
     },
+
+    'number, Unit': function (x, y) {
+      return addScalar(x, unaryMinus(y));
+    },
+
+    'Unit, number': function (x, y) {
+      return addScalar(x, unaryMinus(y));
+    },
     
     'Matrix, Matrix': function (x, y) {
       // matrix sizes

--- a/test/function/arithmetic/addScalar.test.js
+++ b/test/function/arithmetic/addScalar.test.js
@@ -111,8 +111,26 @@ describe('add', function() {
     }, /Parameter y contains a unit with undefined value/);
   });
 
-  it('should throw an error in case of a unit and non-unit argument', function() {
-    assert.throws(function () {add(math.unit('5cm'), 2);}, /TypeError: Unexpected type of argument in function add/);
+  it('should throw an error in case of a unit and non-unit argument with no defaultUnits config set', function() {
+    assert.throws(function () {add(math.unit('5cm'), 2);}, /TypeError: Can not add a unitless value to one with units./);
+    assert.throws(function () {add(math.unit('5cm'), new Date());}, /TypeError: Unexpected type of argument in function add/);
+    assert.throws(function () {add(new Date(), math.unit('5cm'));}, /TypeError: Unexpected type of argument in function add/);
+  });
+
+  it('should convert unitless numbers to Unit values in order to add them to the other Unit values', function() {
+    var defaultUnitsMath = math.create({'defaultUnits': 'mm'});
+    var add = defaultUnitsMath.add;
+    approx.deepEqual(add(defaultUnitsMath.unit(5, 'mm'), 3), defaultUnitsMath.unit(8, 'mm'));
+    approx.deepEqual(add(10, defaultUnitsMath.unit(2000, 'mm')), defaultUnitsMath.unit(2010, 'mm'));
+
+    defaultUnitsMath.config({'defaultUnits': 'm'});
+    approx.deepEqual(add(defaultUnitsMath.unit(5, 'cm'), 3), defaultUnitsMath.unit(305, 'cm'));
+    approx.deepEqual(add(0, defaultUnitsMath.unit(17, 'mm')), defaultUnitsMath.unit(0.017, 'm'));
+  });
+
+  it('should still throw an error in case of a unit and Date argument with defaultUnits config set', function() {
+    var defaultUnitsMath = math.create({'defaultUnits': 'mm'});
+    var add = defaultUnitsMath.add;
     assert.throws(function () {add(math.unit('5cm'), new Date());}, /TypeError: Unexpected type of argument in function add/);
     assert.throws(function () {add(new Date(), math.unit('5cm'));}, /TypeError: Unexpected type of argument in function add/);
   });

--- a/test/function/arithmetic/subtract.test.js
+++ b/test/function/arithmetic/subtract.test.js
@@ -109,12 +109,19 @@ describe('subtract', function() {
     }, /Parameter y contains a unit with undefined value/);
   });
 
-  it('should throw an error if subtracting numbers from units', function() {
+  it('should throw an error if subtracting numbers from units with no defaultUnits config set', function() {
     assert.throws(function () { subtract(math.unit(5, 'km'), 2); }, TypeError);
     assert.throws(function () { subtract(2, math.unit(5, 'km')); }, TypeError);
   });
 
-  it('should throw an error if subtracting numbers from units', function() {
+  it('should convert unitless numbers to Unit values in order to subtract them from the other Unit values', function() {
+    var defaultUnitsMath = math.create({'defaultUnits': 'km'});
+    var subtract = defaultUnitsMath.subtract;
+    approx.deepEqual(subtract(defaultUnitsMath.unit(5, 'km'), 2), defaultUnitsMath.unit(3, 'km'));
+    approx.deepEqual(subtract(2, defaultUnitsMath.unit(5, 'km')), defaultUnitsMath.unit(-3, 'km'));
+  });
+
+  it('should throw an error if subtracting big numbers from units', function() {
     assert.throws(function () { subtract(math.unit(5, 'km'), bignumber(2)); }, TypeError);
     assert.throws(function () { subtract(bignumber(2), math.unit(5, 'km')); }, TypeError);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,14 +11,16 @@ describe('factory', function() {
       number: 'number',
       precision: 64,
       predictable: false,
-      epsilon: 1e-14
+      epsilon: 1e-14,
+      defaultUnits: undefined
     });
   });
 
   it('should create an instance of math.js with custom configuration', function() {
     var math1 = math.create({
       matrix: 'array',
-      number: 'bignumber'
+      number: 'bignumber',
+      defaultUnits: 'mm'
     });
 
     assert.strictEqual(typeof math1, 'object');
@@ -27,7 +29,8 @@ describe('factory', function() {
       number: 'bignumber',
       precision: 64,
       predictable: false,
-      epsilon: 1e-14
+      epsilon: 1e-14,
+      defaultUnits: 'mm'
     });
   });
 
@@ -59,7 +62,8 @@ describe('factory', function() {
       number: 'number',
       precision: 64,
       predictable: false,
-      epsilon: 1e-14
+      epsilon: 1e-14,
+      defaultUnits: undefined
     });
 
     // restore the original config


### PR DESCRIPTION
I took a crack at implementing #426 myself. Let me know what you think.

I think it only really makes sense to do this for addition and subtraction. Multiplying and dividing units doesn't seem to work right now, and multiplying by unitless numbers is probably more common any way. I also considered supporting BigNumbers, but it turns out you can't create Units with BigNumbers, so it seemed like that was getting out of scope for the change.