### PR TITLE
Change decimal.js import

### DIFF
--- a/src/type/bignumber/BigNumber.js
+++ b/src/type/bignumber/BigNumber.js
@@ -1,5 +1,6 @@
 'use strict'
-const Decimal = require('decimal.js/decimal.js') // make sure to pick the es5 version
+
+import Decimal from 'decimal.js'
 
 function factory (type, config, load, typed, math) {
   const BigNumber = Decimal.clone({precision: config.precision})


### PR DESCRIPTION
BigNumber imports `decimal.js/decimal.js`, which uses the ES5 bundle for the library. Since it's now possible to do ES6 imports, we should be able to switch this over to the ES6 version.

This is of interest to me because a project I'm working on uses the ES6 bundle of decimal.js for other things, and we're trying to avoid having to ship both bundles. Because of that, I just changed this one import - I'm not sure what your plans are for using es6 imports elsewhere, if you want to migrate more of the imports I might be able to help with that.