### PR TITLE
Ponyfill Object.assign

### DIFF
--- a/lib/utils/bignumber/formatter.js
+++ b/lib/utils/bignumber/formatter.js
@@ -1,4 +1,7 @@
 'use strict';
+
+var objectUtils = require('../object');
+
 /**
  * Convert a BigNumber to a formatted string representation.
  *
@@ -107,7 +110,7 @@ exports.format = function (value, options) {
       // TODO: clean up some day. Deprecated since: 2018-01-24
       // @deprecated upper and lower are replaced with upperExp and lowerExp since v4.0.0
       if (options && options.exponential && (options.exponential.lower !== undefined || options.exponential.upper !== undefined)) {
-        var fixedOptions = Object.assign({}, options);
+        var fixedOptions = objectUtils.map(options, function (x) { return x; });
         fixedOptions.exponential = undefined;
         if (options.exponential.lower !== undefined) {
           fixedOptions.lowerExp = Math.round(Math.log(options.exponential.lower) / Math.LN10);

--- a/lib/utils/number.js
+++ b/lib/utils/number.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var objectUtils = require('./object');
+
 /**
  * @typedef {{sign: '+' | '-' | '', coefficients: number[], exponent: number}} SplitValue
  */
@@ -162,7 +164,7 @@ exports.format = function(value, options) {
       // TODO: clean up some day. Deprecated since: 2018-01-24
       // @deprecated upper and lower are replaced with upperExp and lowerExp since v4.0.0
       if (options && options.exponential && (options.exponential.lower !== undefined || options.exponential.upper !== undefined)) {
-        var fixedOptions = Object.assign({}, options);
+        var fixedOptions = objectUtils.map(options, function(x) { return x; });
         fixedOptions.exponential = undefined;
         if (options.exponential.lower !== undefined) {
           fixedOptions.lowerExp = Math.round(Math.log(options.exponential.lower) / Math.LN10);


### PR DESCRIPTION
Internet Explorer 11 does not support Object.assign, as this is a browser that is _meant_ to be supported by mathjs we should probably use this ponyfill.

I have added a new dependancy in this commit (https://www.npm.com/package/object-assign) as I thought it made sense to not reinvent the wheel here.

If we ever start transpiling mathjs we would then be able to revert this commit.

This will fix some of the tests failing on IE 11 in #1105.