### PR TITLE
Added rule to simplify that allows for combining of like terms in embedded quantities

### DIFF
--- a/lib/function/algebra/simplify.js
+++ b/lib/function/algebra/simplify.js
@@ -210,6 +210,9 @@ function factory (type, config, load, typed, math) {
     { l: 'n1*n2 + n2', r: '(n1+1)*n2' },
     { l: 'n1*n3 + n2*n3', r: '(n1+n2)*n3' },
 
+    // remove parenthesis in the case of negating a quantitiy
+    { l: 'n1 + -1 * (n2 + n3)', r:'n1 + -1 * n2 + -1 * n3' },
+
     simplifyConstant,
 
     { l: '(-n)*n1', r: '-(n*n1)' }, // make factors positive (and undo 'make non-constant terms positive')
@@ -227,8 +230,8 @@ function factory (type, config, load, typed, math) {
 
     { l: 'n*(n1/n2)', r:'(n*n1)/n2' }, // '*' before '/'
     { l: 'n-(n1+n2)', r:'n-n1-n2' }, // '-' before '+'
-    // { l: '(n1/n2)/n3', r: 'n1/(n2*n3)' }, 
-    // { l: '(n*n1)/(n*n2)', r: 'n1/n2' }, 
+    // { l: '(n1/n2)/n3', r: 'n1/(n2*n3)' },
+    // { l: '(n*n1)/(n*n2)', r: 'n1/n2' },
 
     { l: '1*n', r: 'n' } // this pattern can be produced by simplifyConstant
 
@@ -353,7 +356,7 @@ function factory (type, config, load, typed, math) {
 
         // Create a new node by cloning the rhs of the matched rule
         res = repl.clone();
-     
+
         // Replace placeholders with their respective nodes without traversing deeper into the replaced nodes
         var _transform = function(node) {
           if(node.isSymbolNode && matches.placeholders.hasOwnProperty(node.name)) {
@@ -363,9 +366,9 @@ function factory (type, config, load, typed, math) {
             return node.map(_transform);
           }
         }
-        
+
         res = _transform(res);
-        
+
         // var after = res.toString({parenthesis: 'all'});
         // console.log('Simplified ' + before + ' to ' + after);
       }

--- a/test/function/algebra/simplify.test.js
+++ b/test/function/algebra/simplify.test.js
@@ -166,6 +166,12 @@ describe('simplify', function() {
     simplifyAndCompare('x-1-2x+2', '1-x');
   });
 
+  it('should collect like terms that are embedded in other terms', function() {
+    simplifyAndCompare('10 - (x - 2)', '12 - x');
+    simplifyAndCompare('x - (y + x)', '-y');
+    simplifyAndCompare('x - (y - (y - x))', '0');
+  });
+
   it('should collect separated like factors', function() {
     simplifyAndCompare('x*y*-x/(x^2)', '-y');
     simplifyAndCompare('x/2*x', 'x^2/2');
@@ -228,7 +234,7 @@ describe('simplify', function() {
 
   it('resolve() should substitute scoped constants', function() {
     assert.equal(
-        math.simplify.resolve(math.parse('x+y'), {x:1}).toString(), 
+        math.simplify.resolve(math.parse('x+y'), {x:1}).toString(),
         "1 + y"
     ); // direct
     simplifyAndCompare('x+y', 'x+y', {}); // operator
@@ -242,7 +248,7 @@ describe('simplify', function() {
     simplifyAndCompare('x+y', '6', {x:2,y:math.parse("x+x")});
     simplifyAndCompare('x+(y+2-1-1)', '6', {x:2,y:math.parse("x+x")}); // parentheses
     simplifyAndCompare('log(x+y)', String(Math.log(6)), {x:2,y:math.parse("x+x")}); // function
-    simplifyAndCompare('combinations( ceil(abs(sin(x)) * y), abs(x) )', 
+    simplifyAndCompare('combinations( ceil(abs(sin(x)) * y), abs(x) )',
         'combinations(ceil(0.9092974268256817 * y ), 2)', {x:-2});
 
     // TODO(deal with accessor nodes) simplifyAndCompare('size(text)[1]', '11', {text: "hello world"})


### PR DESCRIPTION
Currently, expressions such as `10 - (x - 2)` and `x - (y + x)` are not at all simplified. The reason why is the outer negation turns into a multiply by `-1`, but this blocks the flattening of the entire expression, so the outer and inner like terms never get a chance to combine.

This pull request adds an additional rule to `simplify` that allows for this flattening to take place by distributing the `-1` factor over the inner terms. While this does fix the cases above (simplifying them to `12 - x` and `-y`, respectively) and related expressions, it does not help with expressions such as `10 - 5 * (x - 2)`. However, the more general cases (such as this one) are more difficult, since we cannot guarantee that these transformations will be useful (consider `10 + (y + 2) * (y - 2)`, should this be multiplied out or not?). As such, for now I think the rule specifically for negatives added in this pull request is a good improvement for now, and at some later point in time we can have a discussion about what behavior we want for `simplify` in such cases.

Also, sorry for all the whitespace changes! My editor makes them automatically.