### PR TITLE
Improve debugging support

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -801,7 +801,7 @@ function factory (type, config, load, typed, math) {
       // other = new Unit(null, valuelessUnit)
       other = Unit.parse(valuelessUnit)
       if (!this.equalBase(other)) {
-        throw new Error('Units do not match')
+        throw new Error(`Units do not match ('${other.toString()}' != '${this.toString()}')`)
       }
       if (other.value !== null) {
         throw new Error('Cannot convert to a unit with a value')
@@ -813,7 +813,7 @@ function factory (type, config, load, typed, math) {
       return other
     } else if (type.isUnit(valuelessUnit)) {
       if (!this.equalBase(valuelessUnit)) {
-        throw new Error('Units do not match')
+        throw new Error(`Units do not match ('${valuelessUnit.toString()}' != '${this.toString()}')`)
       }
       if (valuelessUnit.value !== null) {
         throw new Error('Cannot convert to a unit with a value')


### PR DESCRIPTION
When this error is encountered in the field, I see it via honeybadger, but I have none of the context about what unit it was called in, and what unit it was being converted to. Help the debugging by adding some info to the exception. 

I'm not entirely sure that 'toString' is what I want here - perhaps others in the community can help make that the right expression?