### PR TITLE
Partial application for FunctionAssignmentNodes

### DIFF
--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -68,10 +68,10 @@ function factory (type, config, load, typed) {
     params = params || this.params;
 
     return params.reduceRight(function(typedFns, _, index) {
-      const nextIndex = index + 1;
-      const key = types.slice(0, nextIndex).join(',');
-      const signature = params.slice(0, nextIndex).join(',');
-      const partialName = `${this.name}_${params.slice(0, nextIndex).join('_')}`;
+      var nextIndex = index + 1;
+      var key = types.slice(0, nextIndex).join(',');
+      var signature = params.slice(0, nextIndex).join(',');
+      var partialName = `${this.name}_${params.slice(0, nextIndex).join('_')}`;
 
       if (nextIndex === params.length) {
         return `"${key}": function (${signature}) { return ${compiledExpr} }`;

--- a/lib/expression/node/FunctionAssignmentNode.js
+++ b/lib/expression/node/FunctionAssignmentNode.js
@@ -51,6 +51,45 @@ function factory (type, config, load, typed) {
   FunctionAssignmentNode.prototype.isFunctionAssignmentNode = true;
 
   /**
+   * Will create a typed function which allows for currying and partial application
+   * Similar to haskell or ramda's curry function
+   *
+   * Example:
+   * addNums(x, y) = x + y  // function(arg0, arg1)
+   * addNums(1, 2) // 3
+   * add5 = addNums(5)  // function(arg0)
+   * add5(3) // 8
+   *
+   * @param {Object} compiledExpr     A Compiled expression `this.expr._compile(defs, childArgs);`
+   * @private
+   */
+  FunctionAssignmentNode.prototype._typedCurry = function (compiledExpr, types, params) {
+    types = types || this.types;
+    params = params || this.params;
+
+    return params.reduceRight(function(typedFns, _, index) {
+      const nextIndex = index + 1;
+      const key = types.slice(0, nextIndex).join(',');
+      const signature = params.slice(0, nextIndex).join(',');
+      const partialName = `${this.name}_${params.slice(0, nextIndex).join('_')}`;
+
+      if (nextIndex === params.length) {
+        return `"${key}": function (${signature}) { return ${compiledExpr} }`;
+      }
+
+      return `
+        "${key}": function (${signature}){
+          return typed("${partialName}", {
+            ${this._typedCurry(compiledExpr, types.slice(nextIndex), params.slice(nextIndex))}
+          });
+        },
+        ${typedFns}
+      `;
+    }.bind(this), '')
+  };
+
+
+  /**
    * Compile the node to javascript code
    * @param {Object} defs     Object which can be used to define functions
    *                          or constants globally available for the compiled
@@ -74,17 +113,16 @@ function factory (type, config, load, typed) {
     // compile the function expression with the child args
     var jsExpr = this.expr._compile(defs, childArgs);
 
-    return 'scope["' + this.name + '"] = ' +
-        '  (function () {' +
-        '    var fn = typed("' + this.name + '", {' +
-        '      "' + this.types.join(',') + '": function (' + this.params.join(',') + ') {' +
-        '        return ' + jsExpr + '' +
-        '      }' +
-        '    });' +
-        '    fn.syntax = "' + this.name + '(' + this.params.join(', ') + ')";' +
-        '    return fn;' +
-        '  })()';
-  };
+    // Curry the function by default
+    return (
+      `scope["${this.name}"] = (function () {
+        return typed("${this.name}", {
+          ${this._typedCurry(jsExpr)}
+        })
+      })()`
+    );
+  }
+
 
   /**
    * Execute a callback for each of the child nodes of this node


### PR DESCRIPTION
This is getting into language theory a little bit which might be out of scope for this project but I would really like to see the functions created in mathjs curry by default.

(similar to [haskell](https://wiki.haskell.org/Partial_application) or [ramda](http://ramdajs.com/docs/#curry))

   Example:

``` matlab
   addNums(x, y, z) = x + y + z  // function(arg0, arg1, arg2)
   addNums(1, 2, 3) // 6
   add5 = addNums(5)  // function(arg0, arg1)
   add5(3, 5) // 13
   add9 = add5(4) // function(arg0)
   add9(1) //10
```

If this is something you guys are interested in I will remove the template strings and add some unit test. 

Note this is only supposed to effect functions that were created in line. Custom typed functions or functions added with `math.import` are not affected by this. 
