### PR TITLE
ConditionalNode: simplify LaTeX by using the 'cases' environment

### DIFF
--- a/lib/expression/node/ConditionalNode.js
+++ b/lib/expression/node/ConditionalNode.js
@@ -165,11 +165,11 @@ function factory (type, config, load, typed) {
    * @return {string} str
    */
   ConditionalNode.prototype._toTex = function (options) {
-    return '\\left\\{\\begin{array}{l l}{'
-        + this.trueExpr.toTex(options) + '}, &\\quad{\\text{if}\\;'
+    return '\\begin{cases} {'
+        + this.trueExpr.toTex(options) + '}, &\\quad{\\text{if }\\;'
         + this.condition.toTex(options)
         + '}\\\\{' + this.falseExpr.toTex(options)
-        + '}, &\\quad{\\text{otherwise}}\\end{array}\\right.';
+        + '}, &\\quad{\\text{otherwise}}\\end{cases}';
   };
 
   return ConditionalNode;

--- a/test/expression/node/ConditionalNode.test.js
+++ b/test/expression/node/ConditionalNode.test.js
@@ -289,7 +289,7 @@ describe('ConditionalNode', function() {
   it ('should LaTeX a ConditionalNode', function () {
     var n = new ConditionalNode(condition, a, b);
 
-    assert.equal(n.toTex(), '\\left\\{\\begin{array}{l l}{a:=2}, &\\quad{\\text{if}\\;true}\\\\{b:=3}, &\\quad{\\text{otherwise}}\\end{array}\\right.');
+    assert.equal(n.toTex(), '\\begin{cases} {a:=2}, &\\quad{\\text{if }\\;true}\\\\{b:=3}, &\\quad{\\text{otherwise}}\\end{cases}');
   });
 
   it ('should LaTeX a ConditionalNode with custom toTex', function () {

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -497,7 +497,7 @@ describe('OperatorNode', function() {
     var cond = new ConditionalNode(a, a, a);
     var pow = new OperatorNode('^', 'pow', [cond, a]);
 
-    assert.equal(pow.toTex(), '\\left({\\left\\{\\begin{array}{l l}{1}, &\\quad{\\text{if}\\;1}\\\\{1}, &\\quad{\\text{otherwise}}\\end{array}\\right.}\\right)^{1}');
+    assert.equal(pow.toTex(), '\\left({\\begin{cases} {1}, &\\quad{\\text{if }\\;1}\\\\{1}, &\\quad{\\text{otherwise}}\\end{cases}}\\right)^{1}');
   });
 
   it ('should LaTeX simple expressions in \'auto\' mode', function () {


### PR DESCRIPTION
While discussing how the LaTeX output of ObjectNodes should look like, I thought that the `cases` environment should be used for ConditionalNodes, not the `array` environment.

This pull request doesn't change what the ConditionalNode looks like (except for one space character after the "if").