### PR TITLE
Fixes jsdoc for qr.js

### DIFF
--- a/lib/function/algebra/decomposition/qr.js
+++ b/lib/function/algebra/decomposition/qr.js
@@ -60,11 +60,9 @@ function factory (type, config, load, typed) {
    *
    *    lu
    *
-   * @param {Matrix | Array} A    A two dimensional matrix or array 
-   * for which to get the QR decomposition.
+   * @param {Matrix | Array} A    A two dimensional matrix or array  for which to get the QR decomposition.
    *
-   * @return {{Q: Array | Matrix, R: Array | Matrix}} Q: the orthogonal
-   * matrix and R: the upper triangular matrix
+   * @return {{Q: Array | Matrix, R: Array | Matrix}} Q: the orthogonal matrix and R: the upper triangular matrix
    */
   var qr = typed('qr', {
 


### PR DESCRIPTION
Descriptions for parameters and return values have been truncated due to newline in jsdoc. This pr removes the newline.

Current, documentation parameter description has been truncated:
![image](https://user-images.githubusercontent.com/16308754/36230488-7707ff4a-11d2-11e8-9219-4ed67796ed84.png)
