### PR TITLE
Fix a small bug with new types.SparseMatrix()

### DIFF
--- a/lib/type/matrix/SparseMatrix.js
+++ b/lib/type/matrix/SparseMatrix.js
@@ -54,7 +54,7 @@ function factory (type, config, load, typed) {
       this._values = [];
       this._index = [];
       this._ptr = [0];
-      this._size = [0];
+      this._size = [0, 0];
       this._datatype = datatype;
     }
   }

--- a/test/type/matrix/SparseMatrix.test.js
+++ b/test/type/matrix/SparseMatrix.test.js
@@ -13,7 +13,7 @@ describe('SparseMatrix', function() {
 
     it('should create empty matrix if called with no argument', function() {
       var m = new SparseMatrix();
-      assert.deepEqual(m._size, [0]);
+      assert.deepEqual(m._size, [0, 0]);
       assert.deepEqual(m._values, []);
       assert.deepEqual(m._index, []);
       assert.deepEqual(m._ptr, [0]);


### PR DESCRIPTION
Fixes an issue with `new types.SparseMatrix()`; currently the size defaults to `[0]`, which causes some odd issues, which are fixed by defaulting the size to `[0, 0]`.  For example:

```
var m = new math.types.SparseMatrix();
m.resize([2, 2]);
m.set([1, 1], 42);
m.get([1, 1]); //Currently returns 0, rather than 42 as expected
```