### PR TITLE
Fix `ParenthesisNode.toString()` to include parentheses when `options.parenthesis` is set to 'all'

### DIFF
--- a/lib/expression/node/ParenthesisNode.js
+++ b/lib/expression/node/ParenthesisNode.js
@@ -98,7 +98,7 @@ function factory (type, config, load, typed) {
    * @override
    */
   ParenthesisNode.prototype._toString = function(options) {
-    if ((!options) || (options && !options.parenthesis) || (options && options.parenthesis === 'keep')) {
+    if ((!options) || (options && !options.parenthesis) || (options && options.parenthesis === 'keep') || (options && options.parenthesis === 'all')) {
       return '(' + this.content.toString(options) + ')';
     }
     return this.content.toString(options);
@@ -111,7 +111,7 @@ function factory (type, config, load, typed) {
    * @override
    */
   ParenthesisNode.prototype.toHTML = function(options) {
-    if ((!options) || (options && !options.parenthesis) || (options && options.parenthesis === 'keep')) {
+    if ((!options) || (options && !options.parenthesis) || (options && options.parenthesis === 'keep') || (options && options.parenthesis === 'all')) {
       return '<span class="math-parenthesis math-round-parenthesis">(</span>' + this.content.toHTML(options) + '<span class="math-parenthesis math-round-parenthesis">)</span>';
     }
     return this.content.toHTML(options);
@@ -124,7 +124,7 @@ function factory (type, config, load, typed) {
    * @override
    */
   ParenthesisNode.prototype._toTex = function(options) {
-    if ((!options) || (options && !options.parenthesis) || (options && options.parenthesis === 'keep')) {
+    if ((!options) || (options && !options.parenthesis) || (options && options.parenthesis === 'keep') || (options && options.parenthesis === 'all')) {
       return '\\left(' + this.content.toTex(options) + '\\right)';
     }
     return this.content.toTex(options);

--- a/test/expression/node/ParenthesisNode.test.js
+++ b/test/expression/node/ParenthesisNode.test.js
@@ -150,7 +150,7 @@ describe('ParenthesisNode', function() {
 
     var p = new math.expression.node.ParenthesisNode(c);
 
-    assert.equal(p.toString({parenthesis: 'all'}), '1');
+    assert.equal(p.toString({parenthesis: 'all'}), '(1)');
     assert.equal(p.toString({parenthesis: 'auto'}), '1');
   });
 
@@ -180,7 +180,7 @@ describe('ParenthesisNode', function() {
 
     var p = new math.expression.node.ParenthesisNode(c);
 
-    assert.equal(p.toTex({parenthesis: 'all'}), '1');
+    assert.equal(p.toTex({parenthesis: 'all'}), '\\left(1\\right)');
     assert.equal(p.toTex({parenthesis: 'auto'}), '1');
   });
 


### PR DESCRIPTION
This changes `ParenthesisNode.toString()` to include parentheses when `options.parenthesis` is set to `all`. This change is necessary if we want calling `node.toString({parenthesis: 'all'})` to actually correspond one-to-one to an AST. I would claim that this makes sense, because otherwise their is no way to get a unique string from an AST without a custom `toString()` handler. Since `all` does this for all other node types except `ParenthesisNode`, I suggest we change the definition of `all` from "makes the output precedence unambiguous" (from the [documentation](http://mathjs.org/docs/expressions/customization.html#parenthesis)) to "makes the output unambiguously represent the given AST".

If we don't want to change the definition of `all` (since it is, technically, a breaking change), I would suggest that we add a new option to the `options.parenthesis` enum, perhaps called `unique`, that will cause `toString` to generate a unique representation of the given AST.

