### PR TITLE
Remove redundant rule wildcard variable 'C' from simplify

### DIFF
--- a/lib/function/algebra/simplify.js
+++ b/lib/function/algebra/simplify.js
@@ -146,8 +146,8 @@ function factory (type, config, load, typed) {
 
     // temporary rules
     { l: 'n-n1', r:'n+-n1' }, // temporarily replace 'subtract' so we can further flatten the 'add' operator
-    { l: '-(c*C)', r: '(-c) * C' }, // make non-constant terms positive
-    { l: '-C', r: '(-1) * C' },
+    { l: '-(c*v)', r: '(-c) * v' }, // make non-constant terms positive
+    { l: '-v', r: '(-1) * v' },
     { l: 'n/n1^n2', r:'n*n1^-n2' }, // temporarily replace 'divide' so we can further flatten the 'multiply' operator
     { l: 'n/n1', r:'n*n1^-1' },
 
@@ -167,8 +167,8 @@ function factory (type, config, load, typed) {
     { l: '(-n)*n1', r: '-(n*n1)' }, // make factors positive (and undo 'make non-constant terms positive')
 
     // ordering of constants
-    { l: 'c+C', r: 'C+c', context: { 'add': { commutative:false } } },
-    { l: 'C*c', r: 'c*C', context: { 'multiply': { commutative:false } } },
+    { l: 'c+v', r: 'v+c', context: { 'add': { commutative:false } } },
+    { l: 'v*c', r: 'c*v', context: { 'multiply': { commutative:false } } },
 
     // undo temporary rules
     { l: '(-1) * n', r: '-n' },
@@ -506,6 +506,7 @@ function factory (type, config, load, typed) {
       if (rule.name.length === 0) {
         throw new Error('Symbol in rule has 0 length...!?');
       }
+
       if (rule.name[0] == 'n' || rule.name.substring(0,2) == '_p') {
         // rule matches _anything_, so assign this node to the rule.name placeholder
         // Assign node to the rule.name placeholder.
@@ -520,16 +521,6 @@ function factory (type, config, load, typed) {
         else {
           // Mis-match: rule was expecting something other than a ConstantNode
           return [];
-        }
-      }
-      else if (rule.name[0] == 'C') {
-        // rule matches anything but a ConstantNode
-        if(node instanceof ConstantNode) {
-          // Mis-match: rule was expecting not a ConstantNode
-          return [];
-        }
-        else {
-          res[0].placeholders[rule.name] = node;
         }
       }
       else if (rule.name[0] == 'c') {


### PR DESCRIPTION
I noticed that 'v' and 'C' have the exact same behaviour as wildcards in simplify rules. I think the original plan was to make 'v' match SymbolNodes that are not built-in constants but that was never implemented. I've arbitrarily removed 'C' here.

This may be a breaking change if people are already using a 'C' wildcard in their own simplify rules, although I never saw any documentation for using the 'C' wildcard so I think it's unlikely. I figured it's not worth putting a deprecation warning first.