### PR TITLE
Remove ghosting from isSafeProperty

### DIFF
--- a/lib/utils/customs.js
+++ b/lib/utils/customs.js
@@ -52,12 +52,6 @@ function isSafeProperty (object, prop) {
   if (!object || typeof object !== 'object') {
     return false;
   }
-  // UNSAFE: ghosted
-  // e.g length
-  if (hasOwnProperty(object, prop) &&
-      (prop in Object.prototype || prop in Function.prototype)) {
-    return false;
-  }
   // SAFE: whitelisted
   // e.g length
   if (hasOwnProperty(safeNativeProperties, prop)) {

--- a/test/expression/security.test.js
+++ b/test/expression/security.test.js
@@ -194,7 +194,7 @@ describe('security', function () {
           'k(x)={map:j};' +
           'i={isIndex:true,isScalar:f,size:g,min:h,max:h,dimension:k};' +
           'subset(subset([[[0]]],i),index(1,1,1))("console.log(\'hacked...\')")()')
-    }, /Error: No access to property "length"/);
+    }, /TypeError: Index must be an integer \(value: constructor\)/);
   })
 
   it ('should not allow using restricted properties via subset (2)', function () {

--- a/test/utils/customs.test.js
+++ b/test/utils/customs.test.js
@@ -111,24 +111,6 @@ describe ('customs', function () {
       // non existing property
       assert.equal(customs.isSafeProperty(object, 'bar'), true);
 
-      // custom inherited property
-      var object = {};
-      object.foo = true;
-      object = Object.create(object);
-      assert.equal(customs.isSafeProperty(object, 'foo'), true);
-
-      // ghosted native property
-      var array = [];
-      array = Object.create(array);
-      array.length = Infinity;
-      assert.equal(customs.isSafeProperty(array, 'length'), false);
-
-      // ghosted custom property
-      var object = {foo: true};
-      object = Object.create(object);
-      object.foo = false;
-      assert.equal(customs.isSafeProperty(object, 'foo'), true);
-
     });
 
   });


### PR DESCRIPTION
From discussion in #888 diallowing ghosting causes problems with natives such as `length` which is both an own property and on the prototype chain and on the root Function.prototype/Array.prototype etc.

There don't appear to be any security concerns for ghosting properties, only for methods.