### PR TITLE
Fix terminate condition of simplify to avoid endless loops

### DIFF
--- a/lib/function/algebra/simplify.js
+++ b/lib/function/algebra/simplify.js
@@ -92,11 +92,12 @@ function factory (type, config, load, typed) {
       rules = _buildRules(rules);
 
       var res = removeParens(expr);
-      var after = res.toString({parenthesis: 'all'});
-      var before = null;
-      while(before != after) {
-        lastsym = 0;
-        before = after;
+      var visited = {};
+
+      var str = res.toString({parenthesis: 'all'});
+      while(!visited[str]) {
+        visited[str] = true;
+        _lastsym = 0; // counter for placeholder symbols
         for (var i=0; i<rules.length; i++) {
           if (typeof rules[i] === 'function') {
             res = rules[i](res);
@@ -107,7 +108,7 @@ function factory (type, config, load, typed) {
           }
           unflattenl(res); // using left-heavy binary tree here since custom rule functions may expect it
         }
-        after = res.toString({parenthesis: 'all'});
+        str = res.toString({paranthesis: 'all'});
       }
 
       return res;
@@ -254,9 +255,9 @@ function factory (type, config, load, typed) {
     return ruleSet;
   }
 
-  var lastsym = 0;
+  var _lastsym = 0;
   function _getExpandPlaceholderSymbol() {
-    return new SymbolNode('_p'+lastsym++);
+    return new SymbolNode('_p' + _lastsym++);
   }
 
   /**

--- a/lib/function/algebra/simplify.js
+++ b/lib/function/algebra/simplify.js
@@ -108,7 +108,7 @@ function factory (type, config, load, typed) {
           }
           unflattenl(res); // using left-heavy binary tree here since custom rule functions may expect it
         }
-        str = res.toString({paranthesis: 'all'});
+        str = res.toString({parenthesis: 'all'});
       }
 
       return res;


### PR DESCRIPTION
It is currently possible for rules to rewrite the expression like A->B then B->A the next loop, but the termination condition for `simplify` only looks for A->A, which would cause and endless simplifying loop. This should fix that scenario.