### PR TITLE
Support rounding mode for bignumber formatting

### DIFF
--- a/lib/utils/bignumber/formatter.js
+++ b/lib/utils/bignumber/formatter.js
@@ -14,34 +14,38 @@
  *    {Object} options An object with formatting options. Available options:
  *                     {string} notation
  *                         Number notation. Choose from:
- *                         'fixed'          Always use regular number notation.
- *                                          For example '123.40' and '14000000'
- *                         'exponential'    Always use exponential notation.
- *                                          For example '1.234e+2' and '1.4e+7'
- *                         'auto' (default) Regular number notation for numbers
- *                                          having an absolute value between
- *                                          `lower` and `upper` bounds, and uses
- *                                          exponential notation elsewhere.
- *                                          Lower bound is included, upper bound
- *                                          is excluded.
- *                                          For example '123.4' and '1.4e7'.
- *                     {number} precision   A number between 0 and 16 to round
- *                                          the digits of the number.
- *                                          In case of notations 'exponential' and
- *                                          'auto', `precision` defines the total
- *                                          number of significant digits returned
- *                                          and is undefined by default.
- *                                          In case of notation 'fixed',
- *                                          `precision` defines the number of
- *                                          significant digits after the decimal
- *                                          point, and is 0 by default.
- *                     {Object} exponential An object containing two parameters,
- *                                          {number} lower and {number} upper,
- *                                          used by notation 'auto' to determine
- *                                          when to return exponential notation.
- *                                          Default values are `lower=1e-3` and
- *                                          `upper=1e5`.
- *                                          Only applicable for notation `auto`.
+ *                         'fixed'           Always use regular number notation.
+ *                                           For example '123.40' and '14000000'
+ *                         'exponential'     Always use exponential notation.
+ *                                           For example '1.234e+2' and '1.4e+7'
+ *                         'auto' (default)  Regular number notation for numbers
+ *                                           having an absolute value between
+ *                                           `lower` and `upper` bounds, and uses
+ *                                           exponential notation elsewhere.
+ *                                           Lower bound is included, upper bound
+ *                                           is excluded.
+ *                                           For example '123.4' and '1.4e7'.
+ *                     {number} precision    A number between 0 and 16 to round
+ *                                           the digits of the number.
+ *                                           In case of notations 'exponential' and
+ *                                           'auto', `precision` defines the total
+ *                                           number of significant digits returned
+ *                                           and is undefined by default.
+ *                                           In case of notation 'fixed',
+ *                                           `precision` defines the number of
+ *                                           significant digits after the decimal
+ *                                           point, and is 0 by default.
+ *                     {Object} exponential  An object containing two parameters,
+ *                                           {number} lower and {number} upper,
+ *                                           used by notation 'auto' to determine
+ *                                           when to return exponential notation.
+ *                                           Default values are `lower=1e-3` and
+ *                                           `upper=1e5`.
+ *                                           Only applicable for notation `auto`.
+ *                     {number} roundingMode Optionally specify the rounding mode
+ *                                           to customize how the formatted number
+ *                                           should be formatted.
+ *                                           
  *    {Function} fn    A custom formatting function. Can be used to override the
  *                     built-in notations. Function `fn` is called with `value` as
  *                     parameter and must return a string. Is useful for example to
@@ -57,6 +61,8 @@
  *    format(12.071, {notation: 'fixed'});                // '12'
  *    format(2.3,    {notation: 'fixed', precision: 2});  // '2.30'
  *    format(52.8,   {notation: 'exponential'});          // '5.28e+1'
+ *    format(2.34,   {notation: 'fixed', precision: 2, roundingMode: 1 });  
+ *                                                        // '2.3'
  *
  * @param {BigNumber} value
  * @param {Object | Function | number} [options]
@@ -76,11 +82,15 @@ exports.format = function (value, options) {
   // default values for options
   var notation = 'auto';
   var precision = undefined;
+  var roundingMode = undefined;
 
   if (options !== undefined) {
     // determine notation from options
     if (options.notation) {
       notation = options.notation;
+    }
+    if (options.roundingMode) {
+      roundingMode = options.roundingMode;
     }
 
     // determine precision from options
@@ -95,10 +105,10 @@ exports.format = function (value, options) {
   // handle the various notations
   switch (notation) {
     case 'fixed':
-      return exports.toFixed(value, precision);
+      return exports.toFixed(value, precision, roundingMode);
 
     case 'exponential':
-      return exports.toExponential(value, precision);
+      return exports.toExponential(value, precision, roundingMode);
 
     case 'auto':
       // determine lower and upper bound for exponential notation.
@@ -133,11 +143,11 @@ exports.format = function (value, options) {
       var abs = value.abs();
       if (abs.gte(lower) && abs.lt(upper)) {
         // normal number notation
-        str = value.toSignificantDigits(precision).toFixed();
+        str = value.toSignificantDigits(precision, roundingMode).toFixed();
       }
       else {
         // exponential notation
-        str = exports.toExponential(value, precision);
+        str = exports.toExponential(value, precision, roundingMode);
       }
 
       // remove trailing zeros after the decimal point
@@ -156,14 +166,15 @@ exports.format = function (value, options) {
 /**
  * Format a number in exponential notation. Like '1.23e+5', '2.3e+0', '3.500e-3'
  * @param {BigNumber} value
- * @param {number} [precision]  Number of digits in formatted output.
- *                              If not provided, the maximum available digits
- *                              is used.
+ * @param {number} [precision]     Number of digits in formatted output.
+ *                                 If not provided, the maximum available digits
+ *                                 is used.
+ * @param {number} [roundingMode]  Optional rounding mode to use.
  * @returns {string} str
  */
-exports.toExponential = function (value, precision) {
+exports.toExponential = function (value, precision, roundingMode) {
   if (precision !== undefined) {
-    return value.toExponential(precision - 1); // Note the offset of one
+    return value.toExponential(precision - 1, roundingMode); // Note the offset of one
   }
   else {
     return value.toExponential();
@@ -175,9 +186,11 @@ exports.toExponential = function (value, precision) {
  * @param {BigNumber} value
  * @param {number} [precision=0]        Optional number of decimals after the
  *                                      decimal point. Zero by default.
+ * @param {number} [roundingMode]       Optional rounding mode to use.
+ * @returns {string} str
  */
-exports.toFixed = function (value, precision) {
-  return value.toFixed(precision || 0);
+exports.toFixed = function (value, precision, roundingMode) {
+  return value.toFixed(precision || 0, roundingMode);
   // Note: the (precision || 0) is needed as the toFixed of BigNumber has an
   // undefined default precision instead of 0.
 };

--- a/test/utils/bignumber/formatter.test.js
+++ b/test/utils/bignumber/formatter.test.js
@@ -140,6 +140,21 @@ describe('format', function () {
       assert.deepEqual(formatter.format(new B(1).div(3), options), '3.33333333333333333e-1');
     });
 
+    it('should format bignumbers in exponential notation with precision and rounding mode', function() {
+      var options = {
+        notation: 'exponential',
+        precision: 3
+      };
+
+      options.roundingMode = BigNumber.ROUND_UP;
+      assert.equal(formatter.format(new BigNumber('2.345'), options), '2.35e+0');
+      assert.equal(formatter.format(new BigNumber('-2.345'), options), '-2.35e+0');
+
+      options.roundingMode = BigNumber.ROUND_DOWN;
+      assert.equal(formatter.format(new BigNumber('2.345'), options), '2.34e+0');
+      assert.equal(formatter.format(new BigNumber('-2.345'), options), '-2.34e+0');
+    });
+
     it('should format bignumbers with custom precision, lower, and upper bound', function() {
       var Big = BigNumber.clone({precision: 100});
 
@@ -206,6 +221,14 @@ describe('format', function () {
       assert.deepEqual(formatter.format(new BigNumber('12345678'), options), '12345678.00');
       assert.deepEqual(formatter.format(new BigNumber('12e18'), options), '12000000000000000000.00');
       assert.deepEqual(formatter.format(new BigNumber('12e30'), options), '12000000000000000000000000000000.00');
+
+      options.roundingMode = BigNumber.ROUND_UP;
+      assert.equal(formatter.format(new BigNumber('2.345'), options), '2.35');
+      assert.equal(formatter.format(new BigNumber('-2.345'), options), '-2.35');
+
+      options.roundingMode = BigNumber.ROUND_DOWN;
+      assert.equal(formatter.format(new BigNumber('2.345'), options), '2.34');
+      assert.equal(formatter.format(new BigNumber('-2.345'), options), '-2.34');
     });
 
     it('should throw an error on unknown notation', function () {
@@ -220,11 +243,28 @@ describe('format', function () {
     var Big = BigNumber.clone({precision: 100});
 
     assert.equal(formatter.toFixed(new Big(2.34)), '2');
+    
+    // with precision
     assert.equal(formatter.toFixed(new Big(2.34), 1), '2.3');
     assert.equal(formatter.toFixed(new Big(2), 20), '2.00000000000000000000');
     assert.equal(formatter.toFixed(new Big(2), 21), '2.000000000000000000000');
     assert.equal(formatter.toFixed(new Big(2), 22), '2.0000000000000000000000');
     assert.equal(formatter.toFixed(new Big(2), 30), '2.000000000000000000000000000000');
+
+    // with rounding modes
+    assert.equal(formatter.toFixed(new Big(2.34), 1, Big.ROUND_UP), '2.4');
+    assert.equal(formatter.toFixed(new Big(2.34), 1, Big.ROUND_DOWN), '2.3');
+    assert.equal(formatter.toFixed(new Big(-2.34), 1, Big.ROUND_UP), '-2.4');
+    assert.equal(formatter.toFixed(new Big(-2.34), 1, Big.ROUND_DOWN), '-2.3');
+    assert.equal(formatter.toFixed(new Big(3.45), 1, Big.ROUND_UP), '3.5');
+    assert.equal(formatter.toFixed(new Big(3.45), 1, Big.ROUND_DOWN), '3.4');
+    assert.equal(formatter.toFixed(new Big(-3.45), 1, Big.ROUND_UP), '-3.5');
+    assert.equal(formatter.toFixed(new Big(-3.45), 1, Big.ROUND_DOWN), '-3.4');
+    assert.equal(formatter.toFixed(new Big(4.56), 1, Big.ROUND_UP), '4.6');
+    assert.equal(formatter.toFixed(new Big(4.56), 1, Big.ROUND_DOWN), '4.5');
+    assert.equal(formatter.toFixed(new Big(-4.56), 1, Big.ROUND_UP), '-4.6');
+    assert.equal(formatter.toFixed(new Big(-4.56), 1, Big.ROUND_DOWN), '-4.5');
+
   });
 
   it('should format a bignumber using toExponential', function() {
@@ -233,6 +273,8 @@ describe('format', function () {
     assert.equal(formatter.toExponential(new Big(2.34)), '2.34e+0');
     assert.equal(formatter.toExponential(new Big(2.34e+3)), '2.34e+3');
     assert.equal(formatter.toExponential(new Big(2.34e-3)), '2.34e-3');
+    
+    // with precision
     assert.equal(formatter.toExponential(new Big(2.34e+3), 2), '2.3e+3');
     assert.equal(formatter.toExponential(new Big(2e+3), 20), '2.0000000000000000000e+3');
     assert.equal(formatter.toExponential(new Big(2e+3), 21), '2.00000000000000000000e+3');
@@ -240,6 +282,20 @@ describe('format', function () {
     assert.equal(formatter.toExponential(new Big(2e+3), 30), '2.00000000000000000000000000000e+3');
     assert.equal(formatter.toExponential(new Big('2e+300'), 30), '2.00000000000000000000000000000e+300');
     assert.equal(formatter.toExponential(new Big('2e-300'), 30), '2.00000000000000000000000000000e-300');
+
+    // with rounding modes
+    assert.equal(formatter.toExponential(new Big(2.34), 2, Big.ROUND_UP), '2.4e+0');
+    assert.equal(formatter.toExponential(new Big(2.34), 2, Big.ROUND_DOWN), '2.3e+0');
+    assert.equal(formatter.toExponential(new Big(-2.34), 2, Big.ROUND_UP), '-2.4e+0');
+    assert.equal(formatter.toExponential(new Big(-2.34), 2, Big.ROUND_DOWN), '-2.3e+0');
+    assert.equal(formatter.toExponential(new Big(3.45), 2, Big.ROUND_UP), '3.5e+0');
+    assert.equal(formatter.toExponential(new Big(3.45), 2, Big.ROUND_DOWN), '3.4e+0');
+    assert.equal(formatter.toExponential(new Big(-3.45), 2, Big.ROUND_UP), '-3.5e+0');
+    assert.equal(formatter.toExponential(new Big(-3.45), 2, Big.ROUND_DOWN), '-3.4e+0');
+    assert.equal(formatter.toExponential(new Big(4.56), 2, Big.ROUND_UP), '4.6e+0');
+    assert.equal(formatter.toExponential(new Big(4.56), 2, Big.ROUND_DOWN), '4.5e+0');
+    assert.equal(formatter.toExponential(new Big(-4.56), 2, Big.ROUND_UP), '-4.6e+0');
+    assert.equal(formatter.toExponential(new Big(-4.56), 2, Big.ROUND_DOWN), '-4.5e+0');
   });
 
 });


### PR DESCRIPTION
Adds ability for user to customize the rounding mode (as available in decimal.js).

Affects:
1. math.format
2. math.toFixed
3. math.toExponential

See:
1. [decimal#toFixed](https://mikemcl.github.io/decimal.js/#toFixed)
1. [decimal#toExponential](https://mikemcl.github.io/decimal.js/#toExponential)
1. [decimal#toSignificantDigits](https://mikemcl.github.io/decimal.js/#toSD)