### PR TITLE
Fix print options argument type

### DIFF
--- a/lib/function/string/print.js
+++ b/lib/function/string/print.js
@@ -44,7 +44,7 @@ function factory (type, config, load, typed) {
    */
   var print = typed ('print', {
     'string, Object': _print,
-    'string, Object, number': _print
+    'string, Object, number | Object': _print
   });
 
   print.toTex = undefined; // use default template


### PR DESCRIPTION
Add missing 'Object' type definition to third parameter. Fixes #700