### PR TITLE
Help greenkeeper to manage lockfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,17 @@ stages:
   - test
   - browser-test
 
+before_install:
+  - npm install -g npm@6
+  - npm install -g greenkeeper-lockfile@1
+
+install: npm install
+
+before_script: greenkeeper-lockfile-update
+
 script: npm run test:src
+
+after_script: greenkeeper-lockfile-upload
 
 # NAME env var is purely cosmetic, only way to identify builds until
 # https://github.com/travis-ci/travis-ci/issues/5898 is fixed.


### PR DESCRIPTION
Fixes issues we are having with greenkeeper, `npm ci`, and lock files.

Solution based on https://github.com/greenkeeperio/greenkeeper-lockfile#npm.

Should prevent CI failures in greenkeeper's PR #1183.
Greenkeeper issue: https://github.com/greenkeeperio/greenkeeper-lockfile/issues/156.

@josdejong How tight should we be on the npm and greenkeeper-lock file versions?