### PR TITLE
Add arcseconds to list of angle units

### DIFF
--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -1902,6 +1902,14 @@ function factory (type, config, load, typed) {
       value: 6.2831853071795864769252867665793,
       offset: 0
     },
+    // arcsec = rad / (3600 * (360 / 2*pi)) = rad / 0.0000048481368110953599358991410235795
+    arcsec: {
+      name: 'arcsec',
+      base: BASE_UNITS.ANGLE,
+      prefixes: PREFIXES.NONE,
+      value: 0.0000048481368110953599358991410235795,
+      offset: 0,
+    },
 
     // Electric current
     A: {
@@ -2358,6 +2366,7 @@ function factory (type, config, load, typed) {
     degrees: 'deg',
     gradients: 'grad',
     cycles: 'cycle',
+    arcseconds: 'arcsec',
 
     BTUs: 'BTU',
     watts: 'watt',


### PR DESCRIPTION
This adds arcseconds as an angle unit. Helpful to me, at least....