### PR TITLE
Speed up reshaping function of a matrix

### DIFF
--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -218,6 +218,19 @@ export function reshape (array, sizes) {
     throw new DimensionError(0, product(exports.size(array)), '!=')
   }
 
+  var totalSize = 1
+  for (var sizeIndex = 0; sizeIndex < sizes.length; sizeIndex++) {
+    totalSize *= sizes[sizeIndex]
+  }
+
+  if (flatArray.length !== totalSize) {
+    throw new DimensionError(
+      product(sizes),
+      product(exports.size(array)),
+      '!='
+    )
+  }
+
   try {
     newArray = _reshape(flatArray, sizes)
   } catch (e) {
@@ -231,19 +244,11 @@ export function reshape (array, sizes) {
     throw e
   }
 
-  if (flatArray.length > 0) {
-    throw new DimensionError(
-      product(sizes),
-      product(exports.size(array)),
-      '!='
-    )
-  }
-
   return newArray
 }
 
 /**
- * Recursively re-shape a multi dimensional array to fit the specified dimensions
+ * Iteratively re-shape a multi dimensional array to fit the specified dimensions
  * @param {Array} array           Array to be reshaped
  * @param {Array.<number>} sizes  List of sizes for each dimension
  * @returns {Array}               Array whose data has been formatted to fit the
@@ -252,20 +257,26 @@ export function reshape (array, sizes) {
  * @throws {DimensionError}       If the product of the new dimension sizes does
  *                                not equal that of the old ones
  */
-function _reshape (array, sizes) {
-  let accumulator = []
-  let i
 
-  if (sizes.length === 0) {
-    if (array.length === 0) {
-      throw new DimensionError(null, null, '!=')
+function _reshape (array, sizes) {
+  // testing if there are enough elements for the requested shape
+  var tmpArray = array
+  var tmpArray2
+  // for each dimensions starting by the last one and ignoring the first one
+  for (var sizeIndex = sizes.length - 1; sizeIndex > 0; sizeIndex--) {
+    var size = sizes[sizeIndex]
+    tmpArray2 = []
+
+    // aggregate the elements of the current tmpArray in elements of the requested size
+    var length = tmpArray.length / size
+    for (var i = 0; i < length; i++) {
+      tmpArray2.push(tmpArray.slice(i * size, (i + 1) * size))
     }
-    return array.shift()
+    // set it as the new tmpArray for the next loop turn or for return
+    tmpArray = tmpArray2
   }
-  for (i = 0; i < sizes[0]; i += 1) {
-    accumulator.push(_reshape(array, sizes.slice(1)))
-  }
-  return accumulator
+
+  return tmpArray
 }
 
 /**

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -253,9 +253,6 @@ export function reshape (array, sizes) {
  * @param {Array.<number>} sizes  List of sizes for each dimension
  * @returns {Array}               Array whose data has been formatted to fit the
  *                                specified dimensions
- *
- * @throws {DimensionError}       If the product of the new dimension sizes does
- *                                not equal that of the old ones
  */
 
 function _reshape (array, sizes) {


### PR DESCRIPTION
So I notice that in this comment [here](https://github.com/josdejong/mathjs/issues/1148#issuecomment-404037975), reshape is terribly slow compared to transpose. The issues lies mainly with how slow the recursion is, and thus, a friend of mine rewrites the reshape function iteratively instead, and the speed boost is immense. 

Here is the log of performance for the transpose of var a = math.ones(1, 100000) :
Call to algorithm for transpose took 67.26909599999993 milliseconds. 
Call to old algorithm for reshape took 6013.208004 milliseconds.
Call to new algorithm for reshape took 117.086568 milliseconds.

Here is the log of performance for reshape for converting 1 x 10000 to 1000 x 100 shape:
Call to old algorithm for power took 7273.37094 milliseconds.
Call to new algorithm for reshape took 120.73325700000004 milliseconds.
