### PR TITLE
Uses unpkg.com instead of wzrd for cdn. 

### DIFF
--- a/examples/browser/plot.html
+++ b/examples/browser/plot.html
@@ -6,7 +6,7 @@
 
   <!-- load http://maurizzzio.github.io/function-plot/ -->
   <script src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
-  <script src="https://wzrd.in/standalone/function-plot@1.14.0"></script>
+  <script src="https://unpkg.com/function-plot@1.14.0/dist/function-plot.js"></script>
 
   <style>
     input[type=text] {


### PR DESCRIPTION
https://wzrd.in is down and so example breaks.

This commit uses unpkg instead which should be more reliable although I can't work out how the build the website so I haven't tested this actually works.

closes #1073 