### PR TITLE
Syntax error includes hint if single quotes are used for a string

### DIFF
--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -1490,7 +1490,7 @@ function factory (type, config, load, typed) {
       // syntax error or unexpected end of expression
       throw createSyntaxError('Unexpected end of expression');
     } else if (token === "'") {
-      throw createSyntaxError('Value expected. Note: strings must be enclosed by double quotes "');
+      throw createSyntaxError('Value expected. Note: strings must be enclosed by double quotes');
     } else {
       throw createSyntaxError('Value expected');
     }

--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -1489,6 +1489,8 @@ function factory (type, config, load, typed) {
     if (token == '') {
       // syntax error or unexpected end of expression
       throw createSyntaxError('Unexpected end of expression');
+    } else if (token === "'") {
+      throw createSyntaxError('Value expected. Note: strings must be enclosed by double quotes "');
     } else {
       throw createSyntaxError('Value expected');
     }


### PR DESCRIPTION
Small modification to `parse.js`, which checks if the token causing the syntax error is `'` and if so informs the user that double quotes are required for strings.

I reckon this is common gotcha and it would save users time if the syntax error message gives a heads up.

`math.parse("6 + '4'")` gives 
 - Previous behaviour: `SyntaxError: Value expected (char 5)`
 - New behaviour:  `SyntaxError: Value expected - note strings must be enclosed by double quotes (char 5)`