### PR TITLE
Fixed Bug in Equation For Intersection of Line and Plane

### DIFF
--- a/lib/function/geometry/intersect.js
+++ b/lib/function/geometry/intersect.js
@@ -125,7 +125,7 @@ function factory (type, config, load, typed) {
   }
 
   function _intersectLinePlane(x1, y1, z1, x2, y2, z2, x, y, z, c){
-    var t = (c - x1*x - y1*y - z1*z)/(x2*x + y2*y + z2*z - x1 - y1 - z1);
+    var t = (c - x1*x - y1*y - z1*z)/(x2*x + y2*y + z2*z - x1*x - y1*y - z1*z);
     var px = x1 + t * (x2 - x1);
     var py = y1 + t * (y2 - y1);
     var pz = z1 + t * (z2 - z1);

--- a/test/function/geometry/intersect.test.js
+++ b/test/function/geometry/intersect.test.js
@@ -21,6 +21,12 @@ describe('intersect', function() {
     assert.deepEqual(math.intersect(math.matrix([1, 0, 1]), [4, -2, 2], math.matrix([1, 1, 1, 6])), math.matrix([7, -4, 3]));
     assert.deepEqual(math.intersect(math.matrix([1, 0, 1]), math.matrix([4, -2, 2]), math.matrix([1, 1, 1, 6])), math.matrix([7, -4, 3]));
   });
+
+  it('should calculate the intersection point of a line and a plane with plane coefficients other than (1, 1, 1)', function() {
+    assert.deepEqual(math.intersect([0, 30, 0], [0, 21, 0], [0, 9, 0, 0]), [0, 0, 0]);
+    assert.deepEqual(math.intersect(math.matrix([0, 30, 0]), [0, 21, 0], math.matrix([0, 9, 0, 0])), math.matrix([0, 0, 0]));
+    assert.deepEqual(math.intersect(math.matrix([0, 30, 0]), math.matrix([0, 21, 0]), math.matrix([0, 9, 0, 0])), math.matrix([0, 0, 0]));
+  });
   
   it('should return null if the points do not intersect', function() {
     assert.deepEqual(math.intersect([0, 1, 0], [0, 0, 0], [1, 1, 0], [1, 0, 0]), null);


### PR DESCRIPTION
The equation to find the value of ’t' for the intersection of a line and a plane does not appear to be entirely correct.  Please double-check.