### PR TITLE
Bugix for Frobenius norm of complex matrices.

### DIFF
--- a/lib/function/arithmetic/norm.js
+++ b/lib/function/arithmetic/norm.js
@@ -5,6 +5,7 @@ function factory (type, config, load, typed) {
   var abs         = load(require('../arithmetic/abs'));
   var add         = load(require('../arithmetic/add'));
   var pow         = load(require('../arithmetic/pow'));
+  var conj        = load(require('../complex/conj'));
   var sqrt        = load(require('../arithmetic/sqrt'));
   var multiply    = load(require('../arithmetic/multiply'));
   var equalScalar = load(require('../relational/equalScalar'));
@@ -192,7 +193,12 @@ function factory (type, config, load, typed) {
       }
       if (p === 'fro') {
         // norm(x) = sqrt(sum(diag(x'x)))
-        return sqrt(trace(multiply(transpose(x), x)));
+        var fro = 0;
+        x.forEach(
+          function (value, index) {
+            fro = add( fro, multiply( value, conj(value) ) );
+          });
+        return sqrt(fro);
       }
       if (p === 2) {
         // not implemented

--- a/test/function/arithmetic/norm.test.js
+++ b/test/function/arithmetic/norm.test.js
@@ -29,6 +29,7 @@ describe('norm', function () {
     assert.equal(math.norm(math.complex(3, -4)), 5);
     assert.equal(math.norm(math.complex(1e200, -4e200)), 4.12310562561766e+200);
     assert.equal(math.norm(math.complex(-4e200, 1e200)), 4.12310562561766e+200);
+    assert.equal(math.norm(math.matrix([[math.complex(3, -4)]]),'fro'), 5);
   });
 
   it('should return the norm of a vector', function () {


### PR DESCRIPTION
As mentioned in #1094 

The code on line 195 of `lib/function/arithmetic/norm.js` is comment with `sqrt(sum(diag(x'x)))` but this is only true for the conjugate transpose. The general formula is `sqrt(sum(sum(pow(abs(a[i,j]),2),i=1..m),j=1..n))`, the square root of the sum of the absolute values squared of the entries.

This commit makes mathjs agree with matlab, and improves the efficiency by directly summing a[i,j]' * a[i,j]. The old method was cubic (for square matrices); this method is quadratic. I also added a short test.

In mathjs 5.2.1:
```js
math.eval('norm([[3+4i]],"fro")')
{ re: 3, im: 4 }
```

In matlab:
```matlab
norm([[3+4i]],'fro')
ans =  5
```

After this commit, mathjs outputs 5.