### PR TITLE
Simplify nested exponentiations

### DIFF
--- a/lib/function/algebra/simplify.js
+++ b/lib/function/algebra/simplify.js
@@ -196,6 +196,9 @@ function factory (type, config, load, typed, math) {
     { l: 'n/n1^n2', r:'n*n1^-n2' }, // temporarily replace 'divide' so we can further flatten the 'multiply' operator
     { l: 'n/n1', r:'n*n1^-1' },
 
+    // expand nested exponentiation
+    { l: '(n ^ n1) ^ n2', r: 'n ^ (n1 * n2)'},
+
     // collect like factors
     { l: 'n*n', r: 'n^2' },
     { l: 'n * n^n1', r: 'n^(n1+1)' },

--- a/test/function/algebra/simplify.test.js
+++ b/test/function/algebra/simplify.test.js
@@ -149,6 +149,12 @@ describe('simplify', function() {
     simplifyAndCompare('x*2*x', '2*x^2');
   });
 
+  it('should handle nested exponentiation', function() {
+    simplifyAndCompare('(x^2)^3', 'x^6');
+    simplifyAndCompare('(x^y)^z', 'x^(y*z)');
+    simplifyAndCompare('8 * x ^ 9 + 2 * (x ^ 3) ^ 3', '10 * x ^ 9');
+  });
+
   it('should not run into an infinite recursive loop', function () {
     simplifyAndCompare('2n - 1', '2 * n - 1');
     simplifyAndCompare('16n - 1', '16 * n - 1');


### PR DESCRIPTION
I randomly stumbled upon this by noticing that the last expression I've added in the unit test (`8 * x ^ 9 + 2 * (x ^ 3) ^ 3`) doesn't simplify to `10 * x ^ 9` as expected.