### PR TITLE
Changes to lup docs to fix error.

### DIFF
--- a/lib/function/algebra/decomposition/lup.js
+++ b/lib/function/algebra/decomposition/lup.js
@@ -44,7 +44,7 @@ function factory (type, config, load, typed) {
    *
    * @param {Matrix | Array} A    A two dimensional matrix or array for which to get the LUP decomposition.
    *
-   * @return {Object}      The lower triangular matrix, the upper triangular matrix and the permutation matrix.
+   * @return {{L: Array | Matrix, U: Array | Matrix, P: Array.<number>}} The lower triangular matrix, the upper triangular matrix and the permutation matrix.
    */
   var lup = typed('lup', {
 

--- a/lib/function/algebra/decomposition/lup.js
+++ b/lib/function/algebra/decomposition/lup.js
@@ -31,7 +31,7 @@ function factory (type, config, load, typed) {
    * Example:
    *
    *    var m = [[2, 1], [1, 4]];
-   *    var r = math.lup();
+   *    var r = math.lup(m);
    *    // r = {
    *    //   L: [[1, 0], [0.5, 1]],
    *    //   U: [[2, 1], [0, 3.5]],

--- a/lib/function/algebra/decomposition/lup.js
+++ b/lib/function/algebra/decomposition/lup.js
@@ -44,7 +44,7 @@ function factory (type, config, load, typed) {
    *
    * @param {Matrix | Array} A    A two dimensional matrix or array for which to get the LUP decomposition.
    *
-   * @return {Array<Matrix>}      The lower triangular matrix, the upper triangular matrix and the permutation matrix.
+   * @return {Object}      The lower triangular matrix, the upper triangular matrix and the permutation matrix.
    */
   var lup = typed('lup', {
 


### PR DESCRIPTION
Fixes #801.

Return type documented as it is done for: http://mathjs.org/docs/reference/functions/slu.html.

Still not entirely clear what is returned by the function without looking at example though. Especially regarding the permutation matrix - a matrix isn't actually returned just the position of ones which the documentation does not mention.