### PR TITLE
Lint build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 stages:
   - lint
   - test
-  - browser-tests
+  - browser-test
 
 # NAME env var is purely cosmetic, only way to identify builds until
 # https://github.com/travis-ci/travis-ci/issues/5898 is fixed.
@@ -17,7 +17,7 @@ jobs:
     - stage: lint
       node_js: 8
       script: npm run lint
-    - stage: browser-tests
+    - stage: browser-test
       node_js: 8
       script: npm run test:browser
       env: NAME=local browser

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,19 @@ node_js:
   - 8
   - 10
 
+stages:
+  - lint
+  - test
+  - browser-tests
+
 # NAME env var is purely cosmetic, only way to identify builds until
 # https://github.com/travis-ci/travis-ci/issues/5898 is fixed.
 
 jobs:
   include:
+    - stage: lint
+      node_js: 8
+      script: npm run lint
     - stage: browser-tests
       node_js: 8
       script: npm run test:browser

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
     - stage: lint
       node_js: 8
       script: npm run lint
+    - stage: test
+      script: npm run test:src
     - stage: browser-test
       node_js: 8
       script: npm run test:browser

--- a/package.json
+++ b/package.json
@@ -157,16 +157,18 @@
   ],
   "scripts": {
     "build": "gulp",
+    "build-and-test": "npm run build && npm run test:dist",
     "compile": "gulp compile",
     "watch": "gulp watch",
     "docs": "gulp docs",
     "lint": "standard --env=mocha --env=worker",
-    "test": "mocha test test-node --recursive --require babel-core/register && npm run lint",
+    "test": "npm run lint && npm run test:src",
+    "test:src": "mocha test test-node --recursive --require babel-core/register",
     "test:dist": "mocha test-dist --recursive",
     "test:browser": "karma start ./browser-test-config/local-karma.js",
     "test:browserstack": "karma start ./browser-test-config/browserstack-karma.js",
     "coverage": "nyc --reporter=lcov --reporter=text-summary mocha test test-node --recursive --require babel-core/register; echo \"\nDetailed coverage report is available at ./coverage/lcov-report/index.html\"",
-    "prepublishOnly": "npm run build && npm test && npm run test:dist"
+    "prepublishOnly": "npm test:src && npm run build-and-test"
   },
   "bin": {
     "mathjs": "./bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "test:browser": "karma start ./browser-test-config/local-karma.js",
     "test:browserstack": "karma start ./browser-test-config/browserstack-karma.js",
     "coverage": "nyc --reporter=lcov --reporter=text-summary mocha test test-node --recursive --require babel-core/register; echo \"\nDetailed coverage report is available at ./coverage/lcov-report/index.html\"",
-    "prepublishOnly": "npm test:src && npm run build-and-test"
+    "prepublishOnly": "npm test && npm run build-and-test"
   },
   "bin": {
     "mathjs": "./bin/cli.js"


### PR DESCRIPTION
Off the back of adding linting in #1129 this PR creates a new travis build step for it.

This means that folk can easily see the difference between linting failures and test failures.
Test will only be run when linting passes, this also means that linting runs once instead of four times.

![image](https://user-images.githubusercontent.com/16308754/41420777-25ee0bda-6fed-11e8-8596-ffe3515c4b51.png)

---

I also changed the name of the browser-test stage for consistancy
