### PR TITLE
Fix several issues with internal help

### DIFF
--- a/lib/expression/Help.js
+++ b/lib/expression/Help.js
@@ -67,13 +67,13 @@ function factory (type, config, load, typed) {
         catch (e) {
           res = e;
         }
-        if (res && !type.isHelp(res)) {
+        if (!type.isHelp(res)) {
           desc += '        ' + string.format(res, {precision: 14}) + '\n';
         }
       }
       desc += '\n';
     }
-    if (doc.seealso) {
+    if (doc.seealso && doc.seealso.length) {
       desc += 'See also: ' + doc.seealso.join(', ') + '\n';
     }
 

--- a/lib/expression/docs/constants/phi.js
+++ b/lib/expression/docs/constants/phi.js
@@ -6,7 +6,7 @@ module.exports = {
   ],
   'description': 'Phi is the golden ratio. Two quantities are in the golden ratio if their ratio is the same as the ratio of their sum to the larger of the two quantities. Phi is defined as `(1 + sqrt(5)) / 2` and is approximately 1.618034...',
   'examples': [
-    'tau'
+    'phi'
   ],
   'seealso': []
 };

--- a/lib/expression/docs/construction/number.js
+++ b/lib/expression/docs/construction/number.js
@@ -3,7 +3,8 @@ module.exports = {
   'category': 'Construction',
   'syntax': [
     'x',
-    'number(x)'
+    'number(x)',
+    'number(unit, valuelessUnit)'
   ],
   'description':
       'Create a number or convert a string or boolean into a number.',
@@ -15,7 +16,7 @@ module.exports = {
     'number("7.2")',
     'number(true)',
     'number([true, false, true, true])',
-    'number("52cm", "m")'
+    'number(unit("52cm"), "m")'
   ],
   'seealso': [
     'bignumber', 'boolean', 'complex', 'fraction', 'index', 'matrix', 'string', 'unit'

--- a/lib/expression/docs/function/algebra/derivative.js
+++ b/lib/expression/docs/function/algebra/derivative.js
@@ -2,8 +2,8 @@ module.exports = {
   'name': 'derivative',
   'category': 'Algebra',
   'syntax': [
-    'derivative(expr)',
-    'derivative(expr, {simplify: boolean})'
+    'derivative(expr, variable)',
+    'derivative(expr, variable, {simplify: boolean})'
   ],
   'description': 'Takes the derivative of an expression expressed in parser Nodes. The derivative will be taken over the supplied variable in the second parameter. If there are multiple variables in the expression, it will return a partial derivative.',
   'examples': [

--- a/lib/expression/docs/function/arithmetic/mod.js
+++ b/lib/expression/docs/function/arithmetic/mod.js
@@ -12,7 +12,7 @@ module.exports = {
     '7 % 3',
     '11 % 2',
     '10 mod 4',
-    'function isOdd(x) = x % 2',
+    'isOdd(x) = x % 2',
     'isOdd(2)',
     'isOdd(3)'
   ],

--- a/lib/expression/docs/function/arithmetic/norm.js
+++ b/lib/expression/docs/function/arithmetic/norm.js
@@ -9,12 +9,12 @@ module.exports = {
   'examples': [
     'abs(-3.5)',
     'norm(-3.5)',
-    'norm(3 - 4i))',
+    'norm(3 - 4i)',
     'norm([1, 2, -3], Infinity)',
     'norm([1, 2, -3], -Infinity)',
     'norm([3, 4], 2)',
     'norm([[1, 2], [3, 4]], 1)',
-    'norm([[1, 2], [3, 4]], \'inf\')',
-    'norm([[1, 2], [3, 4]], \'fro\')'
+    'norm([[1, 2], [3, 4]], "inf")',
+    'norm([[1, 2], [3, 4]], "fro")'
   ]
 };

--- a/lib/expression/docs/function/arithmetic/pow.js
+++ b/lib/expression/docs/function/arithmetic/pow.js
@@ -8,7 +8,7 @@ module.exports = {
   'description':
       'Calculates the power of x to y, x^y.',
   'examples': [
-    '2^3 = 8',
+    '2^3',
     '2*2*2',
     '1 + e ^ (pi * i)'
   ],

--- a/lib/expression/docs/function/arithmetic/xgcd.js
+++ b/lib/expression/docs/function/arithmetic/xgcd.js
@@ -4,7 +4,7 @@ module.exports = {
   'syntax': [
     'xgcd(a, b)'
   ],
-  'description': 'Calculate the extended greatest common divisor for two values',
+  'description': 'Calculate the extended greatest common divisor for two values. The result is an array [d, x, y] with 3 entries, where d is the greatest common divisor, and d = x * a + y * b.',
   'examples': [
     'xgcd(8, 12)',
     'gcd(8, 12)',

--- a/lib/expression/docs/function/bitwise/rightArithShift.js
+++ b/lib/expression/docs/function/bitwise/rightArithShift.js
@@ -3,7 +3,7 @@ module.exports = {
   'category': 'Bitwise',
   'syntax': [
     'x >> y',
-    'leftShift(x, y)'
+    'rightArithShift(x, y)'
   ],
   'description': 'Bitwise right arithmetic shift of a value x by y number of bits.',
   'examples': [

--- a/lib/expression/docs/function/bitwise/rightLogShift.js
+++ b/lib/expression/docs/function/bitwise/rightLogShift.js
@@ -2,8 +2,8 @@ module.exports = {
   'name': 'rightLogShift',
   'category': 'Bitwise',
   'syntax': [
-    'x >> y',
-    'leftShift(x, y)'
+    'x >>> y',
+    'rightLogShift(x, y)'
   ],
   'description': 'Bitwise right logical shift of a value x by y number of bits.',
   'examples': [

--- a/lib/expression/docs/function/logical/xor.js
+++ b/lib/expression/docs/function/logical/xor.js
@@ -2,15 +2,15 @@ module.exports = {
   'name': 'xor',
   'category': 'Logical',
   'syntax': [
-    'x or y',
-    'or(x, y)'
+    'x xor y',
+    'xor(x, y)'
   ],
   'description': 'Logical exclusive or, xor. Test whether one and only one value is defined with a nonzero/nonempty value.',
   'examples': [
     'true xor false',
     'false xor false',
     'true xor true',
-    '0 or 4'
+    '0 xor 4'
   ],
   'seealso': [
     'not', 'and', 'or'

--- a/lib/expression/docs/function/matrix/dot.js
+++ b/lib/expression/docs/function/matrix/dot.js
@@ -2,7 +2,8 @@ module.exports = {
   'name': 'dot',
   'category': 'Matrix',
   'syntax': [
-    'dot(A, B)'
+    'dot(A, B)',
+    'A * B'
   ],
   'description': 'Calculate the dot product of two vectors. ' +
       'The dot product of A = [a1, a2, a3, ..., an] and B = [b1, b2, b3, ..., bn] ' +

--- a/lib/expression/docs/function/matrix/eye.js
+++ b/lib/expression/docs/function/matrix/eye.js
@@ -4,8 +4,7 @@ module.exports = {
   'syntax': [
     'eye(n)',
     'eye(m, n)',
-    'eye([m, n])',
-    'eye'
+    'eye([m, n])'
   ],
   'description': 'Returns the identity matrix with size m-by-n. The matrix has ones on the diagonal and zeros elsewhere.',
   'examples': [

--- a/lib/expression/docs/function/matrix/kron.js
+++ b/lib/expression/docs/function/matrix/kron.js
@@ -2,7 +2,7 @@ module.exports = {
   'name': 'kron',
   'category': 'Matrix',
   'syntax': [
-    'math.kron(x, y)'
+    'kron(x, y)'
   ],
   'description': 'Calculates the kronecker product of 2 matrices or vectors.',
   'examples': [

--- a/lib/expression/docs/function/matrix/map.js
+++ b/lib/expression/docs/function/matrix/map.js
@@ -6,7 +6,7 @@ module.exports = {
   ],
   'description': 'Create a new matrix or array with the results of the callback function executed on each entry of the matrix/array.',
   'examples': [
-    'map([1, 2, 3], function(val) { return value * value })'
+    'map([1, 2, 3], square)'
   ],
   'seealso': ['filter', 'forEach']
 };

--- a/lib/expression/docs/function/matrix/ones.js
+++ b/lib/expression/docs/function/matrix/ones.js
@@ -7,8 +7,7 @@ module.exports = {
     'ones(m, n, p, ...)',
     'ones([m])',
     'ones([m, n])',
-    'ones([m, n, p, ...])',
-    'ones'
+    'ones([m, n, p, ...])'
   ],
   'description': 'Create a matrix containing ones.',
   'examples': [

--- a/lib/expression/docs/function/matrix/zeros.js
+++ b/lib/expression/docs/function/matrix/zeros.js
@@ -7,8 +7,7 @@ module.exports = {
     'zeros(m, n, p, ...)',
     'zeros([m])',
     'zeros([m, n])',
-    'zeros([m, n, p, ...])',
-    'zeros'
+    'zeros([m, n, p, ...])'
   ],
   'description': 'Create a matrix containing zeros.',
   'examples': [

--- a/lib/expression/docs/function/probability/factorial.js
+++ b/lib/expression/docs/function/probability/factorial.js
@@ -2,7 +2,8 @@ module.exports = {
   'name': 'factorial',
   'category': 'Probability',
   'syntax': [
-    'kldivergence(x, y)'
+    'n!',
+    'factorial(n)'
   ],
   'description': 'Compute the factorial of a value',
   'examples': [

--- a/lib/expression/docs/function/probability/kldivergence.js
+++ b/lib/expression/docs/function/probability/kldivergence.js
@@ -2,12 +2,11 @@ module.exports = {
   'name': 'kldivergence',
   'category': 'Probability',
   'syntax': [
-    'n!',
-    'factorial(n)'
+    'kldivergence(x, y)'
   ],
   'description': 'Calculate the Kullback-Leibler (KL) divergence  between two distributions.',
   'examples': [
-    'math.kldivergence([0.7,0.5,0.4], [0.2,0.9,0.5])'
+    'kldivergence([0.7,0.5,0.4], [0.2,0.9,0.5])'
   ],
   'seealso': []
 };

--- a/lib/expression/docs/function/probability/multinomial.js
+++ b/lib/expression/docs/function/probability/multinomial.js
@@ -4,7 +4,7 @@ module.exports = {
   'syntax': [
     'multinomial(A)'
   ],
-  'description': 'Multinomial Coefficients compute the number of ways of picking a1, a2, ..., ai unordered outcomes from `n` possibilities. multinomial takes one array of integers as an argument. The following condition must be enforced: every ai <= 0.',
+  'description': 'Multinomial Coefficients compute the number of ways of picking a1, a2, ..., ai unordered outcomes from `n` possibilities. multinomial takes one array of integers as an argument. The following condition must be enforced: every ai > 0.',
   'examples': [
     'multinomial([1, 2, 1])'
   ],

--- a/lib/expression/docs/function/probability/randomInt.js
+++ b/lib/expression/docs/function/probability/randomInt.js
@@ -1,18 +1,18 @@
 module.exports = {
-  'name': 'randInt',
+  'name': 'randomInt',
   'category': 'Probability',
   'syntax': [
-    'randInt(max)',
-    'randInt(min, max)',
-    'randInt(size)',
-    'randInt(size, max)',
-    'randInt(size, min, max)'
+    'randomInt(max)',
+    'randomInt(min, max)',
+    'randomInt(size)',
+    'randomInt(size, max)',
+    'randomInt(size, min, max)'
   ],
   'description':
       'Return a random integer number',
   'examples': [
-    'randInt(10, 20)',
-    'randInt([2, 3], 10)'
+    'randomInt(10, 20)',
+    'randomInt([2, 3], 10)'
   ],
   'seealso': ['pickRandom', 'random']
 };

--- a/lib/expression/docs/function/relational/compareNatural.js
+++ b/lib/expression/docs/function/relational/compareNatural.js
@@ -6,16 +6,16 @@ module.exports = {
   ],
   'description': 'Compare two values of any type in a deterministic, natural way.',
   'examples': [
-    'compare(2, 3)',
-    'compare(3, 2)',
-    'compare(2, 2)',
-    'compare(5cm, 40mm)',
-    'compare("2", "10")',
-    'compare(2 + 3i, 2 + 4i)',
-    'compare([1, 2, 4], [1, 2, 3])',
-    'compare([1, 5], [1, 2, 3])',
-    'compare([1, 2], [1, 2])',
-    'compare({a: 2}, {a: 4})'
+    'compareNatural(2, 3)',
+    'compareNatural(3, 2)',
+    'compareNatural(2, 2)',
+    'compareNatural(5cm, 40mm)',
+    'compareNatural("2", "10")',
+    'compareNatural(2 + 3i, 2 + 4i)',
+    'compareNatural([1, 2, 4], [1, 2, 3])',
+    'compareNatural([1, 5], [1, 2, 3])',
+    'compareNatural([1, 2], [1, 2])',
+    'compareNatural({a: 2}, {a: 4})'
   ],
   'seealso': [
     'equal', 'unequal', 'smaller', 'smallerEq', 'largerEq', 'compare'

--- a/lib/expression/docs/function/relational/deepEqual.js
+++ b/lib/expression/docs/function/relational/deepEqual.js
@@ -7,8 +7,8 @@ module.exports = {
   'description':
       'Check equality of two matrices element wise. Returns true if the size of both matrices is equal and when and each of the elements are equal.',
   'examples': [
-    '[1,3,4] == [1,3,4]',
-    '[1,3,4] == [1,3]'
+    'deepEqual([1,3,4], [1,3,4])',
+    'deepEqual([1,3,4], [1,3])'
   ],
   'seealso': [
     'equal', 'unequal', 'smaller', 'larger', 'smallerEq', 'largerEq', 'compare'

--- a/lib/expression/docs/function/relational/largerEq.js
+++ b/lib/expression/docs/function/relational/largerEq.js
@@ -8,13 +8,13 @@ module.exports = {
   'description':
       'Check if value x is larger or equal to y. Returns true if x is larger or equal to y, and false if not.',
   'examples': [
-    '2 > 1+1',
     '2 >= 1+1',
+    '2 > 1+1',
     'a = 3.2',
     'b = 6-2.8',
-    '(a > b)'
+    '(a >= b)'
   ],
   'seealso': [
-    'equal', 'unequal', 'smallerEq', 'smaller', 'largerEq', 'compare'
+    'equal', 'unequal', 'smallerEq', 'smaller', 'compare'
   ]
 };

--- a/lib/expression/docs/function/relational/smallerEq.js
+++ b/lib/expression/docs/function/relational/smallerEq.js
@@ -8,11 +8,11 @@ module.exports = {
   'description':
       'Check if value x is smaller or equal to value y. Returns true if x is smaller than y, and false if not.',
   'examples': [
-    '2 < 1+1',
     '2 <= 1+1',
+    '2 < 1+1',
     'a = 3.2',
     'b = 6-2.8',
-    '(a < b)'
+    '(a <= b)'
   ],
   'seealso': [
     'equal', 'unequal', 'larger', 'smaller', 'largerEq', 'compare'

--- a/lib/expression/docs/function/statistics/mad.js
+++ b/lib/expression/docs/function/statistics/mad.js
@@ -8,8 +8,7 @@ module.exports = {
   'description': 'Compute the median absolute deviation of a matrix or a list with values. The median absolute deviation is defined as the median of the absolute deviations from the median.',
   'examples': [
     'mad(10, 20, 30)',
-    'mad([1, 2, 3])',
-    'mad(10, 20, 30)'
+    'mad([1, 2, 3])'
   ],
   'seealso': [
     'mean',

--- a/lib/expression/docs/function/statistics/mode.js
+++ b/lib/expression/docs/function/statistics/mode.js
@@ -8,8 +8,9 @@ module.exports = {
   ],
   'description': 'Computes the mode of all values as an array. In case mode being more than one, multiple values are returned in an array.',
   'examples': [
-    'mode(5, 2, 7)',
-    'mode([3, -1, 5, 7])'
+    'mode(2, 1, 4, 3, 1)',
+    'mode([1, 2.7, 3.2, 4, 2.7])',
+    'mode(1, 4, 6, 1, 6)'
   ],
   'seealso': [
     'max',

--- a/lib/expression/docs/function/trigonometry/acoth.js
+++ b/lib/expression/docs/function/trigonometry/acoth.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   'description': 'Calculate the hyperbolic arccotangent of a value, defined as `acoth(x) = (ln((x+1)/x) + ln(x/(x-1))) / 2`.',
   'examples': [
+    'acoth(2)',
     'acoth(0.5)'
   ],
   'seealso': [

--- a/lib/expression/docs/function/trigonometry/acsc.js
+++ b/lib/expression/docs/function/trigonometry/acsc.js
@@ -6,9 +6,9 @@ module.exports = {
   ],
   'description': 'Calculate the inverse cotangent of a value.',
   'examples': [
-    'acsc(0.5)',
+    'acsc(2)',
     'acsc(csc(0.5))',
-    'acsc(2)'
+    'acsc(0.5)'
   ],
   'seealso': [
     'csc',

--- a/lib/expression/docs/function/trigonometry/asin.js
+++ b/lib/expression/docs/function/trigonometry/asin.js
@@ -7,7 +7,7 @@ module.exports = {
   'description': 'Compute the inverse sine of a value in radians.',
   'examples': [
     'asin(0.5)',
-    'asin(sin(2.3))'
+    'asin(sin(0.5))'
   ],
   'seealso': [
     'sin',

--- a/lib/expression/docs/function/trigonometry/atan.js
+++ b/lib/expression/docs/function/trigonometry/atan.js
@@ -7,7 +7,7 @@ module.exports = {
   'description': 'Compute the inverse tangent of a value in radians.',
   'examples': [
     'atan(0.5)',
-    'atan(tan(2.3))'
+    'atan(tan(0.5))'
   ],
   'seealso': [
     'tan',


### PR DESCRIPTION
This pull request fixes several issues with the internal help.

* Omit "See also" section when empty
Some entries (e.g. distance) have an empty array for seealso. It seemed more consistently to me to keep these empty arrays for later expansion, and to check the length instead.
* Show falsy results in examples
The check to omit the result of the help function also accidentally prevented 0 and false from being shown. E.g. try `help(sign)` in the demo on http://mathjs.org/.
* Fix several copy and paste mistakes
* Fix some syntax errors in examples
* Exchanged some examples
Some trigonometry functions used values out of the "normal" range, also `mode` had only examples not showing the actual use of that function.