### PR TITLE
just a typo fix for mismatching comment tags to relieve my OCD

### DIFF
--- a/lib/expression/node/FunctionNode.js
+++ b/lib/expression/node/FunctionNode.js
@@ -275,7 +275,7 @@ function factory (type, config, load, typed, math) {
     return '<span class="math-function">' + escape(this.fn) + '</span><span class="math-paranthesis math-round-parenthesis">(</span>' + args.join('<span class="math-separator">,</span>') + '<span class="math-paranthesis math-round-parenthesis">)</span>';
   };
 
-  /*
+  /**
    * Expand a LaTeX template
    *
    * @param {string} template

--- a/lib/utils/function.js
+++ b/lib/utils/function.js
@@ -1,6 +1,6 @@
 // function utils
 
-/*
+/**
  * Memoize a given function by caching the computed result.
  * The cache of a memoized function can be cleared by deleting the `cache`
  * property of the function.


### PR DESCRIPTION
Found 2 misappropriated comment tags. Should have been `/** */`, but was using `/* */`.