### PR TITLE
Improve CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ node_js:
   - 8
   - 10
 
-stages:
-  - lint
-  - test
-  - browser-test
-
 before_install:
   - npm install -g npm@6
   - npm install -g greenkeeper-lockfile@1
@@ -26,16 +21,13 @@ after_script: greenkeeper-lockfile-upload
 
 jobs:
   include:
-    - stage: lint
+    - stage: other
       node_js: 8
       script: npm run lint
-    - stage: browser-test
-      node_js: 8
-      script: npm run test:browser
+      env: NAME=lint
+    - script: npm run test:browser
       env: NAME=local browser
-    - # second script to run in the browser-tests stage
-      node_js: 8
-      script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
+    - script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
       env: NAME=browserstack
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,15 @@ after_script: greenkeeper-lockfile-upload
 jobs:
   include:
     - stage: other
-      node_js: lts/*
       script: $SCRIPT
       env: SCRIPT='npm run lint'
+      node_js: lts/*
     - env: SCRIPT='npm run test:browser'
+      node_js: lts/*
     - env:  SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
+      node_js: lts/*
     - env:   SCRIPT='npm run build && npm run test:dist'
+      node_js: lts/*
 
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,13 @@ after_script: greenkeeper-lockfile-upload
 jobs:
   include:
     - stage: other
-      node_js: 8
-      script: npm run lint
-      env: NAME=lint
-    - script: npm run test:browser
-      env: NAME=local browser
-    - script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
-      env: NAME=browserstack
-    - script: npm run build && npm run test:dist
-      env: NAME=test bundling
+      node_js: lts
+      script: $SCRIPT
+      env:
+        - SCRIPT='npm run lint'
+        - SCRIPT='npm run test:browser'
+        - SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
+        - SCRIPT='npm run build && npm run test:dist'
 
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ jobs:
       node_js: lts
       script: $SCRIPT
       env:
-        - SCRIPT='npm run lint'
-        - SCRIPT='npm run test:browser'
-        - SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
-        - SCRIPT='npm run build && npm run test:dist'
+        matrix:
+          - SCRIPT='npm run lint'
+          - SCRIPT='npm run test:browser'
+          - SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
+          - SCRIPT='npm run build && npm run test:dist'
 
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,18 @@ after_script: greenkeeper-lockfile-upload
 jobs:
   include:
     - stage: other
-      script: $SCRIPT
-      env: SCRIPT='npm run lint'
+      script: npm run lint
       node_js: lts/*
-    - env: SCRIPT='npm run test:browser'
+      env: NAME=lint
+    - script: npm run test:browser
       node_js: lts/*
-    - env:  SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
+      env: NAME=local browser test
+    - script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
       node_js: lts/*
-    - env:   SCRIPT='npm run build && npm run test:dist'
+      env: NAME=browserstack test
+    - script: npm run build && npm run test:dist
       node_js: lts/*
+      env: NAME=bundling test
 
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ jobs:
       env: NAME=local browser
     - script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
       env: NAME=browserstack
+    - script: npm run build && npm run test:dist
+      env: NAME=test bundling
 
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,12 @@ after_script: greenkeeper-lockfile-upload
 jobs:
   include:
     - stage: other
-      node_js: lts
+      node_js: lts/*
       script: $SCRIPT
-      env:
-        matrix:
-          - SCRIPT='npm run lint'
-          - SCRIPT='npm run test:browser'
-          - SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
-          - SCRIPT='npm run build && npm run test:dist'
+      env: SCRIPT='npm run lint'
+    - env: SCRIPT='npm run test:browser'
+    - env:  SCRIPT='if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
+    - env:   SCRIPT='npm run build && npm run test:dist'
 
 git:
   depth: 5


### PR DESCRIPTION
Reduces number of build stages (3 -> 2) and adds testing of the mathjs bundle.

I could not find a way to go to one build stage without running linting, browser tests and the bundle test on all three versions of node. This repetition would slow the CI run down to the point where it defeats the point of parallelising these tests.