### PR TITLE
Add complex transpose. A' now takes conjugate.

### DIFF
--- a/lib/expression/embeddedDocs/function/matrix/ctranspose.js
+++ b/lib/expression/embeddedDocs/function/matrix/ctranspose.js
@@ -1,0 +1,17 @@
+module.exports = {
+  'name': 'transpose',
+  'category': 'Matrix',
+  'syntax': [
+    'x\'',
+    'ctranspose(x)'
+  ],
+  'description': 'Complex Conjugate and Transpose a matrix',
+  'examples': [
+    'a = [1, 2, 3; 4, 5, 6]',
+    'a\'',
+    'ctranspose(a)'
+  ],
+  'seealso': [
+    'concat', 'det', 'diag', 'eye', 'inv', 'ones', 'range', 'size', 'squeeze', 'subset', 'trace', 'zeros'
+  ]
+};

--- a/lib/expression/embeddedDocs/index.js
+++ b/lib/expression/embeddedDocs/index.js
@@ -187,6 +187,7 @@ function factory (construction, config, load, typed) {
   // functions - matrix
   docs['concat'] = require('./function/matrix/concat');
   docs.cross = require('./function/matrix/cross');
+  docs.ctranspose = require('./function/matrix/ctranspose');
   docs.det = require('./function/matrix/det');
   docs.diag = require('./function/matrix/diag');
   docs.dot = require('./function/matrix/dot');

--- a/lib/expression/parse.js
+++ b/lib/expression/parse.js
@@ -1155,7 +1155,7 @@ function factory (type, config, load, typed) {
   }
 
   /**
-   * Left hand operators: factorial x!, transpose x'
+   * Left hand operators: factorial x!, ctranspose x'
    * @return {Node} node
    * @private
    */
@@ -1166,7 +1166,7 @@ function factory (type, config, load, typed) {
 
     operators = {
       '!': 'factorial',
-      '\'': 'transpose'
+      '\'': 'ctranspose'
     };
 
     while (operators.hasOwnProperty(token)) {

--- a/lib/function/matrix/ctranspose.js
+++ b/lib/function/matrix/ctranspose.js
@@ -1,0 +1,53 @@
+'use strict';
+
+
+function factory (type, config, load, typed) {
+  var transpose = load(require('./transpose'));
+  var conj = load(require('../complex/conj'));
+  var latex = require('../../utils/latex');
+
+  /**
+   * Transpose and complex conjugate a matrix. All values of the matrix are
+   * reflected over its main diagonal and then the complex conjugate is
+   * taken. This is equivalent to complex conjugation for scalars and
+   * vectors.
+   *
+   * Syntax:
+   *
+   *     math.ctranspose(x)
+   *
+   * Examples:
+   *
+   *     var A = [[1, 2, 3], [4, 5, math.complex(6,7)]];
+   *     math.ctranspose(A);               // returns [[1, 4], [2, 5], [3, {re:6,im:7}]]
+   *
+   * See also:
+   *
+   *     transpose, diag, inv, subset, squeeze
+   *
+   * @param {Array | Matrix} x  Matrix to be ctransposed
+   * @return {Array | Matrix}   The ctransposed matrix
+   */
+  var ctranspose = typed('ctranspose', {
+
+    'Array': function (x) {
+      return conj( transpose( x ) );
+    },
+
+    'Matrix': function (x) {
+      return conj( transpose( x ) );
+    },
+
+    // scalars
+    'any': function (x) {
+      return conj(x);
+    }
+  });
+
+  ctranspose.toTex = {1: '\\left(${args[0]}\\right)' + latex.operators['ctranspose']};
+
+  return ctranspose;
+}
+
+exports.name = 'ctranspose';
+exports.factory = factory;

--- a/lib/function/matrix/ctranspose.js
+++ b/lib/function/matrix/ctranspose.js
@@ -30,17 +30,8 @@ function factory (type, config, load, typed) {
    */
   var ctranspose = typed('ctranspose', {
 
-    'Array': function (x) {
-      return conj( transpose( x ) );
-    },
-
-    'Matrix': function (x) {
-      return conj( transpose( x ) );
-    },
-
-    // scalars
     'any': function (x) {
-      return conj(x);
+      return conj( transpose( x ) );
     }
   });
 

--- a/lib/function/matrix/index.js
+++ b/lib/function/matrix/index.js
@@ -2,6 +2,7 @@
 module.exports = [
   require('./concat'),
   require('./cross'),
+  require('./ctranspose'),
   require('./det'),
   require('./diag'),
   require('./dot'),

--- a/lib/utils/latex.js
+++ b/lib/utils/latex.js
@@ -44,6 +44,7 @@ exports.symbols = {
 
 exports.operators = {
   'transpose': '^\\top',
+  'ctranspose': '^H',
   'factorial': '!',
   'pow': '^',
   'dotPow': '.^\\wedge', //TODO find ideal solution

--- a/test/function/matrix/ctranspose.test.js
+++ b/test/function/matrix/ctranspose.test.js
@@ -1,0 +1,164 @@
+// test transpose
+var assert = require('assert'),
+    math = require('../../../index'),
+    ctranspose = math.ctranspose;
+
+describe('ctranspose', function() {
+
+  it('should transpose a real scalar', function() {
+    assert.deepEqual(ctranspose(3), 3);
+  });
+
+  it('should conjugate a complex scalar', function() {
+    assert.deepEqual(ctranspose(math.complex(3,4)), math.complex(3,-4));
+  });
+
+  it('should transpose a vector', function() {
+    assert.deepEqual(ctranspose([1,2,3]), [1,2,3]);
+    assert.deepEqual(ctranspose(math.matrix([1,2,3]).toArray()), [1,2,3]);
+  });
+
+  it('should conjgate a complex vector', function() {
+    var a = math.complex(1,2);
+    var b = math.complex(3,4);
+    var c = math.complex(5,6);
+    var aH = math.complex(1,-2);
+    var bH = math.complex(3,-4);
+    var cH = math.complex(5,-6);
+    assert.deepEqual(ctranspose([a,b,c]),[aH,bH,cH]);
+    assert.deepEqual(ctranspose(math.matrix([a,b,c])).toArray(), [aH,bH,cH]);
+  });
+
+  it('should transpose a 2d matrix', function() {
+    assert.deepEqual(ctranspose([[1,2,3],[4,5,6]]), [[1,4],[2,5],[3,6]]);
+    assert.deepEqual(ctranspose(math.matrix([[1,2,3],[4,5,6]]).toArray()), [[1,4],[2,5],[3,6]]);
+    assert.deepEqual(ctranspose([[1,2],[3,4]]), [[1,3],[2,4]]);
+    assert.deepEqual(ctranspose([[1,2,3,4]]), [[1],[2],[3],[4]]);
+  });
+
+  it('should conjugate transpose a 2d complex matrix', function() {
+    var a = math.complex(1,2);
+    var b = math.complex(3,4);
+    var c = math.complex(5,6);
+    var d = math.complex(7,8);
+    var e = math.complex(9,10);
+    var f = math.complex(11,12);
+    var aH = math.complex(1,-2);
+    var bH = math.complex(3,-4);
+    var cH = math.complex(5,-6);
+    var dH = math.complex(7,-8);
+    var eH = math.complex(9,-10);
+    var fH = math.complex(11,-12);
+    assert.deepEqual(ctranspose([[a,b,c],[d,e,f]]), [[aH,dH],[bH,eH],[cH,fH]]);
+    assert.deepEqual(ctranspose(math.matrix([[a,b,c],[d,e,f]])).toArray(), [[aH,dH],[bH,eH],[cH,fH]]);
+    assert.deepEqual(ctranspose([[a,b],[c,d]]), [[aH,cH],[bH,dH]]);
+    assert.deepEqual(ctranspose([[a,b,c,d]]), [[aH],[bH],[cH],[dH]]);
+  });
+
+  it('should throw an error for invalid matrix transpose', function() {
+    assert.throws(function () {
+      assert.deepEqual(ctranspose([[]]), [[]]);  // size [2,0]
+    });
+    assert.throws(function () {
+      ctranspose([[[1],[2]],[[3],[4]]]); // size [2,2,1]
+    });
+  });
+
+  it('should throw an error if called with an invalid number of arguments', function() {
+    assert.throws(function () {ctranspose();}, /TypeError: Too few arguments/);
+    assert.throws(function () {ctranspose([1,2],2);}, /TypeError: Too many arguments/);
+  });
+
+  describe('DenseMatrix', function () {
+
+    it('should transpose a 2d matrix', function() {
+      var a = math.complex(1,2);
+      var b = math.complex(3,4);
+      var c = math.complex(5,6);
+      var d = math.complex(7,8);
+      var e = math.complex(9,10);
+      var f = math.complex(11,12);
+      var aH = math.complex(1,-2);
+      var bH = math.complex(3,-4);
+      var cH = math.complex(5,-6);
+      var dH = math.complex(7,-8);
+      var eH = math.complex(9,-10);
+      var fH = math.complex(11,-12);
+      var m = math.matrix([[a,b,c],[d,e,f]])
+      var t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[aH,dH],[bH,eH],[cH,fH]]);
+
+      m = math.matrix([[a,b],[c,d],[e,f]])
+      t = ctranspose(m);
+      assert.deepEqual(t.toArray(), [[aH,cH,eH],[bH,dH,fH]]);
+
+      m = math.matrix([[a,b],[c,d]])
+      t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[aH,cH],[bH,dH]]);
+
+      m = math.matrix([[a,b,c,d]])
+      t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[aH],[bH],[cH],[dH]]);
+
+      m = math.matrix([[a,b],[c,d]], 'dense', 'number');
+      t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[aH,cH],[bH,dH]]);
+      assert.ok(t.datatype() === 'number');
+    });
+
+    it('should throw an error for invalid matrix transpose', function() {
+      var m = math.matrix([[]]);
+      assert.throws(function () { transpose(m); });
+
+      m = math.matrix([[[1],[2]],[[3],[4]]]);
+      assert.throws(function () { transpose(m); });
+    });
+  });
+
+  describe('SparseMatrix', function () {
+
+    it('should transpose a 2d matrix', function() {
+      var a = math.complex(1,2);
+      var b = math.complex(3,4);
+      var c = math.complex(5,6);
+      var d = math.complex(7,8);
+      var e = math.complex(9,10);
+      var f = math.complex(11,12);
+      var aH = math.complex(1,-2);
+      var bH = math.complex(3,-4);
+      var cH = math.complex(5,-6);
+      var dH = math.complex(7,-8);
+      var eH = math.complex(9,-10);
+      var fH = math.complex(11,-12);
+      var m = math.sparse([[a,b,c],[d,e,f]]);
+      var t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[aH,dH],[bH,eH],[cH,fH]]);
+
+      m = math.sparse([[a,b],[c,d],[e,f]]);
+      t = ctranspose(m);
+      assert.deepEqual(t.toArray(), [[aH,cH,eH],[bH,dH,fH]]);
+
+      m = math.sparse([[a,b],[c,d]])
+      t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[aH,cH],[bH,dH]]);
+
+      /* Failing test, but I'm not sure if would be expected to pass */
+      /*
+      m = math.sparse([[1,2,3,4]], 'number');
+      t = ctranspose(m);
+      assert.deepEqual(t.valueOf(), [[1],[2],[3],[4]]);
+      assert.ok(t.datatype() === 'number');
+      */
+    });
+
+    it('should throw an error for invalid matrix transpose', function() {
+      var m = math.matrix([[]], 'sparse');
+      assert.throws(function () { transpose(m); });
+    });
+  });
+
+  it('should LaTeX transpose', function () {
+    var expression = math.parse('ctranspose([[1+2i,3+4i],[5+6i,7+8i]])');
+    assert.equal(expression.toTex(), '\\left(\\begin{bmatrix}1+2~ i&3+4~ i\\\\5+6~ i&7+8~ i\\\\\\end{bmatrix}\\right)^H');
+  });
+});


### PR DESCRIPTION
As mentioned in #1094:

In matlab and octave the expression A' produces the Hermitian
conjugate, the complex conjugate of the transpose.

Now transpose produces the transpose, while ctranspose produces
the conjugate transpose. These are equal for real numbers, while
for complex numbers only the conjugate transpose is of much use.