### PR TITLE
Improves derivative for 3 argument nodes. Closes #1002

### DIFF
--- a/lib/function/algebra/derivative.js
+++ b/lib/function/algebra/derivative.js
@@ -567,21 +567,18 @@ function factory (type, config, load, typed) {
       var arg2 = node.args[1];
 
       switch (node.op) {
-        case '+':
         case '-':
-          // d/dx(+/-f(x)) = +/-f'(x)
-          if (node.args.length == 1) {
-            return new OperatorNode(node.op, node.fn, [_derivative(arg1, constNodes)]);
-          }
-
+          if (node.args.length > 1)
+            new Error('Too many args in subtract OperatorNode');
+        case '+':
           // Linearity of differentiation, d/dx(f(x) +/- g(x)) = f'(x) +/- g'(x)
-          return new OperatorNode(node.op, node.fn, [
-            _derivative(arg1, constNodes),
-            _derivative(arg2, constNodes)
-          ]);
+          return new OperatorNode(node.op, node.fn, node.args.map(function(arg) {
+            return _derivative(arg, constNodes);
+          }));
         case '*':
           // d/dx(c*f(x)) = c*f'(x)
-          if (constNodes[arg1] !== undefined || constNodes[arg2] !== undefined) {
+          // todo I would like to remove this if statement. Would break tests due different order of terms.
+          if (node.args.length === 2 && (constNodes[arg1] !== undefined || constNodes[arg2] !== undefined)) {
             var newArgs = (constNodes[arg1] !== undefined)
               ? [arg1.clone(), _derivative(arg2, constNodes)]
               : [arg2.clone(), _derivative(arg1, constNodes)];
@@ -590,10 +587,13 @@ function factory (type, config, load, typed) {
           }
 
           // Product Rule, d/dx(f(x)*g(x)) = f'(x)*g(x) + f(x)*g'(x)
-          return new OperatorNode('+', 'add', [
-            new OperatorNode('*', 'multiply', [_derivative(arg1, constNodes), arg2.clone()]),
-            new OperatorNode('*', 'multiply', [arg1.clone(), _derivative(arg2, constNodes)])
-          ]);
+          return new OperatorNode('+', 'add', node.args.map(function(argOuter) {
+            return new OperatorNode('*', 'multiply', node.args.map(function(argInner) {
+              return (argInner === argOuter)
+                ? _derivative(argInner, constNodes)
+                : argInner.clone();
+            }));
+          }));
         case '/':
           // d/dx(f(x) / c) = f'(x) / c
           if (constNodes[arg2] !== undefined) {

--- a/lib/function/algebra/derivative.js
+++ b/lib/function/algebra/derivative.js
@@ -568,10 +568,18 @@ function factory (type, config, load, typed) {
 
       switch (node.op) {
         case '-':
-          if (node.args.length > 1)
-            new Error('Too many args in subtract OperatorNode');
-        case '+':
+          // d/dx(+/-f(x)) = +/-f'(x)
+          if (node.args.length == 1) {
+            return new OperatorNode(node.op, node.fn, [_derivative(arg1, constNodes)]);
+          }
+
           // Linearity of differentiation, d/dx(f(x) +/- g(x)) = f'(x) +/- g'(x)
+          return new OperatorNode(node.op, node.fn, [
+            _derivative(arg1, constNodes),
+            _derivative(arg2, constNodes)
+          ]);
+        case '+':
+          // d/dx(sum(f(x)) = sum(f'(x))
           return new OperatorNode(node.op, node.fn, node.args.map(function(arg) {
             return _derivative(arg, constNodes);
           }));

--- a/lib/function/algebra/derivative.js
+++ b/lib/function/algebra/derivative.js
@@ -567,6 +567,11 @@ function factory (type, config, load, typed) {
       var arg2 = node.args[1];
 
       switch (node.op) {
+        case '+':
+          // d/dx(sum(f(x)) = sum(f'(x))
+          return new OperatorNode(node.op, node.fn, node.args.map(function(arg) {
+            return _derivative(arg, constNodes);
+          }));
         case '-':
           // d/dx(+/-f(x)) = +/-f'(x)
           if (node.args.length == 1) {
@@ -578,11 +583,6 @@ function factory (type, config, load, typed) {
             _derivative(arg1, constNodes),
             _derivative(arg2, constNodes)
           ]);
-        case '+':
-          // d/dx(sum(f(x)) = sum(f'(x))
-          return new OperatorNode(node.op, node.fn, node.args.map(function(arg) {
-            return _derivative(arg, constNodes);
-          }));
         case '*':
           // d/dx(c*f(x)) = c*f'(x)
           var constantTerms = node.args.filter(function(arg) {

--- a/lib/function/algebra/derivative.js
+++ b/lib/function/algebra/derivative.js
@@ -577,11 +577,20 @@ function factory (type, config, load, typed) {
           }));
         case '*':
           // d/dx(c*f(x)) = c*f'(x)
-          // todo I would like to remove this if statement. Would break tests due different order of terms.
-          if (node.args.length === 2 && (constNodes[arg1] !== undefined || constNodes[arg2] !== undefined)) {
-            var newArgs = (constNodes[arg1] !== undefined)
-              ? [arg1.clone(), _derivative(arg2, constNodes)]
-              : [arg2.clone(), _derivative(arg1, constNodes)];
+          var constantTerms = node.args.filter(function(arg) {
+            return constNodes[arg] !== undefined;
+          });
+
+          if (constantTerms.length > 0) {
+            var nonConstantTerms = node.args.filter(function(arg) {
+              return constNodes[arg] === undefined;
+            });
+
+            var nonConstantNode = nonConstantTerms.length === 1
+              ? nonConstantTerms[0]
+              : new OperatorNode('*', 'multiply', nonConstantTerms);
+
+            var newArgs = constantTerms.concat(_derivative(nonConstantNode, constNodes));
 
             return new OperatorNode('*', 'multiply', newArgs);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjs",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjs",
-  "version": "3.18.1",
+  "version": "3.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/function/algebra/derivative.test.js
+++ b/test/function/algebra/derivative.test.js
@@ -67,6 +67,12 @@ describe('derivative', function() {
     // With '-': d/dx(5x - x - 2) = 5*1 - 1 - 0 = 4
     compareString(derivativeWithoutSimplify('5x - x - 2', 'x'), '5 * 1 - 1 - 0');
 
+    var threeArgAddition = new OperatorNode('+', 'add', [math.parse('x'), math.parse('sin(x)'), math.parse('5x')]);
+    compareString(derivativeWithoutSimplify(threeArgAddition, 'x'), '1 + 1 * cos(x) + 5 * 1');
+
+    var threeArgMultiplication = new OperatorNode('*', 'multiply', [math.parse('x'), math.parse('sin(x)'), math.parse('5x')]);
+    compareString(derivativeWithoutSimplify(threeArgMultiplication, 'x'), '1 * sin(x) * 5 x + x * 1 * cos(x) * 5 x + x * sin(x) * 5 * 1');
+
 
     // d/dx(2*(x + x)) = 2*(1 + 1)
     compareString(derivativeWithoutSimplify('2(x + x)', 'x'), '2 * (1 + 1)');

--- a/test/function/algebra/derivative.test.js
+++ b/test/function/algebra/derivative.test.js
@@ -52,6 +52,8 @@ describe('derivative', function() {
   it('should take the derivative of a OperatorNodes with ConstantNodes', function() {
     compareString(derivativeWithoutSimplify('1 + 2', 'x'), '0');
     compareString(derivativeWithoutSimplify('-100^2 + 3*3/2 - 12', 'x'), '0');
+    var threeArgMultiplyConstant = new OperatorNode('*', 'multiply', [math.parse('3'), math.parse('7^4'), math.parse('123.124')]);
+    compareString(derivativeWithoutSimplify(threeArgMultiplyConstant, 'x'), 0);
   });
 
   it('should take the derivative of a OperatorNodes with SymbolNodes', function() {
@@ -59,6 +61,9 @@ describe('derivative', function() {
     compareString(derivativeWithoutSimplify('-4x', 'x'), '-4 * 1');
     // d/dx(+4x) = +4*1 = +4
     compareString(derivativeWithoutSimplify('+4x', 'x'), '+4 * 1');
+
+    var threeArgMultiplyConstant = new OperatorNode('*', 'multiply', [math.parse('3'), math.parse('x'), math.parse('sin(x)')]);
+    compareString(derivativeWithoutSimplify(threeArgMultiplyConstant, 'x'), '3 * (1 * sin(x) + x * 1 * cos(x))');
 
 
     // Linearity of differentiation


### PR DESCRIPTION
Extends the rules for '+' and '*' to correctly handle `OperatorNode`'s with three arguments.

Adds tests for these cases.

See #1002 
  