### PR TITLE
fix some broken links

### DIFF
--- a/docs/expressions/algebra.md
+++ b/docs/expressions/algebra.md
@@ -17,7 +17,7 @@ console.log(math.simplify('x^2 + x + 3 + x^2').toString())      // '2 * x ^ 2 + 
 console.log(math.simplify('x * y * -x / (x ^ 2)').toString())   // '-y'
 ```
 
-The function accepts either a string or an expression tree (`Node`) as input, and outputs a simplified expression tree (`Node`). This node tree can be transformed and evaluated as described in detail on the page [Expression trees]('./expression_trees.md').
+The function accepts either a string or an expression tree (`Node`) as input, and outputs a simplified expression tree (`Node`). This node tree can be transformed and evaluated as described in detail on the page [Expression trees](expression_trees.md).
 
 ```js
 // work with an expression tree, evaluate results

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,7 +19,7 @@ Other ways to install math.js are described on the [website](http://mathjs.org/d
 Math.js can be used in node.js and in the browser. The library must be loaded
 and instantiated. When creating an instance, one can optionally provide
 configuration options as described in
-[Configuration](configuration.md).
+[Configuration](core/configuration.md).
 
 ### ES6 modules
 
@@ -91,7 +91,7 @@ require(['mathjs'], function (math) {
 
 Math.js can be used similar to JavaScript's built-in Math library. Besides that,
 math.js can evaluate expressions (see [Expressions](expressions/index.md)) and
-supports chaining (see [Chaining](chaining.md)).
+supports chaining (see [Chaining](core/chaining.md)).
 
 The example code below shows how to use math.js. More examples can be found in the
 section [Examples](http://mathjs.org/examples/index.html).

--- a/src/function/algebra/decomposition/qr.js
+++ b/src/function/algebra/decomposition/qr.js
@@ -53,7 +53,7 @@ function factory (type, config, load, typed) {
    *
    * See also:
    *
-   *    lusolve
+   *    lup, lusolve
    *
    * @param {Matrix | Array} A    A two dimensional matrix or array
    * for which to get the QR decomposition.

--- a/src/function/algebra/decomposition/qr.js
+++ b/src/function/algebra/decomposition/qr.js
@@ -53,7 +53,7 @@ function factory (type, config, load, typed) {
    *
    * See also:
    *
-   *    lu
+   *    lusolve
    *
    * @param {Matrix | Array} A    A two dimensional matrix or array
    * for which to get the QR decomposition.

--- a/src/function/combinatorics/stirlingS2.js
+++ b/src/function/combinatorics/stirlingS2.js
@@ -30,7 +30,7 @@ function factory (type, config, load, typed) {
    *
    * See also:
    *
-   *    Bell numbers
+   *    bellNumbers
    *
    * @param {Number | BigNumber} n    Total number of objects in the set
    * @param {Number | BigNumber} k    Number of objects in the subset


### PR DESCRIPTION
Thought there might be some other broken links so I asked a crawler to find them for me :nerd_face:. Fixed them except for links to contributors. I assumed all broken link in `docs/reference/functions` were built automatically so had to be fixed in jsdoc.

![image](https://user-images.githubusercontent.com/4118690/42418019-35cf07ae-8297-11e8-933e-321272f50659.png)
