### PR TITLE
add missing parentheses

### DIFF
--- a/docs/expressions/expression_trees.md
+++ b/docs/expressions/expression_trees.md
@@ -57,7 +57,7 @@ All nodes have the following methods:
     ```js
     var node = math.parse('2 + x'); // returns the root Node of an expression tree
     var code = node.compile();      // returns {eval: function (scope) {...}}
-    var eval = code.eval({x: 3};    // returns 5
+    var eval = code.eval({x: 3});   // returns 5
     ```
 
 -   `eval([scope]) : Object`
@@ -67,7 +67,7 @@ All nodes have the following methods:
     
     ```js
     var node = math.parse('2 + x'); // returns the root Node of an expression tree
-    var eval = node.eval({x: 3};    // returns 5
+    var eval = node.eval({x: 3});   // returns 5
     ```
 
 -   `equals(other: Node) : boolean`


### PR DESCRIPTION
Hey,

looks like in the samples from `expression_trees.md`,

some parentheses are missing in the sample code.