### PR TITLE
explicity list files to be included in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-coverage
-img
-misc
-node_modules
-tools
-gulpfile.js
-.idea
-.npmignore
-.travis.yml

--- a/package.json
+++ b/package.json
@@ -137,6 +137,11 @@
     "zeros": "1.0.0"
   },
   "main": "./index",
+  "files": [
+      "dist",
+      "lib",
+      "src",
+  ],
   "scripts": {
     "build": "gulp",
     "watch": "gulp watch",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   "files": [
       "dist",
       "lib",
-      "src",
+      "src"
   ],
   "scripts": {
     "build": "gulp",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,12 @@
   "files": [
       "dist",
       "lib",
-      "src"
+      "src",
+      "bin",
+      "core.js",
+      "docs",
+      "examples",
+      "CONTRIBUTING.md"
   ],
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
Rather than add everything to the npm package it is better to only add the nessary files.
This commit lists the files to include based on https://docs.npmjs.com/files/package.json#files

Note that to test this you would have to publish an npm module and manually check that it works.

I propse adding this to v5 #1045.