### PR TITLE
Add Support for Complex Numbers in Kronecker Product Function

### DIFF
--- a/lib/function/matrix/kron.js
+++ b/lib/function/matrix/kron.js
@@ -4,6 +4,7 @@ var size = require('../../utils/array').size;
 
 function factory(type, config, load, typed) {
   var matrix = load(require('../../type/matrix/function/matrix'));
+  var multiply = load(require('../arithmetic/multiply'))
     /**
      * Calculates the kronecker product of 2 matrices / vectors.
      *
@@ -73,7 +74,7 @@ function factory(type, config, load, typed) {
             return b.map(function(b) {
                 return a.map(function(y) {
                     return b.map(function(x) {
-                        return r.push(y * x);
+                        return r.push(multiply(y, x));
                     });
                 }, t.push(r = []));
             });

--- a/lib/function/matrix/kron.js
+++ b/lib/function/matrix/kron.js
@@ -4,7 +4,7 @@ var size = require('../../utils/array').size;
 
 function factory(type, config, load, typed) {
   var matrix = load(require('../../type/matrix/function/matrix'));
-  var multiply = load(require('../arithmetic/multiply'))
+  var multiplyScalar = load(require('../arithmetic/multiplyScalar'))
     /**
      * Calculates the kronecker product of 2 matrices / vectors.
      *
@@ -74,7 +74,7 @@ function factory(type, config, load, typed) {
             return b.map(function(b) {
                 return a.map(function(y) {
                     return b.map(function(x) {
-                        return r.push(multiply(y, x));
+                        return r.push(multiplyScalar(y, x));
                     });
                 }, t.push(r = []));
             });

--- a/test/function/matrix/kron.test.js
+++ b/test/function/matrix/kron.test.js
@@ -38,6 +38,23 @@ describe('kron', function() {
     assert.deepEqual(math.kron([1,2,6,8], [12,1,2,3]), [[12,1,2,3,24,2,4,6,72,6,12,18,96,8,16,24]]);
   });
 
+  it('should support complex numbers', function() {
+    assert.deepEqual(math.kron([
+      [1,math.complex(0,1)],
+      [math.complex(0,1),2]
+    ],
+    [
+      [2,2],
+      [2,2]
+    ]),
+    [
+      [2,2,math.complex(0,2),math.complex(0,2)],
+      [2,2,math.complex(0,2),math.complex(0,2)],
+      [math.complex(0,2),math.complex(0,2),4,4],
+      [math.complex(0,2),math.complex(0,2),4,4]
+    ]);
+  });
+
   it('should throw an error for greater then 2 dimensions', function() {
     assert.throws(function () {
       math.kron([[[1, 1], [1, 1]], [[1, 1], [1, 1]]], [[[1, 2, 3], [4, 5, 6]], [[6, 7, 8], [9, 10, 11]]]);


### PR DESCRIPTION
Just changing from:
```javascript
y * x
```
to 
```javascript
math.multiply(y,x)
```

So Complex Numbers are supported.

Also added a unit test, so it all works.
Any feedback or things to change just say! 😄 