### PR TITLE
Prototyped Scopes

### DIFF
--- a/lib/expression/node/ObjectNode.js
+++ b/lib/expression/node/ObjectNode.js
@@ -59,7 +59,7 @@ function factory (type, config, load, typed) {
     var entries = [];
     for (var key in node.properties) {
       if (hasOwnProperty(node.properties, key)) {
-        if (!isSafeProperty(key)) {
+        if (!isSafeProperty(node.properties, key)) {
           throw new Error('No access to property "' + key + '"');
         }
 

--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -15,7 +15,7 @@ function getSafeProperty (object, prop) {
   if (isPlainObject(object)) {
     // only allow getting properties defined on the object itself,
     // not inherited from it's prototype.
-    if (hasOwnProperty(object, prop)) {
+    if (isSafeProperty(object, prop)) {
       return object[prop];
     }
 
@@ -51,7 +51,7 @@ function setSafeProperty (object, prop, value) {
       // property already exists
       // override when the property is defined on the object itself.
       // don't allow overriding inherited properties like .constructor or .toString
-      if (hasOwnProperty(object, prop)) {
+      if (isSafeProperty(object, prop)) {
         return object[prop] = value;
       }
     }

--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -64,12 +64,18 @@ function isSafeProperty (object, prop) {
   }
   // UNSAFE: inherited from Object prototype
   // e.g constructor
-  if (hasOwnProperty(Object.prototype, prop)) {
+  if (prop in Object.prototype) {
+    // 'in' is used instead of hasOwnProperty for nodejs v0.10
+    // which is inconsistent on root prototypes. It is safe
+    // here because Object.prototype is a root object
     return false;
   }
   // UNSAFE: inherited from Function prototype
   // e.g call, apply
-  if (hasOwnProperty(Function.prototype, prop)) {
+  if (prop in Function.prototype) {
+    // 'in' is used instead of hasOwnProperty for nodejs v0.10
+    // which is inconsistent on root prototypes. It is safe
+    // here because Function.prototype is a root object
     return false;
   }
   return true;
@@ -111,12 +117,18 @@ function isSafeMethod (object, method) {
   }
   // UNSAFE: inherited from Object prototype
   // e.g constructor
-  if (hasOwnProperty(Object.prototype, method)) {
+  if (method in Object.prototype) {
+    // 'in' is used instead of hasOwnProperty for nodejs v0.10
+    // which is inconsistent on root prototypes. It is safe
+    // here because Object.prototype is a root object
     return false;
   }
   // UNSAFE: inherited from Function prototype
   // e.g call, apply
-  if (hasOwnProperty(Function.prototype, method)) {
+  if (method in Function.prototype) {
+    // 'in' is used instead of hasOwnProperty for nodejs v0.10
+    // which is inconsistent on root prototypes. It is safe
+    // here because Function.prototype is a root object
     return false;
   }
   return true;

--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -71,7 +71,30 @@ function setSafeProperty (object, prop, value) {
  * @return {boolean} Returns true when safe
  */
 function isSafeProperty (prop) {
-  return !(prop in {});
+  if (!object || typeof object !== 'object') {
+    return false;
+  }
+  // UNSAFE: ghosted
+  // e.g length
+  if (hasOwnProperty(object, prop) && (prop in object.__proto__)) {
+    return false;
+  }
+  // SAFE: whitelisted
+  // e.g length
+  if (hasOwnProperty(safeNativeProperties, prop)) {
+    return true;
+  }
+  // UNSAFE: inherited from Object prototype
+  // e.g constructor
+  if (hasOwnProperty(Object.prototype, prop)) {
+    return false;
+  }
+  // UNSAFE: inherited from Function prototype
+  // e.g call, apply
+  if (hasOwnProperty(Function.prototype, prop)) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -95,27 +118,39 @@ function validateSafeMethod (object, method) {
  * @return {boolean} Returns true when safe, false otherwise
  */
 function isSafeMethod (object, method) {
-  // test for plain functions defined on the object (instead of a method)
-  if (hasOwnProperty(object, method)) {
-    return isPlainObject(object);
+  if (!object || typeof object[method] !== 'function') {
+    return false;
   }
-  else {
-    // only allow methods:
-    // - defined on the prototype of this object
-    // - not defined on the prototype of native Object
-    //   i.e. constructor, __defineGetter__, hasOwnProperty, etc. are not allowed
-    // - calling methods on a function (like bind) is not allowed
-    // - A few safe native methods are allowed: toString, valueOf, toLocaleString
-    return (object && typeof object !== 'function' &&
-        (hasOwnProperty(object.constructor.prototype, method) ||
-            hasOwnProperty(object.__proto__, method)) &&
-        (!hasOwnProperty(Object.prototype, method) || hasOwnProperty(safeNativeMethods, method)));
+  // UNSAFE: ghosted
+  // e.g toString
+  if (hasOwnProperty(object, method) && (method in object.__proto__)) {
+    return false;
   }
+  // SAFE: whitelisted
+  // e.g toString
+  if (hasOwnProperty(safeNativeMethods, method)) {
+    return true;
+  }
+  // UNSAFE: inherited from Object prototype
+  // e.g constructor
+  if (hasOwnProperty(Object.prototype, method)) {
+    return false;
+  }
+  // UNSAFE: inherited from Function prototype
+  // e.g call, apply
+  if (hasOwnProperty(Function.prototype, method)) {
+    return false;
+  }
+  return true;
 }
 
 function isPlainObject (object) {
   return typeof object === 'object' && object && object.constructor === Object;
 }
+
+var safeNativeProperties = {
+  length: true
+};
 
 var safeNativeMethods = {
   toString: true,

--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -70,7 +70,7 @@ function setSafeProperty (object, prop, value) {
  * @param {string} prop
  * @return {boolean} Returns true when safe
  */
-function isSafeProperty (prop) {
+function isSafeProperty (object, prop) {
   if (!object || typeof object !== 'object') {
     return false;
   }

--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -11,18 +11,9 @@ var hasOwnProperty = require('./object').hasOwnProperty;
  * @return {*} Returns the property value when safe
  */
 function getSafeProperty (object, prop) {
-  // only allow getting properties of a plain object
-  if (isPlainObject(object)) {
-    // only allow getting properties defined on the object itself,
-    // not inherited from it's prototype.
-    if (isSafeProperty(object, prop)) {
-      return object[prop];
-    }
-
-    if (!(prop in object)) {
-      // this is a not existing property on a plain object
-      return undefined;
-    }
+  // only allow getting safe properties of a plain object
+  if (isPlainObject(object) && isSafeProperty(object, prop)) {
+    return object[prop];
   }
 
   if (typeof object[prop] === 'function' && isSafeMethod(object, prop)) {
@@ -43,22 +34,9 @@ function getSafeProperty (object, prop) {
  */
 // TODO: merge this function into access.js?
 function setSafeProperty (object, prop, value) {
-  // only allow setting properties of a plain object
-  if (isPlainObject(object)) {
-    // only allow setting properties defined on the object itself,
-    // not inherited from it's prototype.
-    if (prop in object) {
-      // property already exists
-      // override when the property is defined on the object itself.
-      // don't allow overriding inherited properties like .constructor or .toString
-      if (isSafeProperty(object, prop)) {
-        return object[prop] = value;
-      }
-    }
-    else {
-      // this is a new property, that's just ok
-      return object[prop] = value;
-    }
+  // only allow setting safe properties of a plain object
+  if (isPlainObject(object) && isSafeProperty(object, prop)) {
+    return object[prop] = value;
   }
 
   throw new Error('No access to property "' + prop + '"');

--- a/test/expression/security.test.js
+++ b/test/expression/security.test.js
@@ -80,7 +80,7 @@ describe('security', function () {
       math.eval('{}.constructor.assign(cos.constructor, {binding: cos.bind})\n' +
           '{}.constructor.assign(cos.constructor, {bind: null})\n' +
           'cos.constructor.binding()("console.log(\'hacked...\')")()');
-    }, /Error: No access to property "constructor/);
+    }, /Error: No access to property "bind/);
   })
 
   it ('should not allow calling Function via imported, overridden function', function () {

--- a/test/utils/customs.test.js
+++ b/test/utils/customs.test.js
@@ -91,17 +91,25 @@ describe ('customs', function () {
   describe ('isSafeProperty', function () {
 
     it ('plain objects', function () {
-      var object = {
-        foo: true
-      };
+      var object = {};
+
+      /* From Object.prototype:
+        Object.getOwnPropertyNames(Object.prototype).forEach(
+          key => typeof ({})[key] !== 'function' && console.log(key))
+      */
       assert.equal(customs.isSafeProperty(object, '__proto__'), false);
+
+      /* From Function.prototype:
+        Object.getOwnPropertyNames(Function.prototype).forEach(
+          key => typeof (function () {})[key] !== 'function' && console.log(key))
+      */
       assert.equal(customs.isSafeProperty(object, 'length'), true);
       assert.equal(customs.isSafeProperty(object, 'name'), false);
       assert.equal(customs.isSafeProperty(object, 'arguments'), false);
       assert.equal(customs.isSafeProperty(object, 'caller'), false);
 
       // non existing property
-      assert.equal(customs.isSafeProperty(object, 'foo'), true);
+      assert.equal(customs.isSafeProperty(object, 'bar'), true);
 
       // custom inherited property
       var object = {};

--- a/test/utils/customs.test.js
+++ b/test/utils/customs.test.js
@@ -28,6 +28,18 @@ describe ('customs', function () {
 
       // non existing method
       assert.equal(customs.isSafeMethod(object, 'foo'), false);
+
+      // custom inherited method
+      var object = {};
+      object.foo = function () {};
+      object = Object.create(object);
+      assert.equal(customs.isSafeMethod(object, 'foo'), true);
+
+      // ghosted native method
+      var object = {};
+      object.toString = function () {};
+      assert.equal(customs.isSafeMethod(object, 'toString'), false);
+
     });
 
     it ('function objects', function () {
@@ -50,9 +62,15 @@ describe ('customs', function () {
       assert.equal(customs.isSafeMethod(unit, 'toNumeric'), true);
       assert.equal(customs.isSafeMethod(unit, 'toString'), true);
 
-      // extend the class instance with an overridden method
-      matrix.myFunction = function () {};
-      assert.equal(customs.isSafeMethod(matrix, 'myFunction'), false);
+      // extend the class instance with a custom method
+      var object = math.matrix();
+      object.foo = function () {};
+      assert.equal(customs.isSafeMethod(object, 'foo'), true);
+
+      // extend the class instance with a ghosted method
+      var object = math.matrix();
+      object.toJSON = function () {};
+      assert.equal(customs.isSafeMethod(object, 'toJSON'), false);
 
       // unsafe native methods
       assert.equal(customs.isSafeMethod(matrix, 'constructor'), false);

--- a/test/utils/customs.test.js
+++ b/test/utils/customs.test.js
@@ -88,6 +88,37 @@ describe ('customs', function () {
 
   });
 
+  describe ('isSafeProperty', function () {
+
+    it ('plain objects', function () {
+      var object = {
+        foo: true
+      };
+      assert.equal(customs.isSafeProperty(object, '__proto__'), false);
+      assert.equal(customs.isSafeProperty(object, 'length'), true);
+      assert.equal(customs.isSafeProperty(object, 'name'), false);
+      assert.equal(customs.isSafeProperty(object, 'arguments'), false);
+      assert.equal(customs.isSafeProperty(object, 'caller'), false);
+
+      // non existing property
+      assert.equal(customs.isSafeProperty(object, 'foo'), true);
+
+      // custom inherited property
+      var object = {};
+      object.foo = true;
+      object = Object.create(object);
+      assert.equal(customs.isSafeProperty(object, 'foo'), true);
+
+      // ghosted native property
+      var array = [];
+      array = Object.create(array);
+      array.length = Infinity;
+      assert.equal(customs.isSafeProperty(array, 'length'), false);
+
+    });
+
+  });
+
   it ('should distinguish plain objects', function () {
     var a = {};
     var b = Object.create(a);


### PR DESCRIPTION
Restore access to inherited properties and methods removed by the recent security fixes.

Fixes #886

**I am not a security expert so please do review these changes carefully.**

The most significant changes are in c4951c2, commit message:

```
To safely restore inherited properties and methods on plain objects e.g
with Object.create, some overly broad conditions need to be removed and
others added to more explicitly exclude unsafe properties.

isSafeMethod() has been modified as bellow, roughly the same conditions
are also now used in isSafeProperty() for get/setSafeProperty() which
previously restricted all inherited properties.

- Require __proto__ to have own-method
	Intended to prevent ghosting of class methods, but also prevents
	access to properties from further up the chain.

+ Require any own-method to not be in __proto__
	Explicitly prevents ghosting but not inheritance. Possible to
	defeat only if proto chaining through Object.create is allowed.

- Require object to not be function
	Intended to prevent unsafe function methods like 'bind', but
	also restricts function own-properties.

+ Require method not be in Function.prototype
	Explicitly prevents unsafe function methods like 'bind',
	without restricting function own properties.

Other conditions should be equivalent. The overall affect should be
that inherited properties and methods that are safe and not ghosted
should be allowed.
```