### PR TITLE
Simplify units before returning numeric value

### DIFF
--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -866,7 +866,7 @@ function factory (type, config, load, typed, math) {
       other = this.to(valuelessUnit);
     }
 
-    this.simplifyUnitListLazy();
+    other.simplifyUnitListLazy();
 
     if(other._isDerived()) {
       return other._denormalize(other.value);

--- a/lib/type/unit/Unit.js
+++ b/lib/type/unit/Unit.js
@@ -866,6 +866,8 @@ function factory (type, config, load, typed, math) {
       other = this.to(valuelessUnit);
     }
 
+    this.simplifyUnitListLazy();
+
     if(other._isDerived()) {
       return other._denormalize(other.value);
     }

--- a/test/type/unit/Unit.test.js
+++ b/test/type/unit/Unit.test.js
@@ -252,6 +252,12 @@ describe('Unit', function() {
       var u = new Unit(math.fraction(1,3), 'cm');
       assert.deepEqual(u.toNumeric('mm'), math.fraction(10,3));
     });
+    it ('should simplify units before returning a numeric value', function () {
+      var cm = new Unit(1, 'cm');
+      var m = new Unit(1, 'm');
+      var product = cm.multiply(m)
+      assert.deepEqual(product.toNumeric(), 0.01);
+    });
   });
 
   describe('to', function() {

--- a/test/type/unit/Unit.test.js
+++ b/test/type/unit/Unit.test.js
@@ -253,10 +253,10 @@ describe('Unit', function() {
       assert.deepEqual(u.toNumeric('mm'), math.fraction(10,3));
     });
     it ('should simplify units before returning a numeric value', function () {
-      var cm = new Unit(1, 'cm');
-      var m = new Unit(1, 'm');
+      var cm = new Unit(1, 'gram');
+      var m = new Unit(1, 'kilogram');
       var product = cm.multiply(m)
-      assert.deepEqual(product.toNumeric(), 0.01);
+      assert.deepEqual(product.toNumeric(), 0.001);
     });
   });
 


### PR DESCRIPTION
This should close #901 . There is a separate issue breaking unit tests when run all at once, which I'll be filing shortly. 