### PR TITLE
Decrease runtime of rationalize tests.

### DIFF
--- a/test/function/algebra/rationalize.test.js
+++ b/test/function/algebra/rationalize.test.js
@@ -107,7 +107,7 @@ describe('rationalize', function () {
   })
 
   it('processing power expressions', function () {
-    assert.equal(stri(math.rationalize('(2x+1)^6')), '64*x^6+192*x^5+240*x^4+160*x^3+60*x^2+12*x+1')
+    assert.equal(stri(math.rationalize('(2x+1)^3')), '8*x^3+12*x^2+6*x+1')
     assert.equal(stri(math.rationalize('(2x+1)^3/(x-2)^3')), '(8*x^3+12*x^2+6*x+1)/(x^3-6*x^2+12*x-8)')
   })
 
@@ -115,10 +115,15 @@ describe('rationalize', function () {
     assert.equal(stri(math.rationalize('2x/(x+2) - x/(x+1)')), 'x^2/(x^2+3*x+2)')
     assert.equal(stri(math.rationalize('2x/( (2x-1) / (3x+2) ) - 5x/ ( (3x+4) / (2x^2-5) ) + 3')),
       '(-20*x^4+28*x^3+104*x^2+6*x-12)/(6*x^2+5*x-4)')
-    assert.equal(stri(math.rationalize('x/(1-x)/(x-2)/(x-3)/(x-4) + 2x/ ( (1-2x)/(2-3x) )/ ((3-4x)/(4-5x) )')),
-      '(-30*x^7+344*x^6-1506*x^5+3200*x^4-3472*x^3+1846*x^2-381*x)/(-8*x^6+90*x^5-383*x^4+780*x^3-797*x^2+390*x-72)')
     const no = math.parse('2x/( (2x-1) / (3x+2) ) - 5x/ ( (3x+4) / (2x^2-5) ) + 3')
     assert.equal(stri(math.rationalize(no)), '(-20*x^4+28*x^3+104*x^2+6*x-12)/(6*x^2+5*x-4)')
+  })
+
+  it.skip('processes a really complex expression', function () {
+    // note this test passes but takes for ever to complete
+
+    assert.equal(stri(math.rationalize('x/(1-x)/(x-2)/(x-3)/(x-4) + 2x/ ( (1-2x)/(2-3x) )/ ((3-4x)/(4-5x) )')),
+      '(-30*x^7+344*x^6-1506*x^5+3200*x^4-3472*x^3+1846*x^2-381*x)/(-8*x^6+90*x^5-383*x^4+780*x^3-797*x^2+390*x-72)')
   })
 
   it('testing scope', function () {

--- a/test/function/algebra/rationalize.test.js
+++ b/test/function/algebra/rationalize.test.js
@@ -36,8 +36,6 @@ function objToStrings (obj) {
 
 /// ////////////////// rationalize ///////////////////////
 describe('rationalize', function () {
-  this.timeout(120000)
-
   it('invalid expression', function () {
     assert.throws(function () { math.rationalize('(x*/2)') }, /Value expected \(char 4\)/)
   })


### PR DESCRIPTION
 - Reduces the complexity of the power expansion test example.
 - Moves one particually slow example to a skipped test.
 - Removes the timeout as it is no longer needed.

closes #1142 