### PR TITLE
add a √ character to the pool of operators

### DIFF
--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -988,7 +988,6 @@ function factory (type, config, load, typed) {
       '-': 'unaryMinus',
       '+': 'unaryPlus',
       '~': 'bitNot',
-      '√': 'sqrt',
       'not': 'not'
     }[token];
 
@@ -1024,13 +1023,14 @@ function factory (type, config, load, typed) {
     if (fn) {
       name = token;
       getTokenSkipNewline();
-      if (fn == 'nthRoot') {
-        params = [parseUnary(), node]; // Go back to unary, in reverse so '2√-3' gets run as nthRoot(-3, 2)
+      if (fn == 'nthRoot') { // Go back to unary, we can have '2^-3'
+        params = [parseUnary(), node];
       } else {
-        params = [node, parseUnary()]; // Go back to unary, we can have '2^-3'
+        params = [node, parseUnary()];
       }
       node = new OperatorNode(name, fn, params);
-      }
+    }
+
     return node;
   }
 

--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -110,6 +110,7 @@ function factory (type, config, load, typed) {
     '%': true,
     '^': true,
     '.^': true,
+    '√': true,
     '~': true,
     '!': true,
     '&': true,
@@ -987,6 +988,7 @@ function factory (type, config, load, typed) {
       '-': 'unaryMinus',
       '+': 'unaryPlus',
       '~': 'bitNot',
+      '√': 'sqrt',
       'not': 'not'
     }[token];
 
@@ -1012,16 +1014,23 @@ function factory (type, config, load, typed) {
     var node, name, fn, params;
 
     node = parseLeftHandOperators();
+   
+    fn = {
+        '^': 'pow',
+        '.^': 'dotPow',
+        '√': 'nthRoot'
+    }[token];
 
-    if (token == '^' || token == '.^') {
+    if (fn) {
       name = token;
-      fn = (name == '^') ? 'pow' : 'dotPow';
-
       getTokenSkipNewline();
-      params = [node, parseUnary()]; // Go back to unary, we can have '2^-3'
+      if (fn == 'nthRoot') {
+        params = [parseUnary(), node]; // Go back to unary, in reverse so '2√-3' gets run as nthRoot(-3, 2)
+      } else {
+        params = [node, parseUnary()]; // Go back to unary, we can have '2^-3'
+      }
       node = new OperatorNode(name, fn, params);
-    }
-
+      }
     return node;
   }
 

--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -332,6 +332,15 @@ function factory (type, config, load, typed, math) {
         }
         power *= p;
       }
+      if (parseCharacter('√')) {
+        skipWhitespace();
+        var p = parseNumber();
+        if(p == null) {
+          // No valid number found for the root!
+          throw new SyntaxError('In "' + str + '", "√" must be followed by a floating-point number');
+        }
+        power *= p;
+      }
 
       // Add the unit to the list
       unit.units.push( {

--- a/lib/utils/latex.js
+++ b/lib/utils/latex.js
@@ -44,6 +44,7 @@ exports.operators = {
   'transpose': '^\\top',
   'factorial': '!',
   'pow': '^',
+  'nthRoot': '√',
   'dotPow': '.^\\wedge', //TODO find ideal solution
   'unaryPlus': '+',
   'unaryMinus': '-',

--- a/test/expression/parse.test.js
+++ b/test/expression/parse.test.js
@@ -1547,6 +1547,14 @@ describe('parse', function() {
         assert.equal(node.args[0].toString(), 'a');
         assert.equal(node.args[1].toString(), 'b\'');
       });
+      
+      it('should respect precedence of transpose (3)', function () {
+        var node = math.parse('a √ b\'');
+        assert(node instanceof OperatorNode);
+        assert.equal(node.op, '√');
+        assert.equal(node.args[0].toString(), 'b\'');
+        assert.equal(node.args[1].toString(), 'a');
+      });
 
       it('should respect precedence of conditional operator and other operators', function () {
         assert.equal(parseAndEval('2 > 3 ? true : false'), false);


### PR DESCRIPTION
Not a character typically available from standard keyboards.  I'm using this library as a backend for a calculator and it makes a lot more sense to use an operator here rather than function names like nthRoot() and sqrt().  Especially nthRoot is much less intuitive.  My cursory testing has shown that the changes function as desired.

There is a precedence problem though between the unary square root operator and the n root operator.

√4√4 results in √(4√4) instead of the desired (√4)√4.  It's a narrow case and it isn't obvious to me how to fix it inside of your precedence system so I'm ignoring it for the moment in favor of more pressing defects in my own code base.