### PR TITLE
Bug: When mapping an OperatorNode implicit status is lost

### DIFF
--- a/lib/expression/node/OperatorNode.js
+++ b/lib/expression/node/OperatorNode.js
@@ -113,7 +113,7 @@ function factory (type, config, load, typed) {
     for (var i = 0; i < this.args.length; i++) {
       args[i] = this._ifNode(callback(this.args[i], 'args[' + i + ']', this));
     }
-    return new OperatorNode(this.op, this.fn, args);
+    return new OperatorNode(this.op, this.fn, args, this.implicit);
   };
 
   /**

--- a/test/expression/node/OperatorNode.test.js
+++ b/test/expression/node/OperatorNode.test.js
@@ -120,6 +120,14 @@ describe('OperatorNode', function() {
     assert.deepEqual(g.args[1],  f);
   });
 
+  it('should map an implicit OperatorNode', function () {
+    var x = new SymbolNode('x');
+    var y = new SymbolNode('y');
+    var product = new OperatorNode('*', 'multiply', [x, y], true /* implicit */);
+
+    assert.deepEqual(product.map(function(x) { return x; }), product);
+  });
+
   it ('should throw an error when the map callback does not return a node', function () {
     var a = new SymbolNode('x');
     var b = new ConstantNode(2);


### PR DESCRIPTION
I confused travis with #1028 so here I am trying again.

When calling `map` on an `OperatorNode` with `implicit === true` and `OperatorNode` with `implicit === false` is created.