### PR TITLE
Update defineProperty check

### DIFF
--- a/lib/utils/object.js
+++ b/lib/utils/object.js
@@ -154,7 +154,7 @@ exports.canDefineProperty = function () {
   // test needed for broken IE8 implementation
   try {
     if (Object.defineProperty) {
-      Object.defineProperty({}, 'x', {});
+      Object.defineProperty({}, 'x', { get: function () {} });
       return true;
     }
   } catch (e) {}


### PR DESCRIPTION
We ran into an issue where in IE8, `canDefineProperty()` would return true, and then our application would throw an error in `es5-sham` (https://github.com/es-shims/es5-shim/blob/master/es5-sham.js#L421).

This change ensures `canDefineProperty()` will return false in IE8 (as using `get` will throw an error at that specific line in `es5-sham`).  Let me know if you want me to write tests or anything else!