### PR TITLE
Update isSafeProperty ghosting

### DIFF
--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -54,7 +54,8 @@ function isSafeProperty (object, prop) {
   }
   // UNSAFE: ghosted
   // e.g length
-  if (hasOwnProperty(object, prop) && (prop in object.__proto__)) {
+  if (hasOwnProperty(object, prop) &&
+      (prop in Object.prototype || prop in Function.prototype)) {
     return false;
   }
   // SAFE: whitelisted

--- a/test/expression/security.test.js
+++ b/test/expression/security.test.js
@@ -194,7 +194,7 @@ describe('security', function () {
           'k(x)={map:j};' +
           'i={isIndex:true,isScalar:f,size:g,min:h,max:h,dimension:k};' +
           'subset(subset([[[0]]],i),index(1,1,1))("console.log(\'hacked...\')")()')
-    }, /TypeError: Index must be an integer \(value: constructor\)/);
+    }, /Error: No access to property "length"/);
   })
 
   it ('should not allow using restricted properties via subset (2)', function () {

--- a/test/utils/customs.test.js
+++ b/test/utils/customs.test.js
@@ -123,6 +123,12 @@ describe ('customs', function () {
       array.length = Infinity;
       assert.equal(customs.isSafeProperty(array, 'length'), false);
 
+      // ghosted custom property
+      var object = {foo: true};
+      object = Object.create(object);
+      object.foo = false;
+      assert.equal(customs.isSafeProperty(object, 'foo'), true);
+
     });
 
   });


### PR DESCRIPTION
Change condition for property ghosting to match desired behaviour as discussed in #888 :

- Ghosting custom properties are allowed
- Only ghosting properties on Function.prototype or Object.prototype are restricted