### PR TITLE
Removed PREFIX_NONE

### DIFF
--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -55,7 +55,7 @@ function factory (type, config, load, typed) {
       this.units = [
         {
           unit: UNIT_NONE,
-          prefix: PREFIX_NONE,  // link to a list with supported prefixes
+          prefix: PREFIXES.NONE,  // link to a list with supported prefixes
           power: 0
         }
       ];
@@ -1250,8 +1250,6 @@ function factory (type, config, load, typed) {
       PREFIXES.SHORTLONG[key] = PREFIXES.LONG[key];
     }
   }
-
-  var PREFIX_NONE = {name: '', value: 1, scientific: true};
 
   /* Internally, each unit is represented by a value and a dimension array. The elements of the dimensions array have the following meaning:
    * Index  Dimension


### PR DESCRIPTION
Removes `PREFIX_NONE` from `Unit.js`, which is almost but not quite the same as `PREFIXES.NONE`, and which causes things to break if used as the prefix in a custom unit.