### PR TITLE
Realmode exponentiation

### DIFF
--- a/lib/function/arithmetic/pow.js
+++ b/lib/function/arithmetic/pow.js
@@ -95,7 +95,9 @@ function factory (type, config, load, typed) {
    */
   function _pow(x, y) {
 
-    if (config.realmode && !isInteger(y) && x < 0) {
+    // Alternatively could define a 'realmode' config option or something, but
+    // 'predictable' will work for now
+    if (config.predictable && !isInteger(y) && x < 0) {
       // Check to see if y can be represented as a fraction
       try {
         var yFrac = fraction(y);
@@ -109,6 +111,8 @@ function factory (type, config, load, typed) {
       catch (ex) {
         // fraction() throws an error if y is Infinity, etc.
       }
+
+      // Unable to express y as a fraction, so continue on
     }
 
     if (isInteger(y) || x >= 0 || config.predictable) {

--- a/lib/function/arithmetic/pow.js
+++ b/lib/function/arithmetic/pow.js
@@ -10,6 +10,8 @@ function factory (type, config, load, typed) {
   var log = load(require('./log'));
   var multiply = load(require('./multiply'));
   var matrix = load(require('../../type/matrix/function/matrix'));
+  var fraction = load(require('../../type/fraction/function/fraction'));
+  var number = load(require('../../type/number'));
 
   /**
    * Calculates the power of x to y, `x ^ y`.
@@ -92,6 +94,23 @@ function factory (type, config, load, typed) {
    * @private
    */
   function _pow(x, y) {
+
+    if (config.realmode && !isInteger(y) && x < 0) {
+      // Check to see if y can be represented as a fraction
+      try {
+        var yFrac = fraction(y);
+        var yNum = number(yFrac);
+        if(y === yNum || Math.abs((y - yNum) / y) < 1e-14) {
+          if(yFrac.d % 2 === 1) {
+            return (yFrac.n % 2 === 0 ? 1 : -1) * Math.pow(-x, y);
+          }
+        }
+      }
+      catch (ex) {
+        // fraction() throws an error if y is Infinity, etc.
+      }
+    }
+
     if (isInteger(y) || x >= 0 || config.predictable) {
       return Math.pow(x, y);
     }

--- a/test/function/arithmetic/pow.test.js
+++ b/test/function/arithmetic/pow.test.js
@@ -4,6 +4,7 @@ var approx = require('../../../tools/approx');
 var error = require('../../../lib/error/index');
 var math = require('../../../index');
 var mathPredictable = math.create({predictable: true});
+var mathRealmode = math.create({realmode: true});
 var bignumber = math.bignumber;
 var fraction = math.fraction;
 var complex = math.complex;
@@ -34,6 +35,30 @@ describe('pow', function() {
     var res = mathPredictable.pow(-2,1.5);
     assert.equal(typeof res, 'number');
     assert(isNaN(res));
+  });
+
+  it('should return a real-valued root if one exists with realmode:true', function() {
+    approx.equal(mathRealmode.pow(-8, 1/3), -2);
+    approx.equal(mathRealmode.pow(-8, 2/3), 4);
+    approx.equal(mathRealmode.pow(-8, 3/3), -8);
+    approx.equal(mathRealmode.pow(-8, 4/3), 16);
+    approx.equal(mathRealmode.pow(-8, 5/3), -32);
+    approx.equal(mathRealmode.pow(-8, -5/3), -0.03125);
+    approx.equal(mathRealmode.pow(-1, 2/3), 1);
+    approx.equal(mathRealmode.pow(-1, 50/99), 1);
+    approx.equal(mathRealmode.pow(-1, 49/99), -1);
+    approx.equal(mathRealmode.pow(-17, 29/137), -1.8216292479175);
+    approx.equal(mathRealmode.pow(-1, 0), 1);
+    approx.equal(mathRealmode.pow(-1, 0.2), -1);
+    approx.equal(mathRealmode.pow(-1, 1), -1);
+
+    approx.equal(mathRealmode.pow(4, 2), 16);
+    approx.equal(mathRealmode.pow(4, 0.5), 2);
+    approx.equal(mathRealmode.pow(-4, 2), 16);
+
+    assert(mathRealmode.pow(-1, 49/100).isComplex);
+    assert(mathRealmode.pow(-17, 29/138).isComplex);
+    assert(mathRealmode.pow(-17, 3.14159265358979323).isComplex);
   });
 
   it('should exponentiate booleans to the given power', function() {
@@ -171,8 +196,6 @@ describe('pow', function() {
 	});
 
   it('should throw an error when doing number ^ unit', function() {
-    // This is supported now --ericman314
-    //assert.throws(function () {pow(unit('5cm'), 2)});
     assert.throws(function () {pow(2, unit('5cm'))});
   });
 

--- a/test/function/arithmetic/pow.test.js
+++ b/test/function/arithmetic/pow.test.js
@@ -4,7 +4,6 @@ var approx = require('../../../tools/approx');
 var error = require('../../../lib/error/index');
 var math = require('../../../index');
 var mathPredictable = math.create({predictable: true});
-var mathRealmode = math.create({realmode: true});
 var bignumber = math.bignumber;
 var fraction = math.fraction;
 var complex = math.complex;
@@ -37,28 +36,28 @@ describe('pow', function() {
     assert(isNaN(res));
   });
 
-  it('should return a real-valued root if one exists with realmode:true', function() {
-    approx.equal(mathRealmode.pow(-8, 1/3), -2);
-    approx.equal(mathRealmode.pow(-8, 2/3), 4);
-    approx.equal(mathRealmode.pow(-8, 3/3), -8);
-    approx.equal(mathRealmode.pow(-8, 4/3), 16);
-    approx.equal(mathRealmode.pow(-8, 5/3), -32);
-    approx.equal(mathRealmode.pow(-8, -5/3), -0.03125);
-    approx.equal(mathRealmode.pow(-1, 2/3), 1);
-    approx.equal(mathRealmode.pow(-1, 50/99), 1);
-    approx.equal(mathRealmode.pow(-1, 49/99), -1);
-    approx.equal(mathRealmode.pow(-17, 29/137), -1.8216292479175);
-    approx.equal(mathRealmode.pow(-1, 0), 1);
-    approx.equal(mathRealmode.pow(-1, 0.2), -1);
-    approx.equal(mathRealmode.pow(-1, 1), -1);
+  it('should return a real-valued root if one exists with predictable:true', function() {
+    approx.equal(mathPredictable.pow(-8, 1/3), -2);
+    approx.equal(mathPredictable.pow(-8, 2/3), 4);
+    approx.equal(mathPredictable.pow(-8, 3/3), -8);
+    approx.equal(mathPredictable.pow(-8, 4/3), 16);
+    approx.equal(mathPredictable.pow(-8, 5/3), -32);
+    approx.equal(mathPredictable.pow(-8, -5/3), -0.03125);
+    approx.equal(mathPredictable.pow(-1, 2/3), 1);
+    approx.equal(mathPredictable.pow(-1, 50/99), 1);
+    approx.equal(mathPredictable.pow(-1, 49/99), -1);
+    approx.equal(mathPredictable.pow(-17, 29/137), -1.8216292479175);
+    approx.equal(mathPredictable.pow(-1, 0), 1);
+    approx.equal(mathPredictable.pow(-1, 0.2), -1);
+    approx.equal(mathPredictable.pow(-1, 1), -1);
 
-    approx.equal(mathRealmode.pow(4, 2), 16);
-    approx.equal(mathRealmode.pow(4, 0.5), 2);
-    approx.equal(mathRealmode.pow(-4, 2), 16);
+    approx.equal(mathPredictable.pow(4, 2), 16);
+    approx.equal(mathPredictable.pow(4, 0.5), 2);
+    approx.equal(mathPredictable.pow(-4, 2), 16);
 
-    assert(mathRealmode.pow(-1, 49/100).isComplex);
-    assert(mathRealmode.pow(-17, 29/138).isComplex);
-    assert(mathRealmode.pow(-17, 3.14159265358979323).isComplex);
+    assert(isNaN(mathPredictable.pow(-1, 49/100)));
+    assert(isNaN(mathPredictable.pow(-17, 29/138)));
+    assert(isNaN(mathPredictable.pow(-17, 3.14159265358979323)));
   });
 
   it('should exponentiate booleans to the given power', function() {


### PR DESCRIPTION
Here's an experiment with `realmode` option for exponentiation.

Example:
```js
console.log(math.eval('(-8)^(2/3)').toString());
math.config({realmode:true});
console.log(math.eval('(-8)^(2/3)').toString());
```

Output:
```
-1.9999999999999987 + 3.464101615137754i
3.9999999999999996
```

Let's try this out and see how it feels and make sure everything seems right with this. We can change the name of `realmode` too, or use an existing option like `predictable`, or whatever. When we are satisfied with it then I will add some notes to the docs before you merge the PR.