### PR TITLE
Fixed the regex for the '-' symbol in an negative imaginary number

### DIFF
--- a/lib/type/complex/Complex.js
+++ b/lib/type/complex/Complex.js
@@ -82,7 +82,7 @@ function factory (type, config, load, typed, math) {
         if (im == -1) {
           str = strRe + ' - i';
         } else {
-          str = strRe + ' - ' + (/[\d-.]/.test(strIm.charAt(0)) ? strIm.substring(1) : strIm) + 'i';
+          str = strRe + ' - ' + (/[-]/.test(strIm.charAt(0)) ? strIm.substring(1) : strIm) + 'i';
         }
       } else {
         if (im == 1) {

--- a/lib/type/complex/Complex.js
+++ b/lib/type/complex/Complex.js
@@ -82,7 +82,7 @@ function factory (type, config, load, typed, math) {
         if (im == -1) {
           str = strRe + ' - i';
         } else {
-          str = strRe + ' - ' + (/[-]/.test(strIm.charAt(0)) ? strIm.substring(1) : strIm) + 'i';
+          str = strRe + ' - ' + strIm.substring(1) + 'i';
         }
       } else {
         if (im == 1) {


### PR DESCRIPTION
I think you are trying to match the '-' symbol in an negative imaginary number of complex number, but using /[\b-.]/ as regex instead of /[-]/, right?
I found this because of an Exception('org.mozilla.javascript.EcmaError: SyntaxError: Invalid range in character class') appears while I was trying to evaluate math.js with Mozilla Rhino. 