### PR TITLE
WIP: Implements UnaryOperatorNode

### DIFF
--- a/lib/core/typed.js
+++ b/lib/core/typed.js
@@ -66,6 +66,7 @@ exports.create = function create(type) {
   type.isNode = function (x) { return x && x.isNode && x.constructor.prototype.isNode || false };
   type.isObjectNode = function (x) { return x && x.isObjectNode && x.constructor.prototype.isNode || false };
   type.isOperatorNode = function (x) { return x && x.isOperatorNode && x.constructor.prototype.isNode || false };
+  type.isUnaryOperatorNode = function (x) { return x && x.isUnaryOperatorNode && x.constructor.prototype.isNode || false };
   type.isParenthesisNode = function (x) { return x && x.isParenthesisNode && x.constructor.prototype.isNode || false };
   type.isRangeNode = function (x) { return x && x.isRangeNode && x.constructor.prototype.isNode || false };
   type.isSymbolNode = function (x) { return x && x.isSymbolNode && x.constructor.prototype.isNode || false };
@@ -106,6 +107,7 @@ exports.create = function create(type) {
     { name: 'SymbolNode',      test: type.isSymbolNode },
     { name: 'ParenthesisNode', test: type.isParenthesisNode },
     { name: 'FunctionNode',    test: type.isFunctionNode },
+    { name: 'UnaryOperatorNode',         test: type.isUnaryOperatorNode },
     { name: 'FunctionAssignmentNode',    test: type.isFunctionAssignmentNode },
     { name: 'ArrayNode',                 test: type.isArrayNode },
     { name: 'AssignmentNode',            test: type.isAssignmentNode },

--- a/lib/expression/node/UnaryOperatorNode.js
+++ b/lib/expression/node/UnaryOperatorNode.js
@@ -1,27 +1,25 @@
 'use strict';
 
 var latex = require('../../utils/latex');
-var map = require('../../utils/array').map;
 var escape = require('../../utils/string').escape;
 var isSafeMethod = require('../../utils/customs').isSafeMethod;
 var getSafeProperty = require('../../utils/customs').getSafeProperty;
 var operators = require('../operators');
 
-function factory (type, config, load, typed) {
+function factory (type, config, load) {
   var Node = load(require('./Node'));
 
   /**
-   * @constructor OperatorNode
+   * @constructor UnaryOperatorNode
    * @extends {Node}
    * An operator with two arguments, like 2+3
    *
    * @param {string} op           Operator name, for example '+'
    * @param {string} fn           Function name, for example 'add'
-   * @param {Node[]} args         Operator arguments
-   * @param {boolean} [implicit]  Is this an implicit multiplication?
+   * @param {Node} value          Operator argument
    */
-  function OperatorNode(op, fn, args, implicit) {
-    if (!(this instanceof OperatorNode)) {
+  function UnaryOperatorNode(op, fn, value) {
+    if (!(this instanceof UnaryOperatorNode)) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
 
@@ -32,24 +30,20 @@ function factory (type, config, load, typed) {
     if (typeof fn !== 'string') {
       throw new TypeError('string expected for parameter "fn"');
     }
-    if (!Array.isArray(args) || !args.every(type.isNode)) {
-      throw new TypeError('Array containing Nodes expected for parameter "args"');
+    if (!type.isNode(value)) {
+      throw new TypeError('Node expected for parameter "value"');
     }
 
-    if (args.length === 1)
-      throw new Error();
-
-    this.implicit = (implicit === true);
     this.op = op;
     this.fn = fn;
-    this.args = args || [];
+    this.value = value;
   }
 
-  OperatorNode.prototype = new Node();
+  UnaryOperatorNode.prototype = new Node();
 
-  OperatorNode.prototype.type = 'OperatorNode';
+  UnaryOperatorNode.prototype.type = 'UnaryOperatorNode';
 
-  OperatorNode.prototype.isOperatorNode = true;
+  UnaryOperatorNode.prototype.isUnaryOperatorNode = true;
 
   /**
    * Compile a node into a JavaScript function.
@@ -64,7 +58,7 @@ function factory (type, config, load, typed) {
    * @return {function} Returns a function which can be called like:
    *                        evalNode(scope: Object, args: Object, context: *)
    */
-  OperatorNode.prototype._compile = function (math, argNames) {
+  UnaryOperatorNode.prototype._compile = function (math, argNames) {
     // validate fn
     if (typeof this.fn !== 'string' || !isSafeMethod(math, this.fn)) {
       if (!math[this.fn]) {
@@ -76,276 +70,105 @@ function factory (type, config, load, typed) {
     }
 
     var fn = getSafeProperty(math, this.fn);
-    var evalArgs = map(this.args, function (arg) {
-      return arg._compile(math, argNames);
-    });
+    var evalArg = this.value._compile(math, argNames);
 
-    if (evalArgs.length === 1) {
-      var evalArg0 = evalArgs[0];
-      return function evalOperatorNode(scope, args, context) {
-        return fn(evalArg0(scope, args, context));
-      };
-    }
-    else if (evalArgs.length === 2) {
-      var evalArg0 = evalArgs[0];
-      var evalArg1 = evalArgs[1];
-      return function evalOperatorNode(scope, args, context) {
-        return fn(evalArg0(scope, args, context), evalArg1(scope, args, context))
-      };
-    }
-    else {
-      return function evalOperatorNode(scope, args, context) {
-        return fn.apply(null, map(evalArgs, function (evalArg) {
-          return evalArg(scope, args, context)
-        }));
-      };
-    }
-  }
+    return function evalUnaryOperatorNode(scope, args, context) {
+      return fn(evalArg(scope, args, context));
+    };
+  };
 
   /**
    * Execute a callback for each of the child nodes of this node
    * @param {function(child: Node, path: string, parent: Node)} callback
    */
-  OperatorNode.prototype.forEach = function (callback) {
-    for (var i = 0; i < this.args.length; i++) {
-      callback(this.args[i], 'args[' + i + ']', this);
-    }
+  UnaryOperatorNode.prototype.forEach = function (callback) {
+    callback(this.value, 'value', this);
   };
 
   /**
-   * Create a new OperatorNode having it's childs be the results of calling
+   * Create a new UnaryOperatorNode having it's childs be the results of calling
    * the provided callback function for each of the childs of the original node.
    * @param {function(child: Node, path: string, parent: Node): Node} callback
-   * @returns {OperatorNode} Returns a transformed copy of the node
+   * @returns {UnaryOperatorNode} Returns a transformed copy of the node
    */
-  OperatorNode.prototype.map = function (callback) {
-    var args = [];
-    for (var i = 0; i < this.args.length; i++) {
-      args[i] = this._ifNode(callback(this.args[i], 'args[' + i + ']', this));
-    }
-    return new OperatorNode(this.op, this.fn, args);
+  UnaryOperatorNode.prototype.map = function (callback) {
+    return new UnaryOperatorNode(this.op, this.fn, this._ifNode(callback(this.value, 'value', this)));
   };
 
   /**
    * Create a clone of this node, a shallow copy
-   * @return {OperatorNode}
+   * @return {UnaryOperatorNode}
    */
-  OperatorNode.prototype.clone = function () {
-    return new OperatorNode(this.op, this.fn, this.args.slice(0), this.implicit);
+  UnaryOperatorNode.prototype.clone = function () {
+    return new UnaryOperatorNode(this.op, this.fn, this.value);
   };
 
   /**
-   * Calculate which parentheses are necessary. Gets an OperatorNode
+   * Calculate which parentheses are necessary. Gets an UnaryOperatorNode
    * (which is the root of the tree) and an Array of Nodes
-   * (this.args) and returns an array where 'true' means that an argument
+   * (this.value) and returns an array where 'true' means that an argument
    * has to be enclosed in parentheses whereas 'false' means the opposite.
    *
-   * @param {OperatorNode} root
+   * @param {UnaryOperatorNode} root
    * @param {string} parenthesis
-   * @param {Node[]} args
+   * @param {Node} value
    * @param {boolean} latex
-   * @return {boolean[]}
+   * @return {boolean}
    * @private
    */
-  function calculateNecessaryParentheses(root, parenthesis, implicit, args, latex) {
-    //precedence of the root OperatorNode
+  function areParenthesisNeeded(root, parenthesis, value, latex) {
+    //precedence of the root UnaryOperatorNode
     var precedence = operators.getPrecedence(root, parenthesis);
-    var associativity = operators.getAssociativity(root, parenthesis);
 
-    if ((parenthesis === 'all') || ((args.length > 2) && (root.getIdentifier() !== 'OperatorNode:add') && (root.getIdentifier() !== 'OperatorNode:multiply'))) {
-      var parens = args.map(function (arg) {
-        switch (arg.getContent().type) { //Nodes that don't need extra parentheses
-          case 'ArrayNode':
-          case 'ConstantNode':
-          case 'SymbolNode':
-          case 'ParenthesisNode':
-            return false;
-            break;
-          default:
-            return true;
-        }
-      });
-      return parens;
-    }
-
-    var result = undefined;
-    switch (args.length) {
-      case 0:
-        result = [];
-        break;
-
-      case 1: //unary operators
-        //precedence of the operand
-        var operandPrecedence = operators.getPrecedence(args[0], parenthesis);
-
-        //handle special cases for LaTeX, where some of the parentheses aren't needed
-        if (latex && (operandPrecedence !== null)) {
-          var operandIdentifier;
-          var rootIdentifier;
-          if (parenthesis === 'keep') {
-            operandIdentifier = args[0].getIdentifier();
-            rootIdentifier = root.getIdentifier();
-          }
-          else {
-            //Ignore Parenthesis Nodes when not in 'keep' mode
-            operandIdentifier = args[0].getContent().getIdentifier();
-            rootIdentifier = root.getContent().getIdentifier();
-          }
-          if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
-            result = [false];
-            break;
-          }
-
-          if (operators.properties[operandPrecedence][operandIdentifier].latexParens === false) {
-            result = [false];
-            break;
-          }
-        }
-
-        if (operandPrecedence === null) {
-          //if the operand has no defined precedence, no parens are needed
-          result = [false];
-          break;
-        }
-
-        if (operandPrecedence <= precedence) {
-          //if the operands precedence is lower, parens are needed
-          result = [true];
-          break;
-        }
-
-        //otherwise, no parens needed
-        result = [false];
-        break;
-
-      case 2: //binary operators
-        var lhsParens; //left hand side needs parenthesis?
-        //precedence of the left hand side
-        var lhsPrecedence = operators.getPrecedence(args[0], parenthesis);
-        //is the root node associative with the left hand side
-        var assocWithLhs = operators.isAssociativeWith(root, args[0], parenthesis);
-
-        if (lhsPrecedence === null) {
-          //if the left hand side has no defined precedence, no parens are needed
-          //FunctionNode for example
-          lhsParens = false;
-        }
-        else if ((lhsPrecedence === precedence) && (associativity === 'right') && !assocWithLhs) {
-          //In case of equal precedence, if the root node is left associative
-          // parens are **never** necessary for the left hand side.
-          //If it is right associative however, parens are necessary
-          //if the root node isn't associative with the left hand side
-          lhsParens = true;
-        }
-        else if (lhsPrecedence < precedence) {
-          lhsParens = true;
-        }
-        else {
-          lhsParens = false;
-        }
-
-        var rhsParens; //right hand side needs parenthesis?
-        //precedence of the right hand side
-        var rhsPrecedence = operators.getPrecedence(args[1], parenthesis);
-        //is the root node associative with the right hand side?
-        var assocWithRhs = operators.isAssociativeWith(root, args[1], parenthesis);
-
-        if (rhsPrecedence === null) {
-          //if the right hand side has no defined precedence, no parens are needed
-          //FunctionNode for example
-          rhsParens = false;
-        }
-        else if ((rhsPrecedence === precedence) && (associativity === 'left') && !assocWithRhs) {
-          //In case of equal precedence, if the root node is right associative
-          // parens are **never** necessary for the right hand side.
-          //If it is left associative however, parens are necessary
-          //if the root node isn't associative with the right hand side
-          rhsParens = true;
-        }
-        else if (rhsPrecedence < precedence) {
-          rhsParens = true;
-        }
-        else {
-          rhsParens = false;
-        }
-
-        //handle special cases for LaTeX, where some of the parentheses aren't needed
-        if (latex) {
-          var rootIdentifier;
-          var lhsIdentifier;
-          var rhsIdentifier;
-          if (parenthesis === 'keep') {
-            rootIdentifier = root.getIdentifier();
-            lhsIdentifier = root.args[0].getIdentifier();
-            rhsIdentifier = root.args[1].getIdentifier();
-          }
-          else {
-            //Ignore ParenthesisNodes when not in 'keep' mode
-            rootIdentifier = root.getContent().getIdentifier();
-            lhsIdentifier = root.args[0].getContent().getIdentifier();
-            rhsIdentifier = root.args[1].getContent().getIdentifier();
-          }
-
-          if (lhsPrecedence !== null) {
-            if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
-              lhsParens = false;
-            }
-
-            if (operators.properties[lhsPrecedence][lhsIdentifier].latexParens === false) {
-              lhsParens = false;
-            }
-          }
-
-          if (rhsPrecedence !== null) {
-            if (operators.properties[precedence][rootIdentifier].latexRightParens === false) {
-              rhsParens = false;
-            }
-
-            if (operators.properties[rhsPrecedence][rhsIdentifier].latexParens === false) {
-              rhsParens = false;
-            }
-          }
-        }
-
-        result = [lhsParens, rhsParens];
-        break;
-
-      default:
-        if ((root.getIdentifier() === 'OperatorNode:add') || (root.getIdentifier() === 'OperatorNode:multiply')) {
-          var result = args.map(function (arg) {
-            var argPrecedence = operators.getPrecedence(arg, parenthesis);
-            var assocWithArg = operators.isAssociativeWith(root, arg, parenthesis);
-            var argAssociativity = operators.getAssociativity(arg, parenthesis);
-            if (argPrecedence === null) {
-              //if the argument has no defined precedence, no parens are needed
-              return false;
-            } else if ((precedence === argPrecedence) && (associativity === argAssociativity) && !assocWithArg) {
-              return true;
-            } else if (argPrecedence < precedence) {
-              return true;
-            }
-
-            return false;
-          });
-        }
-        break;
-    }
-
-    //handles an edge case of 'auto' parentheses with implicit multiplication of ConstantNode
-    //In that case print parentheses for ParenthesisNodes even though they normally wouldn't be
-    //printed.
-    if ((args.length >= 2) && (root.getIdentifier() === 'OperatorNode:multiply') && root.implicit && (parenthesis === 'auto') && (implicit === 'hide')) {
-      result = args.map(function (arg, index) {
-        var isParenthesisNode = (arg.getIdentifier() === 'ParenthesisNode');
-        if (result[index] || isParenthesisNode) { //put in parenthesis?
+    if (parenthesis === 'all') {
+      switch (value.getContent().type) { //Nodes that don't need extra parentheses
+        case 'ArrayNode':
+        case 'ConstantNode':
+        case 'SymbolNode':
+        case 'ParenthesisNode':
+          return false;
+        default:
           return true;
-        }
-
-        return false;
-      });
+      }
     }
 
-    return result;
+    //precedence of the operand
+    var operandPrecedence = operators.getPrecedence(value, parenthesis);
+
+    //handle special cases for LaTeX, where some of the parentheses aren't needed
+    if (latex && (operandPrecedence !== null)) {
+      var operandIdentifier;
+      var rootIdentifier;
+      if (parenthesis === 'keep') {
+        operandIdentifier = value.getIdentifier();
+        rootIdentifier = root.getIdentifier();
+      }
+      else {
+        //Ignore Parenthesis Nodes when not in 'keep' mode
+        operandIdentifier = value.getContent().getIdentifier();
+        rootIdentifier = root.getContent().getIdentifier();
+      }
+      if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
+        return false;
+      }
+
+      if (operators.properties[operandPrecedence][operandIdentifier].latexParens === false) {
+        return false;
+      }
+    }
+
+    if (operandPrecedence === null) {
+      //if the operand has no defined precedence, no parens are needed
+      return false;
+    }
+
+    if (operandPrecedence <= precedence) {
+      //if the operands precedence is lower, parens are needed
+      return true;
+    }
+
+    //otherwise, no parens needed
+    return false;
   }
 
   /**
@@ -353,63 +176,28 @@ function factory (type, config, load, typed) {
    * @param {Object} options
    * @return {string} str
    */
-  OperatorNode.prototype._toString = function (options) {
+  UnaryOperatorNode.prototype._toString = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var implicit = (options && options.implicit) ? options.implicit : 'hide';
-    var args = this.args;
-    var parens = calculateNecessaryParentheses(this, parenthesis, implicit, args, false);
+    var paren = areParenthesisNeeded(this, parenthesis, this.value, false);
 
-    if (args.length === 1) { //unary operators
-      var assoc = operators.getAssociativity(this, parenthesis);
+    var assoc = operators.getAssociativity(this, parenthesis);
 
-      var operand = args[0].toString(options);
-      if (parens[0]) {
-        operand = '(' + operand + ')';
-      }
-
-      if (assoc === 'right') { //prefix operator
-        return this.op + operand;
-      }
-      else if (assoc === 'left') { //postfix
-        return operand + this.op;
-      }
-
-      //fall back to postfix
-      return operand + this.op;
-    } else if (args.length == 2) {
-      var lhs = args[0].toString(options); //left hand side
-      var rhs = args[1].toString(options); //right hand side
-      if (parens[0]) { //left hand side in parenthesis?
-        lhs = '(' + lhs + ')';
-      }
-      if (parens[1]) { //right hand side in parenthesis?
-        rhs = '(' + rhs + ')';
-      }
-
-      if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit == 'hide')) {
-        return lhs + ' ' + rhs;
-      }
-
-      return lhs + ' ' + this.op + ' ' + rhs;
-    } else if ((args.length > 2) && ((this.getIdentifier() === 'OperatorNode:add') || (this.getIdentifier() === 'OperatorNode:multiply'))) {
-      var stringifiedArgs = args.map(function (arg, index) {
-        arg = arg.toString(options);
-        if (parens[index]) { //put in parenthesis?
-          arg = '(' + arg + ')';
-        }
-
-        return arg;
-      });
-
-      if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit === 'hide')) {
-        return stringifiedArgs.join(' ');
-      }
-
-      return stringifiedArgs.join(' ' + this.op + ' ');
-    } else {
-      //fallback to formatting as a function call
-      return this.fn + '(' + this.args.join(', ') + ')';
+    var operand = this.value.toString(options);
+    console.log("name: ", this.getIdentifier());
+    console.log("assos: ", paren);
+    if (paren) {
+      operand = '(' + operand + ')';
     }
+
+    if (assoc === 'right') { //prefix operator
+      return this.op + operand;
+    }
+    else if (assoc === 'left') { //postfix
+      return operand + this.op;
+    }
+
+    //fall back to postfix
+    return operand + this.op;
   };
 
   /**
@@ -417,65 +205,26 @@ function factory (type, config, load, typed) {
    * @param {Object} options
    * @return {string} str
    */
-  OperatorNode.prototype.toHTML = function (options) {
+  UnaryOperatorNode.prototype.toHTML = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var implicit = (options && options.implicit) ? options.implicit : 'hide';
-    var args = this.args;
-    var parens = calculateNecessaryParentheses(this, parenthesis, implicit, args, false);
+    var paren = areParenthesisNeeded(this, parenthesis, this.value, false);
 
-    if (args.length === 1) { //unary operators
-      var assoc = operators.getAssociativity(this, parenthesis);
+    var assoc = operators.getAssociativity(this, parenthesis);
 
-      var operand = args[0].toHTML(options);
-      if (parens[0]) {
-        operand = '<span class="math-parenthesis math-round-parenthesis">(</span>' + operand + '<span class="math-parenthesis math-round-parenthesis">)</span>';
-      }
+    var operand = this.value.toHTML(options);
+    if (paren) {
+      operand = '<span class="math-parenthesis math-round-parenthesis">(</span>' + operand + '<span class="math-parenthesis math-round-parenthesis">)</span>';
+    }
 
-      if (assoc === 'right') { //prefix operator
-        return '<span class="math-operator math-unary-operator math-lefthand-unary-operator">' + escape(this.op) + '</span>' + operand;
-      }
-      else if (assoc === 'left') { //postfix
-        return '<span class="math-operator math-unary-operator math-righthand-unary-operator">' + escape(this.op) + '</span>' + operand;
-      }
-
-      //fall back to postfix
+    if (assoc === 'right') { //prefix operator
+      return '<span class="math-operator math-unary-operator math-lefthand-unary-operator">' + escape(this.op) + '</span>' + operand;
+    }
+    else if (assoc === 'left') { //postfix
       return '<span class="math-operator math-unary-operator math-righthand-unary-operator">' + escape(this.op) + '</span>' + operand;
     }
-	else if (args.length == 2) { // binary operatoes
-      var lhs = args[0].toHTML(options); //left hand side
-      var rhs = args[1].toHTML(options); //right hand side
-      if (parens[0]) { //left hand side in parenthesis?
-        lhs = '<span class="math-parenthesis math-round-parenthesis">(</span>' + lhs + '<span class="math-parenthesis math-round-parenthesis">)</span>';
-      }
-      if (parens[1]) { //right hand side in parenthesis?
-        rhs = '<span class="math-parenthesis math-round-parenthesis">(</span>' + rhs + '<span class="math-parenthesis math-round-parenthesis">)</span>';
-      }
-	  
-	  if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit == 'hide')) {
-	    return lhs + '<span class="math-operator math-binary-operator math-implicit-binary-operator"></span>' + rhs;
-	  }
-      
-	  return lhs + '<span class="math-operator math-binary-operator math-explicit-binary-operator">' + escape(this.op) + '</span>' + rhs;
-    }
-	else if ((args.length > 2) && ((this.getIdentifier() === 'OperatorNode:add') || (this.getIdentifier() === 'OperatorNode:multiply'))) {
-      var stringifiedArgs = args.map(function (arg, index) {
-        arg = arg.toHTML(options);
-        if (parens[index]) { //put in parenthesis?
-          arg = '<span class="math-parenthesis math-round-parenthesis">(</span>' + arg + '<span class="math-parenthesis math-round-parenthesis">)</span>';
-        }
 
-        return arg;
-      });
-
-      if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit === 'hide')) {
-        return stringifiedArgs.join('<span class="math-operator math-binary-operator math-implicit-binary-operator"></span>');
-      }
-
-      return stringifiedArgs.join('<span class="math-operator math-binary-operator math-explicit-binary-operator">' + escape(this.op) + '</span>');
-    } else {
-      //fallback to formatting as a function call
-      return '<span class="math-function">' + escape(this.fn) + '</span><span class="math-paranthesis math-round-parenthesis">(</span>' + stringifiedArgs.join('<span class="math-separator">,</span>') + '<span class="math-paranthesis math-round-parenthesis">)</span>';
-    }
+    //fall back to postfix
+    return '<span class="math-operator math-unary-operator math-righthand-unary-operator">' + escape(this.op) + '</span>' + operand;
   };
 
   /**
@@ -483,107 +232,41 @@ function factory (type, config, load, typed) {
    * @param {Object} options
    * @return {string} str
    */
-  OperatorNode.prototype._toTex = function (options) {
+  UnaryOperatorNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var implicit = (options && options.implicit) ? options.implicit : 'hide';
-    var args = this.args;
-    var parens = calculateNecessaryParentheses(this, parenthesis, implicit, args, true);
+    var paren = areParenthesisNeeded(this, parenthesis, this.value, true);
     var op = latex.operators[this.fn];
-    op = typeof op === 'undefined' ? this.op : op; //fall back to using this.op
+    op = typeof op === 'undefined' ? this.op : op; // fall back to using this.op
 
-    if (args.length === 1) { //unary operators
-      var assoc = operators.getAssociativity(this, parenthesis);
+    var assoc = operators.getAssociativity(this, parenthesis);
 
-      var operand = args[0].toTex(options);
-      if (parens[0]) {
-        operand = '\\left(' + operand + '\\right)';
-      }
-
-      if (assoc === 'right') { //prefix operator
-        return op + operand;
-      }
-      else if (assoc === 'left') { //postfix operator
-        return operand + op;
-      }
-
-      //fall back to postfix
-      return operand + op;
-    } else if (args.length === 2) { //binary operators
-      var lhs = args[0]; //left hand side
-      var lhsTex = lhs.toTex(options);
-      if (parens[0]) {
-        lhsTex = '\\left(' + lhsTex + '\\right)';
-      }
-
-      var rhs = args[1]; //right hand side
-      var rhsTex = rhs.toTex(options);
-      if (parens[1]) {
-        rhsTex = '\\left(' + rhsTex + '\\right)';
-      }
-
-      //handle some exceptions (due to the way LaTeX works)
-      var lhsIdentifier;
-      if (parenthesis === 'keep') {
-        lhsIdentifier = lhs.getIdentifier();
-      }
-      else {
-        //Ignore ParenthesisNodes if in 'keep' mode
-        lhsIdentifier = lhs.getContent().getIdentifier();
-      }
-      switch (this.getIdentifier()) {
-        case 'OperatorNode:divide':
-          //op contains '\\frac' at this point
-          return op + '{' + lhsTex + '}' + '{' + rhsTex + '}';
-        case 'OperatorNode:pow':
-          lhsTex = '{' + lhsTex + '}';
-          rhsTex = '{' + rhsTex + '}';
-          switch (lhsIdentifier) {
-            case 'ConditionalNode': //
-            case 'OperatorNode:divide':
-              lhsTex = '\\left(' + lhsTex + '\\right)';
-          }
-        case 'OperatorNode:multiply':
-          if (this.implicit && (implicit === 'hide')) {
-            return lhsTex + '~' + rhsTex;
-          }
-      }
-      return lhsTex + op + rhsTex;
-    } else if ((args.length > 2) && ((this.getIdentifier() === 'OperatorNode:add') || (this.getIdentifier() === 'OperatorNode:multiply'))) {
-      var texifiedArgs = args.map(function (arg, index) {
-        arg = arg.toTex(options);
-        if (parens[index]) {
-          arg = '\\left(' + arg + '\\right)';
-        }
-        return arg;
-      });
-
-      if ((this.getIdentifier() === 'OperatorNode:multiply') && this.implicit) {
-        return texifiedArgs.join('~');
-      }
-
-      return texifiedArgs.join(op)
-    } else {
-      //fall back to formatting as a function call
-      //as this is a fallback, it doesn't use
-      //fancy function names
-      return '\\mathrm{' + this.fn + '}\\left('
-          + args.map(function (arg) {
-            return arg.toTex(options);
-          }).join(',') + '\\right)';
+    var operand = this.value.toTex(options);
+    if (paren) {
+      operand = '\\left(' + operand + '\\right)';
     }
+
+    if (assoc === 'right') { // prefix operator
+      return op + operand;
+    }
+    else if (assoc === 'left') { // postfix operator
+      return operand + op;
+    }
+
+    // fall back to postfix
+    return operand + op;
   };
 
   /**
    * Get identifier.
    * @return {string}
    */
-  OperatorNode.prototype.getIdentifier = function () {
+  UnaryOperatorNode.prototype.getIdentifier = function () {
     return this.type + ':' + this.fn;
   };
 
-  return OperatorNode;
+  return UnaryOperatorNode;
 }
 
-exports.name = 'OperatorNode';
+exports.name = 'UnaryOperatorNode';
 exports.path = 'expression.node';
 exports.factory = factory;

--- a/lib/expression/node/UnaryOperatorNode.js
+++ b/lib/expression/node/UnaryOperatorNode.js
@@ -1,0 +1,589 @@
+'use strict';
+
+var latex = require('../../utils/latex');
+var map = require('../../utils/array').map;
+var escape = require('../../utils/string').escape;
+var isSafeMethod = require('../../utils/customs').isSafeMethod;
+var getSafeProperty = require('../../utils/customs').getSafeProperty;
+var operators = require('../operators');
+
+function factory (type, config, load, typed) {
+  var Node = load(require('./Node'));
+
+  /**
+   * @constructor OperatorNode
+   * @extends {Node}
+   * An operator with two arguments, like 2+3
+   *
+   * @param {string} op           Operator name, for example '+'
+   * @param {string} fn           Function name, for example 'add'
+   * @param {Node[]} args         Operator arguments
+   * @param {boolean} [implicit]  Is this an implicit multiplication?
+   */
+  function OperatorNode(op, fn, args, implicit) {
+    if (!(this instanceof OperatorNode)) {
+      throw new SyntaxError('Constructor must be called with the new operator');
+    }
+
+    //validate input
+    if (typeof op !== 'string') {
+      throw new TypeError('string expected for parameter "op"');
+    }
+    if (typeof fn !== 'string') {
+      throw new TypeError('string expected for parameter "fn"');
+    }
+    if (!Array.isArray(args) || !args.every(type.isNode)) {
+      throw new TypeError('Array containing Nodes expected for parameter "args"');
+    }
+
+    if (args.length === 1)
+      throw new Error();
+
+    this.implicit = (implicit === true);
+    this.op = op;
+    this.fn = fn;
+    this.args = args || [];
+  }
+
+  OperatorNode.prototype = new Node();
+
+  OperatorNode.prototype.type = 'OperatorNode';
+
+  OperatorNode.prototype.isOperatorNode = true;
+
+  /**
+   * Compile a node into a JavaScript function.
+   * This basically pre-calculates as much as possible and only leaves open
+   * calculations which depend on a dynamic scope with variables.
+   * @param {Object} math     Math.js namespace with functions and constants. 
+   * @param {Object} argNames An object with argument names as key and `true`
+   *                          as value. Used in the SymbolNode to optimize
+   *                          for arguments from user assigned functions
+   *                          (see FunctionAssignmentNode) or special symbols
+   *                          like `end` (see IndexNode).
+   * @return {function} Returns a function which can be called like:
+   *                        evalNode(scope: Object, args: Object, context: *)
+   */
+  OperatorNode.prototype._compile = function (math, argNames) {
+    // validate fn
+    if (typeof this.fn !== 'string' || !isSafeMethod(math, this.fn)) {
+      if (!math[this.fn]) {
+        throw new Error('Function ' + this.fn + ' missing in provided namespace "math"');
+      }
+      else {
+        throw new Error('No access to function "' + this.fn + '"');
+      }
+    }
+
+    var fn = getSafeProperty(math, this.fn);
+    var evalArgs = map(this.args, function (arg) {
+      return arg._compile(math, argNames);
+    });
+
+    if (evalArgs.length === 1) {
+      var evalArg0 = evalArgs[0];
+      return function evalOperatorNode(scope, args, context) {
+        return fn(evalArg0(scope, args, context));
+      };
+    }
+    else if (evalArgs.length === 2) {
+      var evalArg0 = evalArgs[0];
+      var evalArg1 = evalArgs[1];
+      return function evalOperatorNode(scope, args, context) {
+        return fn(evalArg0(scope, args, context), evalArg1(scope, args, context))
+      };
+    }
+    else {
+      return function evalOperatorNode(scope, args, context) {
+        return fn.apply(null, map(evalArgs, function (evalArg) {
+          return evalArg(scope, args, context)
+        }));
+      };
+    }
+  }
+
+  /**
+   * Execute a callback for each of the child nodes of this node
+   * @param {function(child: Node, path: string, parent: Node)} callback
+   */
+  OperatorNode.prototype.forEach = function (callback) {
+    for (var i = 0; i < this.args.length; i++) {
+      callback(this.args[i], 'args[' + i + ']', this);
+    }
+  };
+
+  /**
+   * Create a new OperatorNode having it's childs be the results of calling
+   * the provided callback function for each of the childs of the original node.
+   * @param {function(child: Node, path: string, parent: Node): Node} callback
+   * @returns {OperatorNode} Returns a transformed copy of the node
+   */
+  OperatorNode.prototype.map = function (callback) {
+    var args = [];
+    for (var i = 0; i < this.args.length; i++) {
+      args[i] = this._ifNode(callback(this.args[i], 'args[' + i + ']', this));
+    }
+    return new OperatorNode(this.op, this.fn, args);
+  };
+
+  /**
+   * Create a clone of this node, a shallow copy
+   * @return {OperatorNode}
+   */
+  OperatorNode.prototype.clone = function () {
+    return new OperatorNode(this.op, this.fn, this.args.slice(0), this.implicit);
+  };
+
+  /**
+   * Calculate which parentheses are necessary. Gets an OperatorNode
+   * (which is the root of the tree) and an Array of Nodes
+   * (this.args) and returns an array where 'true' means that an argument
+   * has to be enclosed in parentheses whereas 'false' means the opposite.
+   *
+   * @param {OperatorNode} root
+   * @param {string} parenthesis
+   * @param {Node[]} args
+   * @param {boolean} latex
+   * @return {boolean[]}
+   * @private
+   */
+  function calculateNecessaryParentheses(root, parenthesis, implicit, args, latex) {
+    //precedence of the root OperatorNode
+    var precedence = operators.getPrecedence(root, parenthesis);
+    var associativity = operators.getAssociativity(root, parenthesis);
+
+    if ((parenthesis === 'all') || ((args.length > 2) && (root.getIdentifier() !== 'OperatorNode:add') && (root.getIdentifier() !== 'OperatorNode:multiply'))) {
+      var parens = args.map(function (arg) {
+        switch (arg.getContent().type) { //Nodes that don't need extra parentheses
+          case 'ArrayNode':
+          case 'ConstantNode':
+          case 'SymbolNode':
+          case 'ParenthesisNode':
+            return false;
+            break;
+          default:
+            return true;
+        }
+      });
+      return parens;
+    }
+
+    var result = undefined;
+    switch (args.length) {
+      case 0:
+        result = [];
+        break;
+
+      case 1: //unary operators
+        //precedence of the operand
+        var operandPrecedence = operators.getPrecedence(args[0], parenthesis);
+
+        //handle special cases for LaTeX, where some of the parentheses aren't needed
+        if (latex && (operandPrecedence !== null)) {
+          var operandIdentifier;
+          var rootIdentifier;
+          if (parenthesis === 'keep') {
+            operandIdentifier = args[0].getIdentifier();
+            rootIdentifier = root.getIdentifier();
+          }
+          else {
+            //Ignore Parenthesis Nodes when not in 'keep' mode
+            operandIdentifier = args[0].getContent().getIdentifier();
+            rootIdentifier = root.getContent().getIdentifier();
+          }
+          if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
+            result = [false];
+            break;
+          }
+
+          if (operators.properties[operandPrecedence][operandIdentifier].latexParens === false) {
+            result = [false];
+            break;
+          }
+        }
+
+        if (operandPrecedence === null) {
+          //if the operand has no defined precedence, no parens are needed
+          result = [false];
+          break;
+        }
+
+        if (operandPrecedence <= precedence) {
+          //if the operands precedence is lower, parens are needed
+          result = [true];
+          break;
+        }
+
+        //otherwise, no parens needed
+        result = [false];
+        break;
+
+      case 2: //binary operators
+        var lhsParens; //left hand side needs parenthesis?
+        //precedence of the left hand side
+        var lhsPrecedence = operators.getPrecedence(args[0], parenthesis);
+        //is the root node associative with the left hand side
+        var assocWithLhs = operators.isAssociativeWith(root, args[0], parenthesis);
+
+        if (lhsPrecedence === null) {
+          //if the left hand side has no defined precedence, no parens are needed
+          //FunctionNode for example
+          lhsParens = false;
+        }
+        else if ((lhsPrecedence === precedence) && (associativity === 'right') && !assocWithLhs) {
+          //In case of equal precedence, if the root node is left associative
+          // parens are **never** necessary for the left hand side.
+          //If it is right associative however, parens are necessary
+          //if the root node isn't associative with the left hand side
+          lhsParens = true;
+        }
+        else if (lhsPrecedence < precedence) {
+          lhsParens = true;
+        }
+        else {
+          lhsParens = false;
+        }
+
+        var rhsParens; //right hand side needs parenthesis?
+        //precedence of the right hand side
+        var rhsPrecedence = operators.getPrecedence(args[1], parenthesis);
+        //is the root node associative with the right hand side?
+        var assocWithRhs = operators.isAssociativeWith(root, args[1], parenthesis);
+
+        if (rhsPrecedence === null) {
+          //if the right hand side has no defined precedence, no parens are needed
+          //FunctionNode for example
+          rhsParens = false;
+        }
+        else if ((rhsPrecedence === precedence) && (associativity === 'left') && !assocWithRhs) {
+          //In case of equal precedence, if the root node is right associative
+          // parens are **never** necessary for the right hand side.
+          //If it is left associative however, parens are necessary
+          //if the root node isn't associative with the right hand side
+          rhsParens = true;
+        }
+        else if (rhsPrecedence < precedence) {
+          rhsParens = true;
+        }
+        else {
+          rhsParens = false;
+        }
+
+        //handle special cases for LaTeX, where some of the parentheses aren't needed
+        if (latex) {
+          var rootIdentifier;
+          var lhsIdentifier;
+          var rhsIdentifier;
+          if (parenthesis === 'keep') {
+            rootIdentifier = root.getIdentifier();
+            lhsIdentifier = root.args[0].getIdentifier();
+            rhsIdentifier = root.args[1].getIdentifier();
+          }
+          else {
+            //Ignore ParenthesisNodes when not in 'keep' mode
+            rootIdentifier = root.getContent().getIdentifier();
+            lhsIdentifier = root.args[0].getContent().getIdentifier();
+            rhsIdentifier = root.args[1].getContent().getIdentifier();
+          }
+
+          if (lhsPrecedence !== null) {
+            if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
+              lhsParens = false;
+            }
+
+            if (operators.properties[lhsPrecedence][lhsIdentifier].latexParens === false) {
+              lhsParens = false;
+            }
+          }
+
+          if (rhsPrecedence !== null) {
+            if (operators.properties[precedence][rootIdentifier].latexRightParens === false) {
+              rhsParens = false;
+            }
+
+            if (operators.properties[rhsPrecedence][rhsIdentifier].latexParens === false) {
+              rhsParens = false;
+            }
+          }
+        }
+
+        result = [lhsParens, rhsParens];
+        break;
+
+      default:
+        if ((root.getIdentifier() === 'OperatorNode:add') || (root.getIdentifier() === 'OperatorNode:multiply')) {
+          var result = args.map(function (arg) {
+            var argPrecedence = operators.getPrecedence(arg, parenthesis);
+            var assocWithArg = operators.isAssociativeWith(root, arg, parenthesis);
+            var argAssociativity = operators.getAssociativity(arg, parenthesis);
+            if (argPrecedence === null) {
+              //if the argument has no defined precedence, no parens are needed
+              return false;
+            } else if ((precedence === argPrecedence) && (associativity === argAssociativity) && !assocWithArg) {
+              return true;
+            } else if (argPrecedence < precedence) {
+              return true;
+            }
+
+            return false;
+          });
+        }
+        break;
+    }
+
+    //handles an edge case of 'auto' parentheses with implicit multiplication of ConstantNode
+    //In that case print parentheses for ParenthesisNodes even though they normally wouldn't be
+    //printed.
+    if ((args.length >= 2) && (root.getIdentifier() === 'OperatorNode:multiply') && root.implicit && (parenthesis === 'auto') && (implicit === 'hide')) {
+      result = args.map(function (arg, index) {
+        var isParenthesisNode = (arg.getIdentifier() === 'ParenthesisNode');
+        if (result[index] || isParenthesisNode) { //put in parenthesis?
+          return true;
+        }
+
+        return false;
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Get string representation.
+   * @param {Object} options
+   * @return {string} str
+   */
+  OperatorNode.prototype._toString = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var implicit = (options && options.implicit) ? options.implicit : 'hide';
+    var args = this.args;
+    var parens = calculateNecessaryParentheses(this, parenthesis, implicit, args, false);
+
+    if (args.length === 1) { //unary operators
+      var assoc = operators.getAssociativity(this, parenthesis);
+
+      var operand = args[0].toString(options);
+      if (parens[0]) {
+        operand = '(' + operand + ')';
+      }
+
+      if (assoc === 'right') { //prefix operator
+        return this.op + operand;
+      }
+      else if (assoc === 'left') { //postfix
+        return operand + this.op;
+      }
+
+      //fall back to postfix
+      return operand + this.op;
+    } else if (args.length == 2) {
+      var lhs = args[0].toString(options); //left hand side
+      var rhs = args[1].toString(options); //right hand side
+      if (parens[0]) { //left hand side in parenthesis?
+        lhs = '(' + lhs + ')';
+      }
+      if (parens[1]) { //right hand side in parenthesis?
+        rhs = '(' + rhs + ')';
+      }
+
+      if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit == 'hide')) {
+        return lhs + ' ' + rhs;
+      }
+
+      return lhs + ' ' + this.op + ' ' + rhs;
+    } else if ((args.length > 2) && ((this.getIdentifier() === 'OperatorNode:add') || (this.getIdentifier() === 'OperatorNode:multiply'))) {
+      var stringifiedArgs = args.map(function (arg, index) {
+        arg = arg.toString(options);
+        if (parens[index]) { //put in parenthesis?
+          arg = '(' + arg + ')';
+        }
+
+        return arg;
+      });
+
+      if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit === 'hide')) {
+        return stringifiedArgs.join(' ');
+      }
+
+      return stringifiedArgs.join(' ' + this.op + ' ');
+    } else {
+      //fallback to formatting as a function call
+      return this.fn + '(' + this.args.join(', ') + ')';
+    }
+  };
+
+  /**
+   * Get HTML representation.
+   * @param {Object} options
+   * @return {string} str
+   */
+  OperatorNode.prototype.toHTML = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var implicit = (options && options.implicit) ? options.implicit : 'hide';
+    var args = this.args;
+    var parens = calculateNecessaryParentheses(this, parenthesis, implicit, args, false);
+
+    if (args.length === 1) { //unary operators
+      var assoc = operators.getAssociativity(this, parenthesis);
+
+      var operand = args[0].toHTML(options);
+      if (parens[0]) {
+        operand = '<span class="math-parenthesis math-round-parenthesis">(</span>' + operand + '<span class="math-parenthesis math-round-parenthesis">)</span>';
+      }
+
+      if (assoc === 'right') { //prefix operator
+        return '<span class="math-operator math-unary-operator math-lefthand-unary-operator">' + escape(this.op) + '</span>' + operand;
+      }
+      else if (assoc === 'left') { //postfix
+        return '<span class="math-operator math-unary-operator math-righthand-unary-operator">' + escape(this.op) + '</span>' + operand;
+      }
+
+      //fall back to postfix
+      return '<span class="math-operator math-unary-operator math-righthand-unary-operator">' + escape(this.op) + '</span>' + operand;
+    }
+	else if (args.length == 2) { // binary operatoes
+      var lhs = args[0].toHTML(options); //left hand side
+      var rhs = args[1].toHTML(options); //right hand side
+      if (parens[0]) { //left hand side in parenthesis?
+        lhs = '<span class="math-parenthesis math-round-parenthesis">(</span>' + lhs + '<span class="math-parenthesis math-round-parenthesis">)</span>';
+      }
+      if (parens[1]) { //right hand side in parenthesis?
+        rhs = '<span class="math-parenthesis math-round-parenthesis">(</span>' + rhs + '<span class="math-parenthesis math-round-parenthesis">)</span>';
+      }
+	  
+	  if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit == 'hide')) {
+	    return lhs + '<span class="math-operator math-binary-operator math-implicit-binary-operator"></span>' + rhs;
+	  }
+      
+	  return lhs + '<span class="math-operator math-binary-operator math-explicit-binary-operator">' + escape(this.op) + '</span>' + rhs;
+    }
+	else if ((args.length > 2) && ((this.getIdentifier() === 'OperatorNode:add') || (this.getIdentifier() === 'OperatorNode:multiply'))) {
+      var stringifiedArgs = args.map(function (arg, index) {
+        arg = arg.toHTML(options);
+        if (parens[index]) { //put in parenthesis?
+          arg = '<span class="math-parenthesis math-round-parenthesis">(</span>' + arg + '<span class="math-parenthesis math-round-parenthesis">)</span>';
+        }
+
+        return arg;
+      });
+
+      if (this.implicit && (this.getIdentifier() === 'OperatorNode:multiply') && (implicit === 'hide')) {
+        return stringifiedArgs.join('<span class="math-operator math-binary-operator math-implicit-binary-operator"></span>');
+      }
+
+      return stringifiedArgs.join('<span class="math-operator math-binary-operator math-explicit-binary-operator">' + escape(this.op) + '</span>');
+    } else {
+      //fallback to formatting as a function call
+      return '<span class="math-function">' + escape(this.fn) + '</span><span class="math-paranthesis math-round-parenthesis">(</span>' + stringifiedArgs.join('<span class="math-separator">,</span>') + '<span class="math-paranthesis math-round-parenthesis">)</span>';
+    }
+  };
+
+  /**
+   * Get LaTeX representation
+   * @param {Object} options
+   * @return {string} str
+   */
+  OperatorNode.prototype._toTex = function (options) {
+    var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
+    var implicit = (options && options.implicit) ? options.implicit : 'hide';
+    var args = this.args;
+    var parens = calculateNecessaryParentheses(this, parenthesis, implicit, args, true);
+    var op = latex.operators[this.fn];
+    op = typeof op === 'undefined' ? this.op : op; //fall back to using this.op
+
+    if (args.length === 1) { //unary operators
+      var assoc = operators.getAssociativity(this, parenthesis);
+
+      var operand = args[0].toTex(options);
+      if (parens[0]) {
+        operand = '\\left(' + operand + '\\right)';
+      }
+
+      if (assoc === 'right') { //prefix operator
+        return op + operand;
+      }
+      else if (assoc === 'left') { //postfix operator
+        return operand + op;
+      }
+
+      //fall back to postfix
+      return operand + op;
+    } else if (args.length === 2) { //binary operators
+      var lhs = args[0]; //left hand side
+      var lhsTex = lhs.toTex(options);
+      if (parens[0]) {
+        lhsTex = '\\left(' + lhsTex + '\\right)';
+      }
+
+      var rhs = args[1]; //right hand side
+      var rhsTex = rhs.toTex(options);
+      if (parens[1]) {
+        rhsTex = '\\left(' + rhsTex + '\\right)';
+      }
+
+      //handle some exceptions (due to the way LaTeX works)
+      var lhsIdentifier;
+      if (parenthesis === 'keep') {
+        lhsIdentifier = lhs.getIdentifier();
+      }
+      else {
+        //Ignore ParenthesisNodes if in 'keep' mode
+        lhsIdentifier = lhs.getContent().getIdentifier();
+      }
+      switch (this.getIdentifier()) {
+        case 'OperatorNode:divide':
+          //op contains '\\frac' at this point
+          return op + '{' + lhsTex + '}' + '{' + rhsTex + '}';
+        case 'OperatorNode:pow':
+          lhsTex = '{' + lhsTex + '}';
+          rhsTex = '{' + rhsTex + '}';
+          switch (lhsIdentifier) {
+            case 'ConditionalNode': //
+            case 'OperatorNode:divide':
+              lhsTex = '\\left(' + lhsTex + '\\right)';
+          }
+        case 'OperatorNode:multiply':
+          if (this.implicit && (implicit === 'hide')) {
+            return lhsTex + '~' + rhsTex;
+          }
+      }
+      return lhsTex + op + rhsTex;
+    } else if ((args.length > 2) && ((this.getIdentifier() === 'OperatorNode:add') || (this.getIdentifier() === 'OperatorNode:multiply'))) {
+      var texifiedArgs = args.map(function (arg, index) {
+        arg = arg.toTex(options);
+        if (parens[index]) {
+          arg = '\\left(' + arg + '\\right)';
+        }
+        return arg;
+      });
+
+      if ((this.getIdentifier() === 'OperatorNode:multiply') && this.implicit) {
+        return texifiedArgs.join('~');
+      }
+
+      return texifiedArgs.join(op)
+    } else {
+      //fall back to formatting as a function call
+      //as this is a fallback, it doesn't use
+      //fancy function names
+      return '\\mathrm{' + this.fn + '}\\left('
+          + args.map(function (arg) {
+            return arg.toTex(options);
+          }).join(',') + '\\right)';
+    }
+  };
+
+  /**
+   * Get identifier.
+   * @return {string}
+   */
+  OperatorNode.prototype.getIdentifier = function () {
+    return this.type + ':' + this.fn;
+  };
+
+  return OperatorNode;
+}
+
+exports.name = 'OperatorNode';
+exports.path = 'expression.node';
+exports.factory = factory;

--- a/lib/expression/node/UnaryOperatorNode.js
+++ b/lib/expression/node/UnaryOperatorNode.js
@@ -183,8 +183,6 @@ function factory (type, config, load) {
     var assoc = operators.getAssociativity(this, parenthesis);
 
     var operand = this.arg.toString(options);
-    console.log("name: ", this.getIdentifier());
-    console.log("assos: ", paren);
     if (paren) {
       operand = '(' + operand + ')';
     }

--- a/lib/expression/node/UnaryOperatorNode.js
+++ b/lib/expression/node/UnaryOperatorNode.js
@@ -16,9 +16,9 @@ function factory (type, config, load) {
    *
    * @param {string} op           Operator name, for example '+'
    * @param {string} fn           Function name, for example 'add'
-   * @param {Node} value          Operator argument
+   * @param {Node} arg          Operator argument
    */
-  function UnaryOperatorNode(op, fn, value) {
+  function UnaryOperatorNode(op, fn, arg) {
     if (!(this instanceof UnaryOperatorNode)) {
       throw new SyntaxError('Constructor must be called with the new operator');
     }
@@ -30,13 +30,13 @@ function factory (type, config, load) {
     if (typeof fn !== 'string') {
       throw new TypeError('string expected for parameter "fn"');
     }
-    if (!type.isNode(value)) {
-      throw new TypeError('Node expected for parameter "value"');
+    if (!type.isNode(arg)) {
+      throw new TypeError('Node expected for parameter "arg"');
     }
 
     this.op = op;
     this.fn = fn;
-    this.value = value;
+    this.arg = arg;
   }
 
   UnaryOperatorNode.prototype = new Node();
@@ -51,7 +51,7 @@ function factory (type, config, load) {
    * calculations which depend on a dynamic scope with variables.
    * @param {Object} math     Math.js namespace with functions and constants. 
    * @param {Object} argNames An object with argument names as key and `true`
-   *                          as value. Used in the SymbolNode to optimize
+   *                          as arg. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions
    *                          (see FunctionAssignmentNode) or special symbols
    *                          like `end` (see IndexNode).
@@ -70,7 +70,7 @@ function factory (type, config, load) {
     }
 
     var fn = getSafeProperty(math, this.fn);
-    var evalArg = this.value._compile(math, argNames);
+    var evalArg = this.arg._compile(math, argNames);
 
     return function evalUnaryOperatorNode(scope, args, context) {
       return fn(evalArg(scope, args, context));
@@ -82,7 +82,7 @@ function factory (type, config, load) {
    * @param {function(child: Node, path: string, parent: Node)} callback
    */
   UnaryOperatorNode.prototype.forEach = function (callback) {
-    callback(this.value, 'value', this);
+    callback(this.arg, 'arg', this);
   };
 
   /**
@@ -92,7 +92,7 @@ function factory (type, config, load) {
    * @returns {UnaryOperatorNode} Returns a transformed copy of the node
    */
   UnaryOperatorNode.prototype.map = function (callback) {
-    return new UnaryOperatorNode(this.op, this.fn, this._ifNode(callback(this.value, 'value', this)));
+    return new UnaryOperatorNode(this.op, this.fn, this._ifNode(callback(this.arg, 'arg', this)));
   };
 
   /**
@@ -100,28 +100,28 @@ function factory (type, config, load) {
    * @return {UnaryOperatorNode}
    */
   UnaryOperatorNode.prototype.clone = function () {
-    return new UnaryOperatorNode(this.op, this.fn, this.value);
+    return new UnaryOperatorNode(this.op, this.fn, this.arg);
   };
 
   /**
    * Calculate which parentheses are necessary. Gets an UnaryOperatorNode
    * (which is the root of the tree) and an Array of Nodes
-   * (this.value) and returns an array where 'true' means that an argument
+   * (this.arg) and returns an array where 'true' means that an argument
    * has to be enclosed in parentheses whereas 'false' means the opposite.
    *
    * @param {UnaryOperatorNode} root
    * @param {string} parenthesis
-   * @param {Node} value
+   * @param {Node} arg
    * @param {boolean} latex
    * @return {boolean}
    * @private
    */
-  function areParenthesisNeeded(root, parenthesis, value, latex) {
+  function areParenthesisNeeded(root, parenthesis, arg, latex) {
     //precedence of the root UnaryOperatorNode
     var precedence = operators.getPrecedence(root, parenthesis);
 
     if (parenthesis === 'all') {
-      switch (value.getContent().type) { //Nodes that don't need extra parentheses
+      switch (arg.getContent().type) { //Nodes that don't need extra parentheses
         case 'ArrayNode':
         case 'ConstantNode':
         case 'SymbolNode':
@@ -133,19 +133,19 @@ function factory (type, config, load) {
     }
 
     //precedence of the operand
-    var operandPrecedence = operators.getPrecedence(value, parenthesis);
+    var operandPrecedence = operators.getPrecedence(arg, parenthesis);
 
     //handle special cases for LaTeX, where some of the parentheses aren't needed
     if (latex && (operandPrecedence !== null)) {
       var operandIdentifier;
       var rootIdentifier;
       if (parenthesis === 'keep') {
-        operandIdentifier = value.getIdentifier();
+        operandIdentifier = arg.getIdentifier();
         rootIdentifier = root.getIdentifier();
       }
       else {
         //Ignore Parenthesis Nodes when not in 'keep' mode
-        operandIdentifier = value.getContent().getIdentifier();
+        operandIdentifier = arg.getContent().getIdentifier();
         rootIdentifier = root.getContent().getIdentifier();
       }
       if (operators.properties[precedence][rootIdentifier].latexLeftParens === false) {
@@ -178,11 +178,11 @@ function factory (type, config, load) {
    */
   UnaryOperatorNode.prototype._toString = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var paren = areParenthesisNeeded(this, parenthesis, this.value, false);
+    var paren = areParenthesisNeeded(this, parenthesis, this.arg, false);
 
     var assoc = operators.getAssociativity(this, parenthesis);
 
-    var operand = this.value.toString(options);
+    var operand = this.arg.toString(options);
     console.log("name: ", this.getIdentifier());
     console.log("assos: ", paren);
     if (paren) {
@@ -207,11 +207,11 @@ function factory (type, config, load) {
    */
   UnaryOperatorNode.prototype.toHTML = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var paren = areParenthesisNeeded(this, parenthesis, this.value, false);
+    var paren = areParenthesisNeeded(this, parenthesis, this.arg, false);
 
     var assoc = operators.getAssociativity(this, parenthesis);
 
-    var operand = this.value.toHTML(options);
+    var operand = this.arg.toHTML(options);
     if (paren) {
       operand = '<span class="math-parenthesis math-round-parenthesis">(</span>' + operand + '<span class="math-parenthesis math-round-parenthesis">)</span>';
     }
@@ -234,13 +234,13 @@ function factory (type, config, load) {
    */
   UnaryOperatorNode.prototype._toTex = function (options) {
     var parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep';
-    var paren = areParenthesisNeeded(this, parenthesis, this.value, true);
+    var paren = areParenthesisNeeded(this, parenthesis, this.arg, true);
     var op = latex.operators[this.fn];
     op = typeof op === 'undefined' ? this.op : op; // fall back to using this.op
 
     var assoc = operators.getAssociativity(this, parenthesis);
 
-    var operand = this.value.toTex(options);
+    var operand = this.arg.toTex(options);
     if (paren) {
       operand = '\\left(' + operand + '\\right)';
     }

--- a/lib/expression/node/index.js
+++ b/lib/expression/node/index.js
@@ -11,6 +11,7 @@ module.exports = [
   require('./Node'),
   require('./ObjectNode'),
   require('./OperatorNode'),
+  require('./UnaryOperatorNode'),
   require('./ParenthesisNode'),
   require('./RangeNode'),
   require('./SymbolNode'),

--- a/lib/expression/operators.js
+++ b/lib/expression/operators.js
@@ -167,6 +167,19 @@ var properties = [
     }
   },
   { //unary prefix operators
+    'UnaryOperatorNode:unaryPlus': {
+      associativity: 'right'
+    },
+    'UnaryOperatorNode:unaryMinus': {
+      associativity: 'right'
+    },
+    'UnaryOperatorNode:bitNot': {
+      associativity: 'right'
+    },
+    'UnaryOperatorNode:not': {
+      associativity: 'right'
+    },
+    // TODO delete these once OperatorNode is removed
     'OperatorNode:unaryPlus': {
       associativity: 'right'
     },
@@ -192,6 +205,16 @@ var properties = [
     'OperatorNode:dotPow': {
       associativity: 'right',
       associativeWith: []
+    }
+  },
+  { //factorial
+    'UnaryOperatorNode:factorial': {
+      associativity: 'left'
+    }
+  },
+  { //matrix transpose
+    'UnaryOperatorNode:transpose': {
+      associativity: 'left'
     }
   },
   { //factorial

--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -14,6 +14,7 @@ function factory (type, config, load, typed) {
   var IndexNode               = load(require('./node/IndexNode'));
   var ObjectNode              = load(require('./node/ObjectNode'));
   var OperatorNode            = load(require('./node/OperatorNode'));
+  var UnaryOperatorNode       = load(require('./node/UnaryOperatorNode'));
   var ParenthesisNode         = load(require('./node/ParenthesisNode'));
   var FunctionNode            = load(require('./node/FunctionNode'));
   var RangeNode               = load(require('./node/RangeNode'));
@@ -957,7 +958,7 @@ function factory (type, config, load, typed) {
           (token === 'in' && type.isConstantNode(node)) ||
           (token_type === TOKENTYPE.NUMBER &&
               !type.isConstantNode(last) &&
-              (!type.isOperatorNode(last) || last.op === '!')) ||
+              (!(type.isOperatorNode(last) || type.isUnaryOperatorNode(last)) || last.op === '!')) ||
           (token === '(')) {
         // parse implicit multiplication
         //
@@ -981,7 +982,7 @@ function factory (type, config, load, typed) {
    * @private
    */
   function parseUnary () {
-    var name, params, fn;
+    var name, fn;
     var operators = {
       '-': 'unaryMinus',
       '+': 'unaryPlus',
@@ -994,9 +995,8 @@ function factory (type, config, load, typed) {
       name = token;
 
       getTokenSkipNewline();
-      params = [parseUnary()];
 
-      return new OperatorNode(name, fn, params);
+      return new UnaryOperatorNode(name, fn, parseUnary());
     }
 
     return parsePow();
@@ -1031,7 +1031,7 @@ function factory (type, config, load, typed) {
    * @private
    */
   function parseLeftHandOperators ()  {
-    var node, operators, name, fn, params;
+    var node, operators, name, fn;
 
     node = parseCustomNodes();
 
@@ -1045,9 +1045,8 @@ function factory (type, config, load, typed) {
       fn = operators[name];
 
       getToken();
-      params = [node];
 
-      node = new OperatorNode(name, fn, params);
+      node = new UnaryOperatorNode(name, fn, node);
       node = parseAccessors(node);
     }
 

--- a/lib/function/algebra/derivative.js
+++ b/lib/function/algebra/derivative.js
@@ -6,6 +6,7 @@ function factory (type, config, load, typed) {
   var ConstantNode = load(require('../../expression/node/ConstantNode'));
   var FunctionNode = load(require('../../expression/node/FunctionNode'));
   var OperatorNode = load(require('../../expression/node/OperatorNode'));
+  var UnaryOperatorNode = load(require('../../expression/node/UnaryOperatorNode'));
   var ParenthesisNode = load(require('../../expression/node/ParenthesisNode'));
   var SymbolNode = load(require('../../expression/node/SymbolNode'));
 
@@ -171,6 +172,10 @@ function factory (type, config, load, typed) {
         }
       }
       return false;
+    },
+
+    'Object, UnaryOperatorNode, string': function (constNodes, node, varName) {
+      return constNodes[node] = constTag(constNodes, node.arg, varName);
     }
   });
 
@@ -556,6 +561,18 @@ function factory (type, config, load, typed) {
         chainDerivative = new OperatorNode('-', 'unaryMinus', [chainDerivative]);
       }
       return new OperatorNode(op, func, [chainDerivative, funcDerivative]);
+    },
+
+    'UnaryOperatorNode, Object': function (node, constNodes) {
+      if (constNodes[node] !== undefined) {
+        return new ConstantNode('0', config.number);
+      }
+      switch (node.op) {
+        case '-':
+          // d/dx(-f(x)) = -f'(x)
+          return new UnaryOperatorNode('-', node.fn, _derivative(node.arg, constNodes));
+        default: throw new Error('Unary operator "' + node.op + '" not supported by derivative');
+      }
     },
 
     'OperatorNode, Object': function (node, constNodes) {

--- a/lib/function/algebra/rationalize.js
+++ b/lib/function/algebra/rationalize.js
@@ -207,9 +207,14 @@ function factory (type, config, load, typed) {
      */
     function recPoly(node) {
       var tp = node.type;  // node type
-      if (tp==='FunctionNode') 
+      if (tp==='FunctionNode')
         throw new ArgumentsError('There is an unsolved function call')   // No function call in polynomial expression
-      else if (tp==='OperatorNode')  {
+      else if (tp==='UnaryOperatorNode') {
+        if (node.op!=='-') {
+          throw new ArgumentsError('Unary operator ' + node.op + ' invalid in polynomial expression');
+        }
+        recPoly(node.arg);
+      } else if (tp==='OperatorNode')  {
         if (node.op==='^')  {
           if (node.args[1].type!=='ConstantNode' ||  ! number.isInteger(parseFloat(node.args[1].value)))
             throw new ArgumentsError('There is a non-integer exponent');
@@ -228,10 +233,10 @@ function factory (type, config, load, typed) {
          if (pos===-1)    // new variable in expression
            variables.push(name);        
 
-      } else if (tp==='ParenthesisNode') 
+      } else if (tp==='ParenthesisNode')
          recPoly(node.content);
 
-      else if (tp!=='ConstantNode')   
+      else if (tp!=='ConstantNode')
          throw new ArgumentsError('type ' + tp + ' is not allowed in polynomial expression')
          
     }  // end of recPoly

--- a/lib/function/algebra/simplify.js
+++ b/lib/function/algebra/simplify.js
@@ -6,6 +6,7 @@ function factory (type, config, load, typed, math) {
   var ConstantNode = load(require('../../expression/node/ConstantNode'));
   var FunctionNode = load(require('../../expression/node/FunctionNode'));
   var OperatorNode = load(require('../../expression/node/OperatorNode'));
+  var UnaryOperatorNode = load(require('../../expression/node/UnaryOperatorNode'));
   var ParenthesisNode = load(require('../../expression/node/ParenthesisNode'));
   var SymbolNode = load(require('../../expression/node/SymbolNode'));
   var Node = load(require('../../expression/node/Node'));
@@ -19,7 +20,18 @@ function factory (type, config, load, typed, math) {
   var flatten = util.flatten;
   var unflattenr = util.unflattenr;
   var unflattenl = util.unflattenl;
-  var createMakeNodeFunction = util.createMakeNodeFunction;
+  var createMakeNodeFunction = function() {
+    var makeNode = util.createMakeNodeFunction.apply(null, arguments);
+
+    return function() {
+      var node = makeNode.apply(null, arguments);
+
+      if (node instanceof UnaryOperatorNode) {
+        return new OperatorNode(node.op, node.fn, [node.arg]);
+      }
+      return node;
+    }
+  };
 
   /**
    * Simplify an expression tree.
@@ -113,7 +125,7 @@ function factory (type, config, load, typed, math) {
       rules = _buildRules(rules);
 
       var res = resolve(expr, scope);
-      var res = removeParens(res);
+      var res = removeUnaryOperatorNode(removeParens(res));
       var visited = {};
 
       var str = res.toString({parenthesis: 'all'});
@@ -143,6 +155,14 @@ function factory (type, config, load, typed, math) {
     return node.transform(function(node, path, parent) {
       return type.isParenthesisNode(node)
           ? node.content
+          : node;
+    });
+  }
+
+  function removeUnaryOperatorNode(node) {
+    return node.transform(function(node, path, parent) {
+      return type.isUnaryOperatorNode(node)
+          ? new OperatorNode(node.op, node.fn, [node.arg])
           : node;
     });
   }
@@ -270,8 +290,8 @@ function factory (type, config, load, typed, math) {
           /* falls through */
         case 'object':
           newRule = {
-            l: removeParens(parse(rule.l)),
-            r: removeParens(parse(rule.r)),
+            l: removeUnaryOperatorNode(removeParens(parse(rule.l))) ,
+            r: removeUnaryOperatorNode(removeParens(parse(rule.r))),
           }
           if(rule.context) {
             newRule.evaluate = rule.context;
@@ -317,6 +337,12 @@ function factory (type, config, load, typed, math) {
    * @return {ConstantNode | SymbolNode | ParenthesisNode | FunctionNode | OperatorNode} The simplified form of `expr`, or the original node if no simplification was possible.
    */
   var applyRule = typed('applyRule', {
+
+    'UnaryOperatorNode, Object': function (node, rule) {
+      return applyRule(new OperatorNode(node.op, node.fn, [node.arg]), rule);
+    },
+
+
     'Node, Object': function (node, rule) {
 
       //console.log('Entering applyRule(' + node.toString() + ')');

--- a/lib/function/algebra/simplify/simplifyConstant.js
+++ b/lib/function/algebra/simplify/simplifyConstant.js
@@ -10,6 +10,7 @@ function factory(type, config, load, typed, math) {
   var createMakeNodeFunction = util.createMakeNodeFunction;
   var ConstantNode = math.expression.node.ConstantNode;
   var OperatorNode = math.expression.node.OperatorNode;
+  var UnaryOperatorNode = math.expression.node.UnaryOperatorNode;
   var FunctionNode = math.expression.node.FunctionNode;
 
   function simplifyConstant(expr) {
@@ -235,6 +236,11 @@ function factory(type, config, load, typed, math) {
           res = foldOp(fn, args, makeNode);
         }
         return res;
+      case 'UnaryOperatorNode':
+        var value = [foldFraction(node.value)];
+        return !type.isNode(value)
+          ? _eval(node.fn.toString(), [value])
+          : createMakeNodeFunction(node)([value]);
       case 'ParenthesisNode':
         // remove the uneccessary parenthesis
         return foldFraction(node.content);

--- a/lib/function/algebra/simplify/simplifyConstant.js
+++ b/lib/function/algebra/simplify/simplifyConstant.js
@@ -237,7 +237,7 @@ function factory(type, config, load, typed, math) {
         }
         return res;
       case 'UnaryOperatorNode':
-        var value = [foldFraction(node.value)];
+        var value = foldFraction(node.arg);
         return !type.isNode(value)
           ? _eval(node.fn.toString(), [value])
           : createMakeNodeFunction(node)([value]);

--- a/lib/function/algebra/simplify/simplifyCore.js
+++ b/lib/function/algebra/simplify/simplifyCore.js
@@ -3,6 +3,7 @@
 function factory(type, config, load, typed, math) {
   var ConstantNode = math.expression.node.ConstantNode;
   var OperatorNode = math.expression.node.OperatorNode;
+  var UnaryOperatorNode = math.expression.node.UnaryOperatorNode;
   var FunctionNode = math.expression.node.FunctionNode;
   var ParenthesisNode = math.expression.node.ParenthesisNode;
 
@@ -33,7 +34,17 @@ function factory(type, config, load, typed, math) {
    *     The expression to be simplified
    */
   function simplifyCore(node) {
-    if (type.isOperatorNode(node) && node.args.length <= 2) {
+    if (type.isUnaryOperatorNode(node)) {
+      var a = simplifyCore(node.arg);
+      if (node.op === '-') {
+          if (type.isUnaryOperatorNode(a)) {
+              return a.arg;
+          } else if (type.isOperatorNode(a)) {
+              return new OperatorNode('-', 'subtract', [a.args[1], a.args[0]]);
+          }
+      }
+      return new UnaryOperatorNode(node.op, node.fn, a);
+    } else if (type.isOperatorNode(node) && node.args.length <= 2) {
       var a0 = simplifyCore(node.args[0]);
       var a1 = node.args[1] && simplifyCore(node.args[1]);
       if (node.op === "+") {
@@ -66,12 +77,16 @@ function factory(type, config, load, typed, math) {
               if (type.isConstantNode(a1) && a1.value === "0") {
                   return a0;
               }
-              if (type.isOperatorNode(a1) && a1.fn === "unaryMinus") {
+              if (type.isUnaryOperatorNode(a1) && a1.op === '-') {
+                  return simplifyCore(new OperatorNode('+', 'add', [a0, a1.arg]));
+              } else if (type.isOperatorNode(a1) && a1.fn === "unaryMinus") {
                   return simplifyCore(new OperatorNode("+", "add", [a0, a1.args[0]]));
               }
               return new OperatorNode(node.op, node.fn, [a0,a1]);
           } else if (node.fn === "unaryMinus") {
-              if (type.isOperatorNode(a0)) {
+              if (type.isUnaryOperatorNode(a0) && a0.op === '-') {
+                  return a0.arg;
+              } else if (type.isOperatorNode(a0)) {
                   if (a0.fn === 'unaryMinus') {
                       return a0.args[0];
                   } else if (a0.fn === 'subtract') {

--- a/lib/function/algebra/simplify/util.js
+++ b/lib/function/algebra/simplify/util.js
@@ -3,6 +3,7 @@
 function factory(type, config, load, typed, math) {
   var FunctionNode = math.expression.node.FunctionNode;
   var OperatorNode = math.expression.node.OperatorNode;
+  var UnaryOperatorNode = math.expression.node.UnaryOperatorNode;
   var SymbolNode = math.expression.node.SymbolNode;
 
   // TODO commutative/associative properties rely on the arguments
@@ -132,10 +133,22 @@ function factory(type, config, load, typed, math) {
         try{
           return new OperatorNode(node.op, node.fn, args);
         } catch(err){
+          // TODO: why are errors ignored here
           console.error(err);
           return [];
         }
       };
+    }
+    else if (type.isUnaryOperatorNode(node)) {
+      return function(args) {
+
+        // TODO: should errors be ignored (see OperatorNode)
+        if (args.length !== 1) {
+          throw new Error("Exactly one argument is required to make a UnaryOperatorNode");
+        }
+
+        return new UnaryOperatorNode(node.op, node.fn, args[0]);
+      }
     }
     else {
       return function(args){

--- a/test/expression/node/UnaryOperatorNode.test.js
+++ b/test/expression/node/UnaryOperatorNode.test.js
@@ -1,0 +1,757 @@
+// test OperatorNode
+var assert = require('assert');
+var approx = require('../../../tools/approx');
+var math = require('../../../index');
+var Node = math.expression.node.Node;
+var ConstantNode = math.expression.node.ConstantNode;
+var SymbolNode = math.expression.node.SymbolNode;
+var OperatorNode = math.expression.node.OperatorNode;
+var ConditionalNode = math.expression.node.ConditionalNode;
+
+describe('OperatorNode', function() {
+
+  it ('should create an OperatorNode', function () {
+    var n = new OperatorNode('op', 'fn', []);
+    assert(n instanceof OperatorNode);
+    assert(n instanceof Node);
+    assert.equal(n.type, 'OperatorNode');
+  });
+
+  it ('should have isOperatorNode', function () {
+    var node = new OperatorNode('op', 'fn', []);
+    assert(node.isOperatorNode);
+  });
+
+  it ('should throw an error when calling without new operator', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    assert.throws(function () {OperatorNode('+', 'add', [a, b])}, SyntaxError);
+  });
+
+  it ('should compile an OperatorNode', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    var expr = n.compile();
+
+    assert.equal(expr.eval(), 5);
+  });
+
+  it ('should throw an error in case of unresolved operator function', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    var n = new OperatorNode('***', 'foo', [a, b]);
+
+    assert.throws(function () {
+      n.compile();
+    }, /Function foo missing in provided namespace/);
+  });
+
+  it ('should filter an OperatorNode', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    assert.deepEqual(n.filter(function (node) {return node instanceof OperatorNode}),  [n]);
+    assert.deepEqual(n.filter(function (node) {return node instanceof SymbolNode}),    []);
+    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode}),  [a, b]);
+    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode && node.value == '2'}),  [a]);
+    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode && node.value == '4'}),  []);
+  });
+
+  it ('should filter an OperatorNode without contents', function () {
+    var n = new OperatorNode('op', 'fn', []);
+
+    assert.deepEqual(n.filter(function (node) {return node instanceof OperatorNode}),  [n]);
+    assert.deepEqual(n.filter(function (node) {return node instanceof SymbolNode}),    []);
+  });
+
+  it ('should run forEach on an OperatorNode', function () {
+    // x^2-x
+    var a = new SymbolNode('x');
+    var b = new ConstantNode(2);
+    var c = new OperatorNode('^', 'pow', [a, b]);
+    var d = new SymbolNode('x');
+    var e = new OperatorNode('-', 'subtract', [c, d]);
+
+    var nodes = [];
+    var paths = [];
+    e.forEach(function (node, path, parent) {
+      nodes.push(node);
+      paths.push(path);
+      assert.strictEqual(parent, e);
+    });
+
+    assert.equal(nodes.length, 2);
+    assert.strictEqual(nodes[0], c);
+    assert.strictEqual(nodes[1], d);
+    assert.deepEqual(paths, ['args[0]', 'args[1]']);
+  });
+
+  it ('should map an OperatorNode', function () {
+    // x^2-x
+    var a = new SymbolNode('x');
+    var b = new ConstantNode(2);
+    var c = new OperatorNode('^', 'pow', [a, b]);
+    var d = new SymbolNode('x');
+    var e = new OperatorNode('-', 'subtract', [c, d]);
+
+    var nodes = [];
+    var paths = [];
+    var f = new ConstantNode(3);
+    var g = e.map(function (node, path, parent) {
+      nodes.push(node);
+      paths.push(path);
+      assert.strictEqual(parent, e);
+
+      return node instanceof SymbolNode && node.name == 'x' ? f : node;
+    });
+
+    assert.equal(nodes.length, 2);
+    assert.strictEqual(nodes[0], c);
+    assert.strictEqual(nodes[1], d);
+    assert.deepEqual(paths, ['args[0]', 'args[1]']);
+
+    assert.notStrictEqual(g,  e);
+    assert.strictEqual(g.args[0], e.args[0]);
+    assert.strictEqual(g.args[0].args[0], a); // nested x is not replaced
+    assert.deepEqual(g.args[0].args[1], b);
+    assert.deepEqual(g.args[1],  f);
+  });
+
+  it ('should throw an error when the map callback does not return a node', function () {
+    var a = new SymbolNode('x');
+    var b = new ConstantNode(2);
+    var c = new OperatorNode('^', 'pow', [a, b]);
+
+    assert.throws(function () {
+      c.map(function () {});
+    }, /Callback function must return a Node/)
+  });
+
+  it ('should transform an OperatorNodes parameters', function () {
+    // x^2-x
+    var a = new SymbolNode('x');
+    var b = new ConstantNode(2);
+    var c = new OperatorNode('^', 'pow', [a, b]);
+    var d = new SymbolNode('x');
+    var e = new OperatorNode('-', 'subtract', [c, d]);
+
+    var f = new ConstantNode(3);
+    var g = e.transform(function (node) {
+      return node instanceof SymbolNode && node.name == 'x' ? f : node;
+    });
+
+    assert.deepEqual(g.args[1],  f);
+  });
+
+  it ('should transform an OperatorNode itself', function () {
+    // x^2-x
+    var a = new SymbolNode('x');
+    var b = new ConstantNode(2);
+    var c = new OperatorNode('+', 'add', [a, b]);
+
+    var f = new ConstantNode(3);
+    var g = c.transform(function (node) {
+      return node instanceof OperatorNode ? f : node;
+    });
+
+    assert.notStrictEqual(g, c);
+    assert.deepEqual(g,  f);
+  });
+
+  it ('should clone an OperatorNode', function () {
+    // x^2-x
+    var a = new SymbolNode('x');
+    var b = new ConstantNode(2);
+    var c = new OperatorNode('+', 'add', [a, b]);
+
+    var d = c.clone();
+    assert(d instanceof OperatorNode);
+    assert.deepEqual(d, c);
+    assert.notStrictEqual(d, c);
+    assert.notStrictEqual(d.args, c.args);
+    assert.strictEqual(d.args[0], c.args[0]);
+    assert.strictEqual(d.args[1], c.args[1]);
+  });
+
+  it ('should clone implicit multiplications', function () {
+    var two = new ConstantNode(2);
+    var x = new SymbolNode('x');
+    var node = new OperatorNode('*', 'multiply', [two, x], true);
+
+    assert.equal('2 x', node.toString());
+    assert.strictEqual(true, node.clone().implicit);
+    assert.equal(node.toString(), node.clone().toString());
+  });
+
+  it ('test equality another Node', function () {
+    var a = new OperatorNode('+', 'add', [new SymbolNode('x'), new ConstantNode(2)]);
+    var b = new OperatorNode('+', 'add', [new SymbolNode('x'), new ConstantNode(2)]);
+    var c = new OperatorNode('*', 'multiply', [new SymbolNode('x'), new ConstantNode(2)]);
+    var d = new OperatorNode('*', 'add', [new SymbolNode('x'), new ConstantNode(3)]);
+    var e = new OperatorNode('*', 'add', [new SymbolNode('x'), new ConstantNode(2), new ConstantNode(4)]);
+
+    assert.strictEqual(a.equals(null), false);
+    assert.strictEqual(a.equals(undefined), false);
+    assert.strictEqual(a.equals(b), true);
+    assert.strictEqual(a.equals(c), false);
+    assert.strictEqual(a.equals(d), false);
+    assert.strictEqual(a.equals(e), false);
+  });
+
+  describe('toString', function () {
+    it ('should stringify an OperatorNode', function () {
+      var a = new ConstantNode(2);
+      var b = new ConstantNode(3);
+      var c = new ConstantNode(4);
+
+      var n = new OperatorNode('+', 'add', [a, b]);
+      assert.equal(n.toString(), '2 + 3');
+    });
+
+    it ('should stringify an OperatorNode with factorial', function () {
+      var a = new ConstantNode(2);
+      var n = new OperatorNode('!', 'factorial', [a]);
+      assert.equal(n.toString(), '2!');
+    });
+
+    it ('should stringify an OperatorNode with unary minus', function () {
+      var a = new ConstantNode(2);
+      var n = new OperatorNode('-', 'unaryMinus', [a]);
+      assert.equal(n.toString(), '-2');
+    });
+
+    it ('should stringify an OperatorNode with zero arguments', function () {
+      var n = new OperatorNode('foo', 'foo', []);
+      assert.equal(n.toString(), 'foo()');
+    });
+
+    it ('should stringify an OperatorNode with more than two operators', function () {
+      var a = new ConstantNode(2);
+      var b = new ConstantNode(3);
+      var c = new ConstantNode(4);
+
+      var n = new OperatorNode('foo', 'foo', [a, b, c]);
+      assert.equal(n.toString(), 'foo(2, 3, 4)');
+
+    });
+
+    it ('should stringify addition and multiplication with more than two operands', function () {
+      var a = new SymbolNode('a');
+      var b = new SymbolNode('b');
+      var c = new SymbolNode('c');
+
+      var add = new OperatorNode('+', 'add', [a, b, c]);
+      var multiply = new OperatorNode('*', 'multiply', [a, b, c]);
+      var implicitMultiply = new OperatorNode('*', 'multiply', [a, b, c], true);
+
+      assert.equal(add.toString(), 'a + b + c');
+      assert.equal(multiply.toString(), 'a * b * c');
+      assert.equal(implicitMultiply.toString(), 'a b c');
+    });
+
+    it ('should stringify addition and multiplication with more than two operands including OperatorNode', function () {
+      var a = new SymbolNode('a');
+      var b = new SymbolNode('b');
+      var c = new SymbolNode('c');
+      var d = new SymbolNode('d');
+
+      var mult = new OperatorNode('*', 'multiply', [a,b]);
+      var add = new OperatorNode('+', 'add', [a, b]);
+
+      var multipleMultWithMult = new OperatorNode('*', 'multiply', [c, mult, d]);
+      var multipleMultWithAdd = new OperatorNode('*', 'multiply', [c, add, d]);
+      var multipleAddWithMult = new OperatorNode('+', 'add', [c, mult, d]);
+      var multipleAddWithAdd = new OperatorNode('+', 'add', [c, add, d]);
+
+      assert.equal(multipleMultWithMult.toString(), 'c * a * b * d');
+      assert.equal(multipleMultWithAdd.toString(), 'c * (a + b) * d');
+      assert.equal(multipleAddWithMult.toString(), 'c + a * b + d');
+      assert.equal(multipleAddWithAdd.toString(), 'c + a + b + d');
+    });
+
+    it ('should stringify an OperatorNode that contains an operatornode with more than two operands', function () {
+      var a = new SymbolNode('a');
+      var b = new SymbolNode('b');
+      var c = new SymbolNode('c');
+      var d = new SymbolNode('d');
+
+      var mult = new OperatorNode('*', 'multiply', [a, b, c]);
+      var add = new OperatorNode('+', 'add', [a, b, c]);
+
+      var addWithMult = new OperatorNode('+', 'add', [mult, d]);
+      var addWithAdd = new OperatorNode('+', 'add', [add, d]);
+      var multWithMult = new OperatorNode('*', 'multiply', [mult, d]);
+      var multWithAdd = new OperatorNode('*', 'multiply', [add, d]);
+
+      assert.equal(addWithMult.toString(), 'a * b * c + d');
+      assert.equal(addWithAdd.toString(), 'a + b + c + d');
+      assert.equal(multWithMult.toString(), 'a * b * c * d');
+      assert.equal(multWithAdd.toString(), '(a + b + c) * d');
+
+    });
+
+    it ('should stringify an OperatorNode with nested operator nodes', function () {
+      var a = new ConstantNode(2);
+      var b = new ConstantNode(3);
+      var c = new ConstantNode(4);
+      var d = new ConstantNode(5);
+
+      var n1 = new OperatorNode('+', 'add', [a, b]);
+      var n2 = new OperatorNode('-', 'subtract', [c, d]);
+      var n3 = new OperatorNode('*', 'multiply', [n1, n2]);
+
+      assert.equal(n1.toString(), '2 + 3');
+      assert.equal(n2.toString(), '4 - 5');
+      assert.equal(n3.toString(), '(2 + 3) * (4 - 5)');
+    });
+
+    it ('should stringify left associative OperatorNodes that are associative with another Node', function () {
+      assert.equal(math.parse('(a+b)+c').toString({parenthesis: 'auto'}), 'a + b + c');
+      assert.equal(math.parse('a+(b+c)').toString({parenthesis: 'auto'}), 'a + b + c');
+      assert.equal(math.parse('(a+b)-c').toString({parenthesis: 'auto'}), 'a + b - c');
+      assert.equal(math.parse('a+(b-c)').toString({parenthesis: 'auto'}), 'a + b - c');
+
+      assert.equal(math.parse('(a*b)*c').toString({parenthesis: 'auto'}), 'a * b * c');
+      assert.equal(math.parse('a*(b*c)').toString({parenthesis: 'auto'}), 'a * b * c');
+      assert.equal(math.parse('(a*b)/c').toString({parenthesis: 'auto'}), 'a * b / c');
+      assert.equal(math.parse('a*(b/c)').toString({parenthesis: 'auto'}), 'a * b / c');
+    });
+
+    it ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
+      assert.equal(math.parse('(a-b)-c').toString({parenthesis: 'auto'}), 'a - b - c');
+      assert.equal(math.parse('a-(b-c)').toString({parenthesis: 'auto'}), 'a - (b - c)');
+      assert.equal(math.parse('(a-b)+c').toString({parenthesis: 'auto'}), 'a - b + c');
+      assert.equal(math.parse('a-(b+c)').toString({parenthesis: 'auto'}), 'a - (b + c)');
+
+      assert.equal(math.parse('(a/b)/c').toString({parenthesis: 'auto'}), 'a / b / c');
+      assert.equal(math.parse('a/(b/c)').toString({parenthesis: 'auto'}), 'a / (b / c)');
+      assert.equal(math.parse('(a/b)*c').toString({parenthesis: 'auto'}), 'a / b * c');
+      assert.equal(math.parse('a/(b*c)').toString({parenthesis: 'auto'}), 'a / (b * c)');
+    });
+
+    it ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
+      assert.equal(math.parse('(a^b)^c').toString({parenthesis: 'auto'}), '(a ^ b) ^ c');
+      assert.equal(math.parse('a^(b^c)').toString({parenthesis: 'auto'}), 'a ^ b ^ c');
+    });
+
+    it ('should stringify unary OperatorNodes containing a binary OperatorNode', function () {
+      assert.equal(math.parse('(a*b)!').toString(), '(a * b)!');
+      assert.equal(math.parse('-(a*b)').toString(), '-(a * b)');
+      assert.equal(math.parse('-(a+b)').toString(), '-(a + b)');
+    });
+
+    it ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
+      assert.equal(math.parse('(-a)!').toString({parenthesis: 'auto'}), '(-a)!');
+      assert.equal(math.parse('-(a!)').toString({parenthesis: 'auto'}), '-a!');
+      assert.equal(math.parse('-(-a)').toString({parenthesis: 'auto'}), '-(-a)');
+    });
+  });
+
+  it ('should stringify an OperatorNode with custom toString', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, options) {
+      if (node.type === 'OperatorNode') {
+        return node.op + node.fn + '('
+          + node.args[0].toString(options)
+          + ', ' +  node.args[1].toString(options) + ')';
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n1 = new OperatorNode('+', 'add', [a, b]);
+    var n2 = new OperatorNode('-', 'subtract', [a, b]);
+
+    assert.equal(n1.toString({handler: customFunction}), '+add(const(1, number), const(2, number))');
+    assert.equal(n2.toString({handler: customFunction}), '-subtract(const(1, number), const(2, number))');
+  });
+
+  it ('should stringify an OperatorNode with custom toString for a single operator', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, options) {
+      if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
+        return node.args[0].toString(options)
+          + node.op + node.fn + node.op +
+          node.args[1].toString(options);
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const(' + node.value + ', ' + node.valueType + ')'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    assert.equal(n.toString({handler: customFunction}), 'const(1, number)+add+const(2, number)');
+  });
+
+  it ('should respect the \'all\' parenthesis option', function () {
+    assert.equal(math.parse('1+1+1').toString({parenthesis: 'all'}), '(1 + 1) + 1' );
+    assert.equal(math.parse('1+1+1').toTex({parenthesis: 'all'}), '\\left(1+1\\right)+1' );
+  });
+
+  it ('should correctly LaTeX fractions in \'all\' parenthesis mode', function () {
+    assert.equal(math.parse('1/2/3').toTex({parenthesis: 'all'}), '\\frac{\\left(\\frac{1}{2}\\right)}{3}');
+  });
+
+  it ('should LaTeX an OperatorNode', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    var c = new ConstantNode(4);
+
+    var n = new OperatorNode('+', 'add', [a, b]);
+    assert.equal(n.toTex(), '2+3');
+  });
+
+  it ('should LaTeX an OperatorNode with factorial', function () {
+    var a = new ConstantNode(2);
+    var n = new OperatorNode('!', 'factorial', [a]);
+    assert.equal(n.toTex(), '2!');
+  });
+
+  it ('should LaTeX an OperatorNode with factorial of an OperatorNode', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+
+    var sub = new OperatorNode('-', 'subtract', [a, b]);
+    var add = new OperatorNode('+', 'add', [a, b]);
+    var mult = new OperatorNode('*', 'multiply', [a, b]);
+    var div = new OperatorNode('/', 'divide', [a, b]);
+
+    var n1= new OperatorNode('!', 'factorial', [sub] );
+    var n2= new OperatorNode('!', 'factorial', [add] );
+    var n3= new OperatorNode('!', 'factorial', [mult] );
+    var n4= new OperatorNode('!', 'factorial', [div] );
+    assert.equal(n1.toTex(), '\\left(2-3\\right)!');
+    assert.equal(n2.toTex(), '\\left(2+3\\right)!');
+    assert.equal(n3.toTex(), '\\left(2\\cdot3\\right)!');
+    assert.equal(n4.toTex(), '\\frac{2}{3}!');
+  });
+
+  it ('should LaTeX an OperatorNode with unary minus', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+
+    var sub = new OperatorNode('-', 'subtract', [a, b]);
+    var add = new OperatorNode('+', 'add', [a, b]);
+
+    var n1 = new OperatorNode('-', 'unaryMinus', [a]);
+    var n2 = new OperatorNode('-', 'unaryMinus', [sub]);
+    var n3 = new OperatorNode('-', 'unaryMinus', [add]);
+
+    assert.equal(n1.toTex(), '-2');
+    assert.equal(n2.toTex(), '-\\left(2-3\\right)');
+    assert.equal(n3.toTex(), '-\\left(2+3\\right)');
+  });
+
+  it ('should LaTeX an OperatorNode that subtracts an OperatorNode', function() {
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+    var c = new ConstantNode(3);
+
+    var sub = new OperatorNode('-', 'subtract', [b, c]);
+    var add = new OperatorNode('+', 'add', [b, c]);
+
+    var n1 = new OperatorNode('-', 'subtract', [a, sub]);
+    var n2 = new OperatorNode('-', 'subtract', [a, add]);
+
+    assert.equal(n1.toTex(), '1-\\left(2-3\\right)');
+    assert.equal(n2.toTex(), '1-\\left(2+3\\right)');
+  });
+
+  it ('should LaTeX an OperatorNode with zero arguments', function () {
+    var n = new OperatorNode('foo', 'foo', []);
+    assert.equal(n.toTex(), '\\mathrm{foo}\\left(\\right)');
+  });
+
+  it ('should LaTeX an OperatorNode with more than two operators', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    var c = new ConstantNode(4);
+
+    var n = new OperatorNode('foo', 'foo', [a, b, c]);
+    assert.equal(n.toTex(), '\\mathrm{foo}\\left(2,3,4\\right)');
+
+  });
+
+  it ('should LaTeX an OperatorNode with nested operator nodes', function () {
+    var a = new ConstantNode(2);
+    var b = new ConstantNode(3);
+    var c = new ConstantNode(4);
+    var d = new ConstantNode(5);
+
+    var n1 = new OperatorNode('+', 'add', [a, b]);
+    var n2 = new OperatorNode('-', 'subtract', [c, d]);
+    var n3 = new OperatorNode('*', 'multiply', [n1, n2]);
+
+    var m2 = new OperatorNode('*', 'multiply', [n1, c]);
+    var m3 = new OperatorNode('-', 'subtract', [m2, d]);
+
+    assert.equal(n1.toTex(), '2+3');
+    assert.equal(n2.toTex(), '4-5');
+    assert.equal(n3.toTex(), '\\left(2+3\\right)\\cdot\\left(4-5\\right)');
+    assert.equal(m3.toTex(), '\\left(2+3\\right)\\cdot4-5');
+  });
+
+  it ('should LaTeX addition and multiplication with more than two operands', function () {
+    var a = new SymbolNode('a');
+    var b = new SymbolNode('b');
+    var c = new SymbolNode('c');
+
+    var add = new OperatorNode('+', 'add', [a, b, c]);
+    var multiply = new OperatorNode('*', 'multiply', [a, b, c]);
+    var implicitMultiply = new OperatorNode('*', 'multiply', [a, b, c], true);
+
+    assert.equal(add.toTex(), ' a+\\mathrm{b}+ c');
+    assert.equal(multiply.toTex(), ' a\\cdot\\mathrm{b}\\cdot c');
+    assert.equal(implicitMultiply.toTex(), ' a~\\mathrm{b}~ c');
+  });
+
+  it ('should LaTeX addition and multiplication with more than two operands including OperatorNode', function () {
+    var a = new SymbolNode('a');
+    var b = new SymbolNode('b');
+    var c = new SymbolNode('c');
+    var d = new SymbolNode('d');
+
+    var mult = new OperatorNode('*', 'multiply', [a,b]);
+    var add = new OperatorNode('+', 'add', [a, b]);
+
+    var multipleMultWithMult = new OperatorNode('*', 'multiply', [c, mult, d]);
+    var multipleMultWithAdd = new OperatorNode('*', 'multiply', [c, add, d]);
+    var multipleAddWithMult = new OperatorNode('+', 'add', [c, mult, d]);
+    var multipleAddWithAdd = new OperatorNode('+', 'add', [c, add, d]);
+
+    assert.equal(multipleMultWithMult.toTex(), ' c\\cdot a\\cdot\\mathrm{b}\\cdot d');
+    assert.equal(multipleMultWithAdd.toTex(), ' c\\cdot\\left( a+\\mathrm{b}\\right)\\cdot d');
+    assert.equal(multipleAddWithMult.toTex(), ' c+ a\\cdot\\mathrm{b}+ d');
+    assert.equal(multipleAddWithAdd.toTex(), ' c+ a+\\mathrm{b}+ d');
+  });
+
+  it ('should LaTeX an OperatorNode that contains an operatornode with more than two operands', function () {
+    var a = new SymbolNode('a');
+    var b = new SymbolNode('b');
+    var c = new SymbolNode('c');
+    var d = new SymbolNode('d');
+
+    var mult = new OperatorNode('*', 'multiply', [a, b, c]);
+    var add = new OperatorNode('+', 'add', [a, b, c]);
+
+    var addWithMult = new OperatorNode('+', 'add', [mult, d]);
+    var addWithAdd = new OperatorNode('+', 'add', [add, d]);
+    var multWithMult = new OperatorNode('*', 'multiply', [mult, d]);
+    var multWithAdd = new OperatorNode('*', 'multiply', [add, d]);
+
+    assert.equal(addWithMult.toTex(), ' a\\cdot\\mathrm{b}\\cdot c+ d');
+    assert.equal(addWithAdd.toTex(), ' a+\\mathrm{b}+ c+ d');
+    assert.equal(multWithMult.toTex(), ' a\\cdot\\mathrm{b}\\cdot c\\cdot d');
+    assert.equal(multWithAdd.toTex(), '\\left( a+\\mathrm{b}+ c\\right)\\cdot d');
+  });
+
+  it('should LaTeX fractions with operators that are enclosed in parenthesis', function () {
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var add = new OperatorNode('+', 'add', [a,a]);
+    var frac = new OperatorNode('/', 'divide', [add,b]);
+    assert.equal(frac.toTex(), '\\frac{1+1}{2}');
+  });
+
+  it ('should have an identifier', function () {
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    assert.equal(n.getIdentifier(), 'OperatorNode:add');
+  });
+
+  it ('should LaTeX an OperatorNode with custom toTex', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, options) {
+      if (node.type === 'OperatorNode') {
+        return node.op + node.fn + '('
+          + node.args[0].toTex(options)
+          + ', ' +  node.args[1].toTex(options) + ')';
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n1 = new OperatorNode('+', 'add', [a, b]);
+    var n2 = new OperatorNode('-', 'subtract', [a, b]);
+
+    assert.equal(n1.toTex({handler: customFunction}), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
+    assert.equal(n2.toTex({handler: customFunction}), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
+  });
+
+  it ('should LaTeX an OperatorNode with custom toTex for a single operator', function () {
+    //Also checks if the custom functions get passed on to the children
+    var customFunction = function (node, options) {
+      if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
+        return node.args[0].toTex(options)
+          + node.op + node.fn + node.op +
+          node.args[1].toTex(options);
+      }
+      else if (node.type === 'ConstantNode') {
+        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+      }
+    };
+
+    var a = new ConstantNode(1);
+    var b = new ConstantNode(2);
+
+    var n = new OperatorNode('+', 'add', [a, b]);
+
+    assert.equal(n.toTex({handler: customFunction}), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
+  });
+
+  it ('should LaTeX powers of fractions with parentheses', function () {
+    var a = new ConstantNode(1);
+    var frac = new OperatorNode('/', 'divide', [a,a]);
+    var pow = new OperatorNode('^', 'pow', [frac, a]);
+
+    assert.equal(pow.toTex(), '\\left({\\frac{1}{1}}\\right)^{1}');
+  });
+
+  it ('should LaTeX powers of conditions with parentheses', function () {
+    var a = new ConstantNode(1);
+    var cond = new ConditionalNode(a, a, a);
+    var pow = new OperatorNode('^', 'pow', [cond, a]);
+
+    assert.equal(pow.toTex(), '\\left({\\begin{cases} {1}, &\\quad{\\text{if }\\;1}\\\\{1}, &\\quad{\\text{otherwise}}\\end{cases}}\\right)^{1}');
+  });
+
+  it ('should LaTeX simple expressions in \'auto\' mode', function () {
+    //this covers a bug that was triggered previously
+    assert.equal(math.parse('1+(1+1)').toTex({parenthesis: 'auto'}), '1+1+1');
+  });
+
+  it ('should stringify implicit multiplications', function () {
+    var a = math.parse('4a');
+    var b = math.parse('4 a');
+    var c = math.parse('a b');
+    var d = math.parse('2a b');
+    var e = math.parse('a b c');
+    var f = math.parse('(2+3)a');
+    var g = math.parse('(2+3)2');
+    var h = math.parse('2(3+4)');
+
+    assert.equal(a.toString(), a.toString({implicit: 'hide'}));
+    assert.equal(a.toString({implicit: 'hide'}), '4 a');
+    assert.equal(a.toString({implicit: 'show'}), '4 * a');
+
+    assert.equal(b.toString(), b.toString({implicit: 'hide'}));
+    assert.equal(b.toString({implicit: 'hide'}), '4 a');
+    assert.equal(b.toString({implicit: 'show'}), '4 * a');
+
+    assert.equal(c.toString(), c.toString({implicit: 'hide'}));
+    assert.equal(c.toString({implicit: 'hide'}), 'a b');
+    assert.equal(c.toString({implicit: 'show'}), 'a * b');
+
+    assert.equal(d.toString(), d.toString({implicit: 'hide'}));
+    assert.equal(d.toString({implicit: 'hide'}), '2 a b');
+    assert.equal(d.toString({implicit: 'show'}), '2 * a * b');
+
+    assert.equal(e.toString(), e.toString({implicit: 'hide'}));
+    assert.equal(e.toString({implicit: 'hide'}), 'a b c');
+    assert.equal(e.toString({implicit: 'show'}), 'a * b * c');
+
+    assert.equal(f.toString(), f.toString({implicit: 'hide'}));
+    assert.equal(f.toString({implicit: 'hide'}), '(2 + 3) a');
+    assert.equal(f.toString({implicit: 'show'}), '(2 + 3) * a');
+
+    assert.equal(g.toString(), g.toString({implicit: 'hide'}));
+    assert.equal(g.toString({implicit: 'hide'}), '(2 + 3) 2');
+    assert.equal(g.toString({implicit: 'show'}), '(2 + 3) * 2');
+
+    assert.equal(h.toString(), h.toString({implicit: 'hide'}));
+    assert.equal(h.toString({implicit: 'hide'}), '2 (3 + 4)');
+    assert.equal(h.toString({implicit: 'show'}), '2 * (3 + 4)');
+  });
+
+  it ('should LaTeX implicit multiplications', function () {
+    var a = math.parse('4a');
+    var b = math.parse('4 a');
+    var c = math.parse('a b');
+    var d = math.parse('2a b');
+    var e = math.parse('a b c');
+    var f = math.parse('(2+3)a');
+    var g = math.parse('(2+3)2');
+    var h = math.parse('2(3+4)');
+
+    assert.equal(a.toTex(), a.toTex({implicit: 'hide'}));
+    assert.equal(a.toTex({implicit: 'hide'}), '4~ a');
+    assert.equal(a.toTex({implicit: 'show'}), '4\\cdot a');
+
+    assert.equal(b.toTex(), b.toTex({implicit: 'hide'}));
+    assert.equal(b.toTex({implicit: 'hide'}), '4~ a');
+    assert.equal(b.toTex({implicit: 'show'}), '4\\cdot a');
+
+    assert.equal(c.toTex(), c.toTex({implicit: 'hide'}));
+    assert.equal(c.toTex({implicit: 'hide'}), ' a~\\mathrm{b}');
+    assert.equal(c.toTex({implicit: 'show'}), ' a\\cdot\\mathrm{b}');
+
+    assert.equal(d.toTex(), d.toTex({implicit: 'hide'}));
+    assert.equal(d.toTex({implicit: 'hide'}), '2~ a~\\mathrm{b}');
+    assert.equal(d.toTex({implicit: 'show'}), '2\\cdot a\\cdot\\mathrm{b}');
+
+    assert.equal(e.toTex(), e.toTex({implicit: 'hide'}));
+    assert.equal(e.toTex({implicit: 'hide'}), ' a~\\mathrm{b}~ c');
+    assert.equal(e.toTex({implicit: 'show'}), ' a\\cdot\\mathrm{b}\\cdot c');
+
+    assert.equal(f.toTex(), f.toTex({implicit: 'hide'}));
+    assert.equal(f.toTex({implicit: 'hide'}), '\\left(2+3\\right)~ a');
+    assert.equal(f.toTex({implicit: 'show'}), '\\left(2+3\\right)\\cdot a');
+
+    assert.equal(g.toTex(), g.toTex({implicit: 'hide'}));
+    assert.equal(g.toTex({implicit: 'hide'}), '\\left(2+3\\right)~2');
+    assert.equal(g.toTex({implicit: 'show'}), '\\left(2+3\\right)\\cdot2');
+
+    assert.equal(h.toTex(), h.toTex({implicit: 'hide'}));
+    assert.equal(h.toTex({implicit: 'hide'}), '2~\\left(3+4\\right)');
+    assert.equal(h.toTex({implicit: 'show'}), '2\\cdot\\left(3+4\\right)');
+  });
+
+  it ('should stringify implicit multiplications between ConstantNodes with parentheses', function () {
+    var a = math.parse('(4)(4)(4)(4)');
+    var b = math.parse('4b*4(4)');
+    var c = math.parse('(4(4(4)))');
+
+    assert.equal(a.toString({implicit: 'hide', parenthesis: 'auto'}), '(4) (4) (4) (4)');
+    assert.equal(b.toString({implicit: 'hide', parenthesis: 'auto'}), '4 b * 4 (4)');
+    assert.equal(c.toString({implicit: 'hide', parenthesis: 'auto'}), '4 (4 (4))');
+  });
+
+  it ('should LaTeX implicit multiplications between ConstantNodes with parentheses', function () {
+    var a = math.parse('(4)(4)(4)(4)');
+    var b = math.parse('4b*4(4)');
+    var c = math.parse('(4(4(4)))');
+
+    assert.equal(a.toTex({implicit: 'hide', parenthesis: 'auto'}), '\\left(4\\right)~\\left(4\\right)~\\left(4\\right)~\\left(4\\right)');
+    assert.equal(b.toTex({implicit: 'hide', parenthesis: 'auto'}), '4~\\mathrm{b}\\cdot4~\\left(4\\right)');
+    assert.equal(c.toTex({implicit: 'hide', parenthesis: 'auto'}), '4~\\left(4~\\left(4\\right)\\right)');
+  });
+
+  it ('should HTML implicit multiplications between ConstantNodes with parentheses', function () {
+    var a = math.parse('(4)(4)(4)(4)');
+    var b = math.parse('4b*4(4)');
+    var c = math.parse('(4(4(4)))');
+
+    assert.equal(a.toHTML({implicit: 'hide', parenthesis: 'auto'}), '<span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span>');
+    assert.equal(b.toHTML({implicit: 'hide', parenthesis: 'auto'}), '<span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-symbol">b</span><span class="math-operator math-binary-operator math-explicit-binary-operator">*</span><span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span>');
+    assert.equal(c.toHTML({implicit: 'hide', parenthesis: 'auto'}), '<span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-parenthesis math-round-parenthesis">)</span>');
+  });
+});

--- a/test/expression/node/UnaryOperatorNode.test.js
+++ b/test/expression/node/UnaryOperatorNode.test.js
@@ -1,424 +1,234 @@
-// test OperatorNode
+// test UnaryOperatorNode
 var assert = require('assert');
-var approx = require('../../../tools/approx');
 var math = require('../../../index');
-var Node = math.expression.node.Node;
 var ConstantNode = math.expression.node.ConstantNode;
 var SymbolNode = math.expression.node.SymbolNode;
 var OperatorNode = math.expression.node.OperatorNode;
-var ConditionalNode = math.expression.node.ConditionalNode;
+var UnaryOperatorNode = math.expression.node.UnaryOperatorNode;
 
-describe('OperatorNode', function() {
+describe('UnaryOperatorNode', function() {
 
-  it ('should create an OperatorNode', function () {
-    var n = new OperatorNode('op', 'fn', []);
-    assert(n instanceof OperatorNode);
-    assert(n instanceof Node);
-    assert.equal(n.type, 'OperatorNode');
+  var constantNode = new ConstantNode(2);
+
+  it('should have isUnaryOperatorNode', function () {
+    var node = new UnaryOperatorNode('op', 'fn', constantNode);
+    assert(node.isUnaryOperatorNode);
   });
 
-  it ('should have isOperatorNode', function () {
-    var node = new OperatorNode('op', 'fn', []);
-    assert(node.isOperatorNode);
+  it('should throw an error when calling without new operator', function () {
+    assert.throws(function () {
+      UnaryOperatorNode('-', 'unaryMinus', constantNode);
+    }, SyntaxError);
   });
 
-  it ('should throw an error when calling without new operator', function () {
+  it('should throw an error when calling without a value', function () {
+    assert.throws(function () {
+      UnaryOperatorNode('-', 'unaryMinus');
+    }, SyntaxError);
+  });
+
+  it('should compile an UnaryOperatorNode', function () {
+
     var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    assert.throws(function () {OperatorNode('+', 'add', [a, b])}, SyntaxError);
-  });
-
-  it ('should compile an OperatorNode', function () {
-    var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    var n = new OperatorNode('+', 'add', [a, b]);
-
+    var n = new UnaryOperatorNode('-', 'unaryMinus', a);
     var expr = n.compile();
 
-    assert.equal(expr.eval(), 5);
+    assert.equal(expr.eval(), -2);
   });
 
-  it ('should throw an error in case of unresolved operator function', function () {
-    var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    var n = new OperatorNode('***', 'foo', [a, b]);
+  it('should throw an error in case of unresolved operator function', function () {
+    var n = new UnaryOperatorNode('***', 'foo', constantNode);
 
     assert.throws(function () {
       n.compile();
     }, /Function foo missing in provided namespace/);
   });
 
-  it ('should filter an OperatorNode', function () {
-    var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    var n = new OperatorNode('+', 'add', [a, b]);
+  it('should filter an UnaryOperatorNode', function () {
+    var twoNode = new ConstantNode(2);
+    var n = new UnaryOperatorNode('-', 'unaryMinus', twoNode);
 
-    assert.deepEqual(n.filter(function (node) {return node instanceof OperatorNode}),  [n]);
-    assert.deepEqual(n.filter(function (node) {return node instanceof SymbolNode}),    []);
-    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode}),  [a, b]);
-    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode && node.value == '2'}),  [a]);
-    assert.deepEqual(n.filter(function (node) {return node instanceof ConstantNode && node.value == '4'}),  []);
+    assert.deepEqual(n.filter(function (node) {
+      return node instanceof UnaryOperatorNode
+    }), [n]);
+    assert.deepEqual(n.filter(function (node) {
+      return node instanceof SymbolNode
+    }), []);
+    assert.deepEqual(n.filter(function (node) {
+      return node instanceof ConstantNode
+    }), [twoNode]);
+    assert.deepEqual(n.filter(function (node) {
+      return node instanceof ConstantNode && node.value === '2'
+    }), [twoNode]);
+    assert.deepEqual(n.filter(function (node) {
+      return node instanceof ConstantNode && node.value === '4'
+    }), []);
   });
 
-  it ('should filter an OperatorNode without contents', function () {
-    var n = new OperatorNode('op', 'fn', []);
-
-    assert.deepEqual(n.filter(function (node) {return node instanceof OperatorNode}),  [n]);
-    assert.deepEqual(n.filter(function (node) {return node instanceof SymbolNode}),    []);
-  });
-
-  it ('should run forEach on an OperatorNode', function () {
-    // x^2-x
-    var a = new SymbolNode('x');
-    var b = new ConstantNode(2);
-    var c = new OperatorNode('^', 'pow', [a, b]);
-    var d = new SymbolNode('x');
-    var e = new OperatorNode('-', 'subtract', [c, d]);
+  it('should run forEach on an UnaryOperatorNode', function () {
+    var x = new SymbolNode('x');
+    var b = new UnaryOperatorNode('-', 'unaryMinus', x);
 
     var nodes = [];
     var paths = [];
-    e.forEach(function (node, path, parent) {
+    b.forEach(function (node, path, parent) {
       nodes.push(node);
       paths.push(path);
-      assert.strictEqual(parent, e);
+      assert.strictEqual(parent, b);
     });
 
-    assert.equal(nodes.length, 2);
-    assert.strictEqual(nodes[0], c);
-    assert.strictEqual(nodes[1], d);
-    assert.deepEqual(paths, ['args[0]', 'args[1]']);
+    assert.deepEqual(nodes, [x]);
+    assert.deepEqual(paths, ['value']);
   });
 
-  it ('should map an OperatorNode', function () {
-    // x^2-x
-    var a = new SymbolNode('x');
-    var b = new ConstantNode(2);
-    var c = new OperatorNode('^', 'pow', [a, b]);
-    var d = new SymbolNode('x');
-    var e = new OperatorNode('-', 'subtract', [c, d]);
-
-    var nodes = [];
-    var paths = [];
+  it('should map an UnaryOperatorNode', function () {
+    var x = new SymbolNode('x');
+    var b = new UnaryOperatorNode('-', 'unaryMinus', x);
     var f = new ConstantNode(3);
-    var g = e.map(function (node, path, parent) {
+
+    var nodes = [];
+    var paths = [];
+    var c = b.map(function (node, path, parent) {
       nodes.push(node);
       paths.push(path);
-      assert.strictEqual(parent, e);
+      assert.strictEqual(parent, b);
 
-      return node instanceof SymbolNode && node.name == 'x' ? f : node;
+      return node;
     });
 
-    assert.equal(nodes.length, 2);
-    assert.strictEqual(nodes[0], c);
-    assert.strictEqual(nodes[1], d);
-    assert.deepEqual(paths, ['args[0]', 'args[1]']);
+    assert.deepEqual(nodes, [x]);
+    assert.deepEqual(paths, ['value']);
 
-    assert.notStrictEqual(g,  e);
-    assert.strictEqual(g.args[0], e.args[0]);
-    assert.strictEqual(g.args[0].args[0], a); // nested x is not replaced
-    assert.deepEqual(g.args[0].args[1], b);
-    assert.deepEqual(g.args[1],  f);
+    assert.notStrictEqual(c, b);
+    assert.strictEqual(c.value, b.value);
   });
 
-  it ('should throw an error when the map callback does not return a node', function () {
-    var a = new SymbolNode('x');
-    var b = new ConstantNode(2);
-    var c = new OperatorNode('^', 'pow', [a, b]);
+  it('should throw an error when the map callback does not return a node', function () {
+    var x = new SymbolNode('x');
+    var node = new UnaryOperatorNode('-', 'unaryMinus', x);
 
     assert.throws(function () {
-      c.map(function () {});
+      node.map(function () {
+      });
     }, /Callback function must return a Node/)
   });
 
-  it ('should transform an OperatorNodes parameters', function () {
-    // x^2-x
-    var a = new SymbolNode('x');
-    var b = new ConstantNode(2);
-    var c = new OperatorNode('^', 'pow', [a, b]);
-    var d = new SymbolNode('x');
-    var e = new OperatorNode('-', 'subtract', [c, d]);
-
-    var f = new ConstantNode(3);
-    var g = e.transform(function (node) {
-      return node instanceof SymbolNode && node.name == 'x' ? f : node;
-    });
-
-    assert.deepEqual(g.args[1],  f);
-  });
-
-  it ('should transform an OperatorNode itself', function () {
-    // x^2-x
-    var a = new SymbolNode('x');
-    var b = new ConstantNode(2);
-    var c = new OperatorNode('+', 'add', [a, b]);
-
-    var f = new ConstantNode(3);
-    var g = c.transform(function (node) {
-      return node instanceof OperatorNode ? f : node;
-    });
-
-    assert.notStrictEqual(g, c);
-    assert.deepEqual(g,  f);
-  });
-
-  it ('should clone an OperatorNode', function () {
-    // x^2-x
-    var a = new SymbolNode('x');
-    var b = new ConstantNode(2);
-    var c = new OperatorNode('+', 'add', [a, b]);
-
-    var d = c.clone();
-    assert(d instanceof OperatorNode);
-    assert.deepEqual(d, c);
-    assert.notStrictEqual(d, c);
-    assert.notStrictEqual(d.args, c.args);
-    assert.strictEqual(d.args[0], c.args[0]);
-    assert.strictEqual(d.args[1], c.args[1]);
-  });
-
-  it ('should clone implicit multiplications', function () {
-    var two = new ConstantNode(2);
+  it('should transform an UnaryOperatorNodes parameters', function () {
     var x = new SymbolNode('x');
-    var node = new OperatorNode('*', 'multiply', [two, x], true);
+    var b = new UnaryOperatorNode('-', 'unaryMinus', x);
 
-    assert.equal('2 x', node.toString());
-    assert.strictEqual(true, node.clone().implicit);
-    assert.equal(node.toString(), node.clone().toString());
+    var f = new ConstantNode(3);
+
+    var transformed = b.transform(function (node) {
+      return node instanceof SymbolNode && node.name === 'x' ? f : node;
+    });
+
+    var notTransformed = b.transform(function (node) {
+      return node;
+    });
+
+    assert.deepEqual(transformed.value, f);
+    assert.deepEqual(notTransformed.value, x);
   });
 
-  it ('test equality another Node', function () {
-    var a = new OperatorNode('+', 'add', [new SymbolNode('x'), new ConstantNode(2)]);
-    var b = new OperatorNode('+', 'add', [new SymbolNode('x'), new ConstantNode(2)]);
-    var c = new OperatorNode('*', 'multiply', [new SymbolNode('x'), new ConstantNode(2)]);
-    var d = new OperatorNode('*', 'add', [new SymbolNode('x'), new ConstantNode(3)]);
-    var e = new OperatorNode('*', 'add', [new SymbolNode('x'), new ConstantNode(2), new ConstantNode(4)]);
+  it('should transform an UnaryOperatorNode itself', function () {
+    var x = new SymbolNode('x');
+    var b = new UnaryOperatorNode('-', 'unaryMinus', x);
+
+    var f = new ConstantNode(3);
+    var transformed = b.transform(function (node) {
+      return node instanceof UnaryOperatorNode ? f : node;
+    });
+
+    assert.notStrictEqual(transformed, b);
+    assert.deepEqual(transformed, f);
+  });
+
+  it('should clone an UnaryOperatorNode', function () {
+    var x = new SymbolNode('x');
+    var node = new UnaryOperatorNode('-', 'unaryMinus', x);
+
+    var cloned = node.clone();
+    assert(cloned instanceof UnaryOperatorNode);
+    assert.deepEqual(cloned, node);
+    assert.notStrictEqual(cloned, node);
+    assert.strictEqual(cloned.value, node.value);
+  });
+
+
+  it('test equality another Node', function () {
+    var a = new UnaryOperatorNode('-', 'unaryMinus', new SymbolNode('x'));
+    var aAgain = new UnaryOperatorNode('-', 'unaryMinus', new SymbolNode('x'));
+    var b = new UnaryOperatorNode('-', 'unaryMinus', new ConstantNode(2));
+    var c = new UnaryOperatorNode('!', 'factorial', new SymbolNode('x'));
+    var d = new UnaryOperatorNode('*', 'unaryMinus', new SymbolNode('x'));
 
     assert.strictEqual(a.equals(null), false);
     assert.strictEqual(a.equals(undefined), false);
-    assert.strictEqual(a.equals(b), true);
+    assert.strictEqual(a.equals(aAgain), true);
+    assert.strictEqual(a.equals(b), false);
     assert.strictEqual(a.equals(c), false);
     assert.strictEqual(a.equals(d), false);
-    assert.strictEqual(a.equals(e), false);
   });
 
   describe('toString', function () {
-    it ('should stringify an OperatorNode', function () {
+    it('should stringify an UnaryOperatorNode with factorial', function () {
       var a = new ConstantNode(2);
-      var b = new ConstantNode(3);
-      var c = new ConstantNode(4);
-
-      var n = new OperatorNode('+', 'add', [a, b]);
-      assert.equal(n.toString(), '2 + 3');
-    });
-
-    it ('should stringify an OperatorNode with factorial', function () {
-      var a = new ConstantNode(2);
-      var n = new OperatorNode('!', 'factorial', [a]);
+      var n = new UnaryOperatorNode('!', 'factorial', a);
       assert.equal(n.toString(), '2!');
     });
 
-    it ('should stringify an OperatorNode with unary minus', function () {
+    it('should stringify an UnaryOperatorNode with unary minus', function () {
       var a = new ConstantNode(2);
-      var n = new OperatorNode('-', 'unaryMinus', [a]);
+      var n = new UnaryOperatorNode('-', 'unaryMinus', a);
       assert.equal(n.toString(), '-2');
     });
 
-    it ('should stringify an OperatorNode with zero arguments', function () {
-      var n = new OperatorNode('foo', 'foo', []);
-      assert.equal(n.toString(), 'foo()');
-    });
-
-    it ('should stringify an OperatorNode with more than two operators', function () {
-      var a = new ConstantNode(2);
-      var b = new ConstantNode(3);
-      var c = new ConstantNode(4);
-
-      var n = new OperatorNode('foo', 'foo', [a, b, c]);
-      assert.equal(n.toString(), 'foo(2, 3, 4)');
-
-    });
-
-    it ('should stringify addition and multiplication with more than two operands', function () {
-      var a = new SymbolNode('a');
-      var b = new SymbolNode('b');
-      var c = new SymbolNode('c');
-
-      var add = new OperatorNode('+', 'add', [a, b, c]);
-      var multiply = new OperatorNode('*', 'multiply', [a, b, c]);
-      var implicitMultiply = new OperatorNode('*', 'multiply', [a, b, c], true);
-
-      assert.equal(add.toString(), 'a + b + c');
-      assert.equal(multiply.toString(), 'a * b * c');
-      assert.equal(implicitMultiply.toString(), 'a b c');
-    });
-
-    it ('should stringify addition and multiplication with more than two operands including OperatorNode', function () {
-      var a = new SymbolNode('a');
-      var b = new SymbolNode('b');
-      var c = new SymbolNode('c');
-      var d = new SymbolNode('d');
-
-      var mult = new OperatorNode('*', 'multiply', [a,b]);
-      var add = new OperatorNode('+', 'add', [a, b]);
-
-      var multipleMultWithMult = new OperatorNode('*', 'multiply', [c, mult, d]);
-      var multipleMultWithAdd = new OperatorNode('*', 'multiply', [c, add, d]);
-      var multipleAddWithMult = new OperatorNode('+', 'add', [c, mult, d]);
-      var multipleAddWithAdd = new OperatorNode('+', 'add', [c, add, d]);
-
-      assert.equal(multipleMultWithMult.toString(), 'c * a * b * d');
-      assert.equal(multipleMultWithAdd.toString(), 'c * (a + b) * d');
-      assert.equal(multipleAddWithMult.toString(), 'c + a * b + d');
-      assert.equal(multipleAddWithAdd.toString(), 'c + a + b + d');
-    });
-
-    it ('should stringify an OperatorNode that contains an operatornode with more than two operands', function () {
-      var a = new SymbolNode('a');
-      var b = new SymbolNode('b');
-      var c = new SymbolNode('c');
-      var d = new SymbolNode('d');
-
-      var mult = new OperatorNode('*', 'multiply', [a, b, c]);
-      var add = new OperatorNode('+', 'add', [a, b, c]);
-
-      var addWithMult = new OperatorNode('+', 'add', [mult, d]);
-      var addWithAdd = new OperatorNode('+', 'add', [add, d]);
-      var multWithMult = new OperatorNode('*', 'multiply', [mult, d]);
-      var multWithAdd = new OperatorNode('*', 'multiply', [add, d]);
-
-      assert.equal(addWithMult.toString(), 'a * b * c + d');
-      assert.equal(addWithAdd.toString(), 'a + b + c + d');
-      assert.equal(multWithMult.toString(), 'a * b * c * d');
-      assert.equal(multWithAdd.toString(), '(a + b + c) * d');
-
-    });
-
-    it ('should stringify an OperatorNode with nested operator nodes', function () {
-      var a = new ConstantNode(2);
-      var b = new ConstantNode(3);
-      var c = new ConstantNode(4);
-      var d = new ConstantNode(5);
-
-      var n1 = new OperatorNode('+', 'add', [a, b]);
-      var n2 = new OperatorNode('-', 'subtract', [c, d]);
-      var n3 = new OperatorNode('*', 'multiply', [n1, n2]);
-
-      assert.equal(n1.toString(), '2 + 3');
-      assert.equal(n2.toString(), '4 - 5');
-      assert.equal(n3.toString(), '(2 + 3) * (4 - 5)');
-    });
-
-    it ('should stringify left associative OperatorNodes that are associative with another Node', function () {
-      assert.equal(math.parse('(a+b)+c').toString({parenthesis: 'auto'}), 'a + b + c');
-      assert.equal(math.parse('a+(b+c)').toString({parenthesis: 'auto'}), 'a + b + c');
-      assert.equal(math.parse('(a+b)-c').toString({parenthesis: 'auto'}), 'a + b - c');
-      assert.equal(math.parse('a+(b-c)').toString({parenthesis: 'auto'}), 'a + b - c');
-
-      assert.equal(math.parse('(a*b)*c').toString({parenthesis: 'auto'}), 'a * b * c');
-      assert.equal(math.parse('a*(b*c)').toString({parenthesis: 'auto'}), 'a * b * c');
-      assert.equal(math.parse('(a*b)/c').toString({parenthesis: 'auto'}), 'a * b / c');
-      assert.equal(math.parse('a*(b/c)').toString({parenthesis: 'auto'}), 'a * b / c');
-    });
-
-    it ('should stringify left associative OperatorNodes that are not associative with another Node', function () {
-      assert.equal(math.parse('(a-b)-c').toString({parenthesis: 'auto'}), 'a - b - c');
-      assert.equal(math.parse('a-(b-c)').toString({parenthesis: 'auto'}), 'a - (b - c)');
-      assert.equal(math.parse('(a-b)+c').toString({parenthesis: 'auto'}), 'a - b + c');
-      assert.equal(math.parse('a-(b+c)').toString({parenthesis: 'auto'}), 'a - (b + c)');
-
-      assert.equal(math.parse('(a/b)/c').toString({parenthesis: 'auto'}), 'a / b / c');
-      assert.equal(math.parse('a/(b/c)').toString({parenthesis: 'auto'}), 'a / (b / c)');
-      assert.equal(math.parse('(a/b)*c').toString({parenthesis: 'auto'}), 'a / b * c');
-      assert.equal(math.parse('a/(b*c)').toString({parenthesis: 'auto'}), 'a / (b * c)');
-    });
-
-    it ('should stringify right associative OperatorNodes that are not associative with another Node', function () {
-      assert.equal(math.parse('(a^b)^c').toString({parenthesis: 'auto'}), '(a ^ b) ^ c');
-      assert.equal(math.parse('a^(b^c)').toString({parenthesis: 'auto'}), 'a ^ b ^ c');
-    });
-
-    it ('should stringify unary OperatorNodes containing a binary OperatorNode', function () {
+    it('should stringify UnaryOperatorNodes containing a binary OperatorNode', function () {
       assert.equal(math.parse('(a*b)!').toString(), '(a * b)!');
       assert.equal(math.parse('-(a*b)').toString(), '-(a * b)');
       assert.equal(math.parse('-(a+b)').toString(), '-(a + b)');
     });
 
-    it ('should stringify unary OperatorNodes containing a unary OperatorNode', function () {
+    it('should stringify UnaryOperatorNodes containing a UnaryOperatorNode', function () {
       assert.equal(math.parse('(-a)!').toString({parenthesis: 'auto'}), '(-a)!');
       assert.equal(math.parse('-(a!)').toString({parenthesis: 'auto'}), '-a!');
       assert.equal(math.parse('-(-a)').toString({parenthesis: 'auto'}), '-(-a)');
     });
   });
 
-  it ('should stringify an OperatorNode with custom toString', function () {
-    //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, options) {
-      if (node.type === 'OperatorNode') {
-        return node.op + node.fn + '('
-          + node.args[0].toString(options)
-          + ', ' +  node.args[1].toString(options) + ')';
-      }
-      else if (node.type === 'ConstantNode') {
-        return 'const(' + node.value + ', ' + node.valueType + ')'
-      }
-    };
+  it('should stringify an UnaryOperatorNode with custom toString', function () {
+    var passedNode = null;
+    var string = 'should be returned from toString';
 
-    var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
-
-    var n1 = new OperatorNode('+', 'add', [a, b]);
-    var n2 = new OperatorNode('-', 'subtract', [a, b]);
-
-    assert.equal(n1.toString({handler: customFunction}), '+add(const(1, number), const(2, number))');
-    assert.equal(n2.toString({handler: customFunction}), '-subtract(const(1, number), const(2, number))');
-  });
-
-  it ('should stringify an OperatorNode with custom toString for a single operator', function () {
-    //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, options) {
-      if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
-        return node.args[0].toString(options)
-          + node.op + node.fn + node.op +
-          node.args[1].toString(options);
-      }
-      else if (node.type === 'ConstantNode') {
-        return 'const(' + node.value + ', ' + node.valueType + ')'
+    var toStringOptions = {
+      handler: function (node, options) {
+        passedNode = node;
+        assert.deepEqual(options, toStringOptions);
+        return string;
       }
     };
 
     var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
 
-    var n = new OperatorNode('+', 'add', [a, b]);
+    var n = new UnaryOperatorNode('-', 'unaryMinus', a);
 
-    assert.equal(n.toString({handler: customFunction}), 'const(1, number)+add+const(2, number)');
+    assert.equal(n.toString(toStringOptions), string);
   });
 
-  it ('should respect the \'all\' parenthesis option', function () {
-    assert.equal(math.parse('1+1+1').toString({parenthesis: 'all'}), '(1 + 1) + 1' );
-    assert.equal(math.parse('1+1+1').toTex({parenthesis: 'all'}), '\\left(1+1\\right)+1' );
-  });
-
-  it ('should correctly LaTeX fractions in \'all\' parenthesis mode', function () {
-    assert.equal(math.parse('1/2/3').toTex({parenthesis: 'all'}), '\\frac{\\left(\\frac{1}{2}\\right)}{3}');
-  });
-
-  it ('should LaTeX an OperatorNode', function () {
+  it('should LaTeX an UnaryOperatorNode', function () {
     var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    var c = new ConstantNode(4);
-
-    var n = new OperatorNode('+', 'add', [a, b]);
-    assert.equal(n.toTex(), '2+3');
+    var n = new UnaryOperatorNode('-', 'unaryMinus', a);
+    assert.equal(n.toTex(), '-2');
   });
 
-  it ('should LaTeX an OperatorNode with factorial', function () {
+  it('should LaTeX an UnaryOperatorNode with factorial', function () {
     var a = new ConstantNode(2);
-    var n = new OperatorNode('!', 'factorial', [a]);
+    var n = new UnaryOperatorNode('!', 'factorial', a);
     assert.equal(n.toTex(), '2!');
   });
 
-  it ('should LaTeX an OperatorNode with factorial of an OperatorNode', function () {
+  it('should LaTeX an UnaryOperatorNode with factorial of an OperatorNode', function () {
     var a = new ConstantNode(2);
     var b = new ConstantNode(3);
 
@@ -427,331 +237,58 @@ describe('OperatorNode', function() {
     var mult = new OperatorNode('*', 'multiply', [a, b]);
     var div = new OperatorNode('/', 'divide', [a, b]);
 
-    var n1= new OperatorNode('!', 'factorial', [sub] );
-    var n2= new OperatorNode('!', 'factorial', [add] );
-    var n3= new OperatorNode('!', 'factorial', [mult] );
-    var n4= new OperatorNode('!', 'factorial', [div] );
+    var n1 = new UnaryOperatorNode('!', 'factorial', sub);
+    var n2 = new UnaryOperatorNode('!', 'factorial', add);
+    var n3 = new UnaryOperatorNode('!', 'factorial', mult);
+    var n4 = new UnaryOperatorNode('!', 'factorial', div);
     assert.equal(n1.toTex(), '\\left(2-3\\right)!');
     assert.equal(n2.toTex(), '\\left(2+3\\right)!');
     assert.equal(n3.toTex(), '\\left(2\\cdot3\\right)!');
     assert.equal(n4.toTex(), '\\frac{2}{3}!');
   });
 
-  it ('should LaTeX an OperatorNode with unary minus', function () {
+  it('should LaTeX an UnaryOperatorNode with unary minus', function () {
     var a = new ConstantNode(2);
     var b = new ConstantNode(3);
 
     var sub = new OperatorNode('-', 'subtract', [a, b]);
     var add = new OperatorNode('+', 'add', [a, b]);
 
-    var n1 = new OperatorNode('-', 'unaryMinus', [a]);
-    var n2 = new OperatorNode('-', 'unaryMinus', [sub]);
-    var n3 = new OperatorNode('-', 'unaryMinus', [add]);
+    var n1 = new UnaryOperatorNode('-', 'unaryMinus', a);
+    var n2 = new UnaryOperatorNode('-', 'unaryMinus', sub);
+    var n3 = new UnaryOperatorNode('-', 'unaryMinus', add);
 
     assert.equal(n1.toTex(), '-2');
     assert.equal(n2.toTex(), '-\\left(2-3\\right)');
     assert.equal(n3.toTex(), '-\\left(2+3\\right)');
   });
 
-  it ('should LaTeX an OperatorNode that subtracts an OperatorNode', function() {
+  it('should have an identifier', function () {
     var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
-    var c = new ConstantNode(3);
 
-    var sub = new OperatorNode('-', 'subtract', [b, c]);
-    var add = new OperatorNode('+', 'add', [b, c]);
+    var n = new UnaryOperatorNode('-', 'unaryMinus', a);
 
-    var n1 = new OperatorNode('-', 'subtract', [a, sub]);
-    var n2 = new OperatorNode('-', 'subtract', [a, add]);
-
-    assert.equal(n1.toTex(), '1-\\left(2-3\\right)');
-    assert.equal(n2.toTex(), '1-\\left(2+3\\right)');
+    assert.equal(n.getIdentifier(), 'UnaryOperatorNode:unaryMinus');
   });
 
-  it ('should LaTeX an OperatorNode with zero arguments', function () {
-    var n = new OperatorNode('foo', 'foo', []);
-    assert.equal(n.toTex(), '\\mathrm{foo}\\left(\\right)');
-  });
+  it('should LaTeX an UnaryOperatorNode with custom toTex for a single operator', function () {
 
-  it ('should LaTeX an OperatorNode with more than two operators', function () {
-    var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    var c = new ConstantNode(4);
+    var passedNode = null;
+    var string = 'should be returned from toString';
 
-    var n = new OperatorNode('foo', 'foo', [a, b, c]);
-    assert.equal(n.toTex(), '\\mathrm{foo}\\left(2,3,4\\right)');
-
-  });
-
-  it ('should LaTeX an OperatorNode with nested operator nodes', function () {
-    var a = new ConstantNode(2);
-    var b = new ConstantNode(3);
-    var c = new ConstantNode(4);
-    var d = new ConstantNode(5);
-
-    var n1 = new OperatorNode('+', 'add', [a, b]);
-    var n2 = new OperatorNode('-', 'subtract', [c, d]);
-    var n3 = new OperatorNode('*', 'multiply', [n1, n2]);
-
-    var m2 = new OperatorNode('*', 'multiply', [n1, c]);
-    var m3 = new OperatorNode('-', 'subtract', [m2, d]);
-
-    assert.equal(n1.toTex(), '2+3');
-    assert.equal(n2.toTex(), '4-5');
-    assert.equal(n3.toTex(), '\\left(2+3\\right)\\cdot\\left(4-5\\right)');
-    assert.equal(m3.toTex(), '\\left(2+3\\right)\\cdot4-5');
-  });
-
-  it ('should LaTeX addition and multiplication with more than two operands', function () {
-    var a = new SymbolNode('a');
-    var b = new SymbolNode('b');
-    var c = new SymbolNode('c');
-
-    var add = new OperatorNode('+', 'add', [a, b, c]);
-    var multiply = new OperatorNode('*', 'multiply', [a, b, c]);
-    var implicitMultiply = new OperatorNode('*', 'multiply', [a, b, c], true);
-
-    assert.equal(add.toTex(), ' a+\\mathrm{b}+ c');
-    assert.equal(multiply.toTex(), ' a\\cdot\\mathrm{b}\\cdot c');
-    assert.equal(implicitMultiply.toTex(), ' a~\\mathrm{b}~ c');
-  });
-
-  it ('should LaTeX addition and multiplication with more than two operands including OperatorNode', function () {
-    var a = new SymbolNode('a');
-    var b = new SymbolNode('b');
-    var c = new SymbolNode('c');
-    var d = new SymbolNode('d');
-
-    var mult = new OperatorNode('*', 'multiply', [a,b]);
-    var add = new OperatorNode('+', 'add', [a, b]);
-
-    var multipleMultWithMult = new OperatorNode('*', 'multiply', [c, mult, d]);
-    var multipleMultWithAdd = new OperatorNode('*', 'multiply', [c, add, d]);
-    var multipleAddWithMult = new OperatorNode('+', 'add', [c, mult, d]);
-    var multipleAddWithAdd = new OperatorNode('+', 'add', [c, add, d]);
-
-    assert.equal(multipleMultWithMult.toTex(), ' c\\cdot a\\cdot\\mathrm{b}\\cdot d');
-    assert.equal(multipleMultWithAdd.toTex(), ' c\\cdot\\left( a+\\mathrm{b}\\right)\\cdot d');
-    assert.equal(multipleAddWithMult.toTex(), ' c+ a\\cdot\\mathrm{b}+ d');
-    assert.equal(multipleAddWithAdd.toTex(), ' c+ a+\\mathrm{b}+ d');
-  });
-
-  it ('should LaTeX an OperatorNode that contains an operatornode with more than two operands', function () {
-    var a = new SymbolNode('a');
-    var b = new SymbolNode('b');
-    var c = new SymbolNode('c');
-    var d = new SymbolNode('d');
-
-    var mult = new OperatorNode('*', 'multiply', [a, b, c]);
-    var add = new OperatorNode('+', 'add', [a, b, c]);
-
-    var addWithMult = new OperatorNode('+', 'add', [mult, d]);
-    var addWithAdd = new OperatorNode('+', 'add', [add, d]);
-    var multWithMult = new OperatorNode('*', 'multiply', [mult, d]);
-    var multWithAdd = new OperatorNode('*', 'multiply', [add, d]);
-
-    assert.equal(addWithMult.toTex(), ' a\\cdot\\mathrm{b}\\cdot c+ d');
-    assert.equal(addWithAdd.toTex(), ' a+\\mathrm{b}+ c+ d');
-    assert.equal(multWithMult.toTex(), ' a\\cdot\\mathrm{b}\\cdot c\\cdot d');
-    assert.equal(multWithAdd.toTex(), '\\left( a+\\mathrm{b}+ c\\right)\\cdot d');
-  });
-
-  it('should LaTeX fractions with operators that are enclosed in parenthesis', function () {
-    var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
-
-    var add = new OperatorNode('+', 'add', [a,a]);
-    var frac = new OperatorNode('/', 'divide', [add,b]);
-    assert.equal(frac.toTex(), '\\frac{1+1}{2}');
-  });
-
-  it ('should have an identifier', function () {
-    var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
-
-    var n = new OperatorNode('+', 'add', [a, b]);
-
-    assert.equal(n.getIdentifier(), 'OperatorNode:add');
-  });
-
-  it ('should LaTeX an OperatorNode with custom toTex', function () {
-    //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, options) {
-      if (node.type === 'OperatorNode') {
-        return node.op + node.fn + '('
-          + node.args[0].toTex(options)
-          + ', ' +  node.args[1].toTex(options) + ')';
-      }
-      else if (node.type === 'ConstantNode') {
-        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
+    var toStringOptions = {
+      handler: function (node, options) {
+        passedNode = node;
+        assert.deepEqual(options, toStringOptions);
+        return string;
       }
     };
 
     var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
 
-    var n1 = new OperatorNode('+', 'add', [a, b]);
-    var n2 = new OperatorNode('-', 'subtract', [a, b]);
+    var n = new UnaryOperatorNode('-', 'unaryMinus', a);
 
-    assert.equal(n1.toTex({handler: customFunction}), '+add(const\\left(1, number\\right), const\\left(2, number\\right))');
-    assert.equal(n2.toTex({handler: customFunction}), '-subtract(const\\left(1, number\\right), const\\left(2, number\\right))');
-  });
+    assert.equal(n.toTex(toStringOptions), string);
 
-  it ('should LaTeX an OperatorNode with custom toTex for a single operator', function () {
-    //Also checks if the custom functions get passed on to the children
-    var customFunction = function (node, options) {
-      if ((node.type === 'OperatorNode') && (node.fn === 'add')) {
-        return node.args[0].toTex(options)
-          + node.op + node.fn + node.op +
-          node.args[1].toTex(options);
-      }
-      else if (node.type === 'ConstantNode') {
-        return 'const\\left(' + node.value + ', ' + node.valueType + '\\right)'
-      }
-    };
-
-    var a = new ConstantNode(1);
-    var b = new ConstantNode(2);
-
-    var n = new OperatorNode('+', 'add', [a, b]);
-
-    assert.equal(n.toTex({handler: customFunction}), 'const\\left(1, number\\right)+add+const\\left(2, number\\right)');
-  });
-
-  it ('should LaTeX powers of fractions with parentheses', function () {
-    var a = new ConstantNode(1);
-    var frac = new OperatorNode('/', 'divide', [a,a]);
-    var pow = new OperatorNode('^', 'pow', [frac, a]);
-
-    assert.equal(pow.toTex(), '\\left({\\frac{1}{1}}\\right)^{1}');
-  });
-
-  it ('should LaTeX powers of conditions with parentheses', function () {
-    var a = new ConstantNode(1);
-    var cond = new ConditionalNode(a, a, a);
-    var pow = new OperatorNode('^', 'pow', [cond, a]);
-
-    assert.equal(pow.toTex(), '\\left({\\begin{cases} {1}, &\\quad{\\text{if }\\;1}\\\\{1}, &\\quad{\\text{otherwise}}\\end{cases}}\\right)^{1}');
-  });
-
-  it ('should LaTeX simple expressions in \'auto\' mode', function () {
-    //this covers a bug that was triggered previously
-    assert.equal(math.parse('1+(1+1)').toTex({parenthesis: 'auto'}), '1+1+1');
-  });
-
-  it ('should stringify implicit multiplications', function () {
-    var a = math.parse('4a');
-    var b = math.parse('4 a');
-    var c = math.parse('a b');
-    var d = math.parse('2a b');
-    var e = math.parse('a b c');
-    var f = math.parse('(2+3)a');
-    var g = math.parse('(2+3)2');
-    var h = math.parse('2(3+4)');
-
-    assert.equal(a.toString(), a.toString({implicit: 'hide'}));
-    assert.equal(a.toString({implicit: 'hide'}), '4 a');
-    assert.equal(a.toString({implicit: 'show'}), '4 * a');
-
-    assert.equal(b.toString(), b.toString({implicit: 'hide'}));
-    assert.equal(b.toString({implicit: 'hide'}), '4 a');
-    assert.equal(b.toString({implicit: 'show'}), '4 * a');
-
-    assert.equal(c.toString(), c.toString({implicit: 'hide'}));
-    assert.equal(c.toString({implicit: 'hide'}), 'a b');
-    assert.equal(c.toString({implicit: 'show'}), 'a * b');
-
-    assert.equal(d.toString(), d.toString({implicit: 'hide'}));
-    assert.equal(d.toString({implicit: 'hide'}), '2 a b');
-    assert.equal(d.toString({implicit: 'show'}), '2 * a * b');
-
-    assert.equal(e.toString(), e.toString({implicit: 'hide'}));
-    assert.equal(e.toString({implicit: 'hide'}), 'a b c');
-    assert.equal(e.toString({implicit: 'show'}), 'a * b * c');
-
-    assert.equal(f.toString(), f.toString({implicit: 'hide'}));
-    assert.equal(f.toString({implicit: 'hide'}), '(2 + 3) a');
-    assert.equal(f.toString({implicit: 'show'}), '(2 + 3) * a');
-
-    assert.equal(g.toString(), g.toString({implicit: 'hide'}));
-    assert.equal(g.toString({implicit: 'hide'}), '(2 + 3) 2');
-    assert.equal(g.toString({implicit: 'show'}), '(2 + 3) * 2');
-
-    assert.equal(h.toString(), h.toString({implicit: 'hide'}));
-    assert.equal(h.toString({implicit: 'hide'}), '2 (3 + 4)');
-    assert.equal(h.toString({implicit: 'show'}), '2 * (3 + 4)');
-  });
-
-  it ('should LaTeX implicit multiplications', function () {
-    var a = math.parse('4a');
-    var b = math.parse('4 a');
-    var c = math.parse('a b');
-    var d = math.parse('2a b');
-    var e = math.parse('a b c');
-    var f = math.parse('(2+3)a');
-    var g = math.parse('(2+3)2');
-    var h = math.parse('2(3+4)');
-
-    assert.equal(a.toTex(), a.toTex({implicit: 'hide'}));
-    assert.equal(a.toTex({implicit: 'hide'}), '4~ a');
-    assert.equal(a.toTex({implicit: 'show'}), '4\\cdot a');
-
-    assert.equal(b.toTex(), b.toTex({implicit: 'hide'}));
-    assert.equal(b.toTex({implicit: 'hide'}), '4~ a');
-    assert.equal(b.toTex({implicit: 'show'}), '4\\cdot a');
-
-    assert.equal(c.toTex(), c.toTex({implicit: 'hide'}));
-    assert.equal(c.toTex({implicit: 'hide'}), ' a~\\mathrm{b}');
-    assert.equal(c.toTex({implicit: 'show'}), ' a\\cdot\\mathrm{b}');
-
-    assert.equal(d.toTex(), d.toTex({implicit: 'hide'}));
-    assert.equal(d.toTex({implicit: 'hide'}), '2~ a~\\mathrm{b}');
-    assert.equal(d.toTex({implicit: 'show'}), '2\\cdot a\\cdot\\mathrm{b}');
-
-    assert.equal(e.toTex(), e.toTex({implicit: 'hide'}));
-    assert.equal(e.toTex({implicit: 'hide'}), ' a~\\mathrm{b}~ c');
-    assert.equal(e.toTex({implicit: 'show'}), ' a\\cdot\\mathrm{b}\\cdot c');
-
-    assert.equal(f.toTex(), f.toTex({implicit: 'hide'}));
-    assert.equal(f.toTex({implicit: 'hide'}), '\\left(2+3\\right)~ a');
-    assert.equal(f.toTex({implicit: 'show'}), '\\left(2+3\\right)\\cdot a');
-
-    assert.equal(g.toTex(), g.toTex({implicit: 'hide'}));
-    assert.equal(g.toTex({implicit: 'hide'}), '\\left(2+3\\right)~2');
-    assert.equal(g.toTex({implicit: 'show'}), '\\left(2+3\\right)\\cdot2');
-
-    assert.equal(h.toTex(), h.toTex({implicit: 'hide'}));
-    assert.equal(h.toTex({implicit: 'hide'}), '2~\\left(3+4\\right)');
-    assert.equal(h.toTex({implicit: 'show'}), '2\\cdot\\left(3+4\\right)');
-  });
-
-  it ('should stringify implicit multiplications between ConstantNodes with parentheses', function () {
-    var a = math.parse('(4)(4)(4)(4)');
-    var b = math.parse('4b*4(4)');
-    var c = math.parse('(4(4(4)))');
-
-    assert.equal(a.toString({implicit: 'hide', parenthesis: 'auto'}), '(4) (4) (4) (4)');
-    assert.equal(b.toString({implicit: 'hide', parenthesis: 'auto'}), '4 b * 4 (4)');
-    assert.equal(c.toString({implicit: 'hide', parenthesis: 'auto'}), '4 (4 (4))');
-  });
-
-  it ('should LaTeX implicit multiplications between ConstantNodes with parentheses', function () {
-    var a = math.parse('(4)(4)(4)(4)');
-    var b = math.parse('4b*4(4)');
-    var c = math.parse('(4(4(4)))');
-
-    assert.equal(a.toTex({implicit: 'hide', parenthesis: 'auto'}), '\\left(4\\right)~\\left(4\\right)~\\left(4\\right)~\\left(4\\right)');
-    assert.equal(b.toTex({implicit: 'hide', parenthesis: 'auto'}), '4~\\mathrm{b}\\cdot4~\\left(4\\right)');
-    assert.equal(c.toTex({implicit: 'hide', parenthesis: 'auto'}), '4~\\left(4~\\left(4\\right)\\right)');
-  });
-
-  it ('should HTML implicit multiplications between ConstantNodes with parentheses', function () {
-    var a = math.parse('(4)(4)(4)(4)');
-    var b = math.parse('4b*4(4)');
-    var c = math.parse('(4(4(4)))');
-
-    assert.equal(a.toHTML({implicit: 'hide', parenthesis: 'auto'}), '<span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span>');
-    assert.equal(b.toHTML({implicit: 'hide', parenthesis: 'auto'}), '<span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-symbol">b</span><span class="math-operator math-binary-operator math-explicit-binary-operator">*</span><span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span>');
-    assert.equal(c.toHTML({implicit: 'hide', parenthesis: 'auto'}), '<span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-operator math-binary-operator math-implicit-binary-operator"></span><span class="math-parenthesis math-round-parenthesis">(</span><span class="math-number">4</span><span class="math-parenthesis math-round-parenthesis">)</span><span class="math-parenthesis math-round-parenthesis">)</span>');
   });
 });

--- a/test/expression/node/UnaryOperatorNode.test.js
+++ b/test/expression/node/UnaryOperatorNode.test.js
@@ -78,7 +78,7 @@ describe('UnaryOperatorNode', function() {
     });
 
     assert.deepEqual(nodes, [x]);
-    assert.deepEqual(paths, ['value']);
+    assert.deepEqual(paths, ['arg']);
   });
 
   it('should map an UnaryOperatorNode', function () {
@@ -97,10 +97,10 @@ describe('UnaryOperatorNode', function() {
     });
 
     assert.deepEqual(nodes, [x]);
-    assert.deepEqual(paths, ['value']);
+    assert.deepEqual(paths, ['arg']);
 
     assert.notStrictEqual(c, b);
-    assert.strictEqual(c.value, b.value);
+    assert.strictEqual(c.arg, b.arg);
   });
 
   it('should throw an error when the map callback does not return a node', function () {
@@ -127,8 +127,8 @@ describe('UnaryOperatorNode', function() {
       return node;
     });
 
-    assert.deepEqual(transformed.value, f);
-    assert.deepEqual(notTransformed.value, x);
+    assert.deepEqual(transformed.arg, f);
+    assert.deepEqual(notTransformed.arg, x);
   });
 
   it('should transform an UnaryOperatorNode itself', function () {
@@ -152,7 +152,7 @@ describe('UnaryOperatorNode', function() {
     assert(cloned instanceof UnaryOperatorNode);
     assert.deepEqual(cloned, node);
     assert.notStrictEqual(cloned, node);
-    assert.strictEqual(cloned.value, node.value);
+    assert.strictEqual(cloned.arg, node.arg);
   });
 
 

--- a/test/expression/node/index.test.js
+++ b/test/expression/node/index.test.js
@@ -5,7 +5,7 @@ var index = require('../../../lib/expression/node/index');
 describe('node/index', function() {
 
   it('should contain all nodes', function() {
-    assert.equal(index.length, 16);
+    assert.equal(index.length, 17);
   });
 
 });

--- a/test/function/algebra/derivative.test.js
+++ b/test/function/algebra/derivative.test.js
@@ -228,11 +228,11 @@ describe('derivative', function() {
 
     assert.throws(function () {
       derivative('[1, 2; 3, 4]', 'x');
-    }, /TypeError: Unexpected type of argument in function constTag \(expected: OperatorNode or ConstantNode or SymbolNode or ParenthesisNode or FunctionNode or FunctionAssignmentNode, actual: ArrayNode, index: 1\)/);
+    }, /TypeError: Unexpected type of argument in function constTag \(expected: OperatorNode or ConstantNode or SymbolNode or ParenthesisNode or FunctionNode or UnaryOperatorNode or FunctionAssignmentNode, actual: ArrayNode, index: 1\)/);
 
     assert.throws(function () {
       derivative('x + [1, 2; 3, 4]', 'x');
-    }, /TypeError: Unexpected type of argument in function constTag \(expected: OperatorNode or ConstantNode or SymbolNode or ParenthesisNode or FunctionNode or FunctionAssignmentNode, actual: ArrayNode, index: 1\)/);
+    }, /TypeError: Unexpected type of argument in function constTag \(expected: OperatorNode or ConstantNode or SymbolNode or ParenthesisNode or FunctionNode or UnaryOperatorNode or FunctionAssignmentNode, actual: ArrayNode, index: 1\)/);
   });
 
   it('should throw error if incorrect number of arguments', function() {


### PR DESCRIPTION
This PR is my attempt to refactor the `OperatorNode` class according to #1025.

 I created new class `UnaryOperatorNode`, the changes to `OperatorNode` affects the following parts of mathjs:
 - `parse` now creates `UnaryOperatorNode`'s where appropriate.
 - `derivative` fairly straightforward changes adding a new typed function case.
 - `rationalize` extra case in input validation.
 - `simplifyConstant` adds extra case
 - `simplifyCore` 
 - `simplify`

Refactoring `simplifyCore` was a bit tricky but I think I managed it. I gave up trying with `simplify` and in this PR `UnaryOperatorNode`s are converted to `OperatorNode`s before the simplification starts which is a hack but I need some help with this function.

This implements aproximately a third of the changes needed to remove `OperatorNode`s from mathjs but gave me a fair bit of insight into the pros and cons of doing so. There is a lot of `if (node.args.length === 2) {}` in the code I came across which would be no longer be needed. There is also currently a fair bit that would break with unhelpful errors if three argument `OperatorNode's found their way into the wrong part of the code base.
