### PR TITLE
Adding linspace and logspace + test cases.

### DIFF
--- a/src/function/matrix/index.js
+++ b/src/function/matrix/index.js
@@ -27,5 +27,7 @@ module.exports = [
   require('./subset'),
   require('./trace'),
   require('./transpose'),
-  require('./zeros')
+  require('./zeros'),
+	require('./linspace'),
+	require('./logspace')
 ]

--- a/src/function/matrix/linspace.js
+++ b/src/function/matrix/linspace.js
@@ -1,0 +1,127 @@
+'use strict'
+
+function factory (type, config, load, typed) {
+  const matrix = load(require('../../type/matrix/function/matrix'))
+	const complex = load(require('../../type/complex/function/complex'))
+  const isInteger = load(require('../utils/isInteger'))
+
+  /**
+   * Create an array of linearly equally spaced points from start to end
+   * By default, the linspace generates a array of 100 linearly equally spaced points from start 
+	 * to end. The number of points can be changed by the extra parameter `n`. For `n = 1` linspace 
+	 * returns the end.
+   *
+   * Syntax:
+   *
+   *     math.linspace(start, end)                    // Create a linspace from start to 
+	 *																									// end with 100 points.
+   *     math.linspace(start, end [, n])        			// Create a linspace from start to
+   *                                                  // end with n points.
+   *
+   * Where:
+   *
+   * - `start: number | Complex`
+   *   Start of the linspace
+   * - `end: number | Complex`
+   *   End of the linspace
+   * - `n: number`
+   *   Number of generated points. Default is 100.
+   *
+   * Examples:
+   *
+   *     math.linspace(2, 5)        // [2, 3, 4, 5]
+	 *		 math.linspace(0, 100, 11)	// [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+	 *		 math.linspace(10, 0, 5)		// [10, 7.5, 5, 2.5, 0]
+   *
+   * See also:
+   *
+   *     logspace, range, ones, zeros
+   *
+   * @param {*} args   Parameters describing the linspace `start`, `end`, and optional `n`.
+   * @return {Array | Matrix} linspace
+   */
+  const linspace = typed('linspace', {
+    'number, number': function (start, end) {
+      return _out(_linspace(start, end, 100))
+    },
+    'number, number, number': function (start, end, n) {
+      return _out(_linspace(start, end, n))
+    },
+		'Complex, Complex': function (start, end) {
+			return _out(_complexLinspace(start, end, 100))
+		},
+		'Complex, Complex, number': function (start, end, n) {
+			return _out(_complexLinspace(start, end, n))
+		},
+		'number, Complex': function (start, end) {
+			return _out(_complexLinspace(complex(start), end, 100))
+		},
+		'Complex, number': function (start, end) {
+			return _out(_complexLinspace(start, complex(end), 100))
+		},
+		'number, Complex, number': function (start, end, n) {
+			return _out(_complexLinspace(complex(start), end, n))
+		},
+		'Complex, number, number': function (start, end, n) {
+			return _out(_complexLinspace(start, complex(end), n))
+		}
+  })
+
+  linspace.toTex = undefined // use default template
+
+  return linspace
+
+  function _out (arr) {
+    return config.matrix === 'Array' ? arr : matrix(arr)
+  }
+
+  /**
+   * Create a linspace with numbers.
+   * @param {number} start
+   * @param {number} end
+   * @param {number} n
+   * @returns {Array} linspace
+   * @private
+   */
+  function _linspace (start, end, n) {
+    if (!isInteger(n)) {
+      throw new SyntaxError('N "' + n + '" is no valid scalar')
+		}
+
+		if (n < 2) {
+			return n === 1 ? [end] : []
+		}
+
+		const array = []
+		n = n - 1
+
+		for (let i = 0; i <= n; i++) {
+			array.push((i*end + (n-i)*start) / n)
+		}
+
+		return array
+  }
+
+  /**
+   * Create a linspace with complex numbers.
+   * @param {Complex} start
+   * @param {Complex} end
+   * @param {number} n
+   * @returns {Array} range
+   * @private
+   */
+	function _complexLinspace (start, end, n) {	
+		let re = _linspace(start.re, end.re, n),
+		    im = _linspace(start.im, end.im, n)
+
+		const array = []
+		for (let i = 0; i < re.length; i++) {
+			array.push(complex(re[i], im[i]))
+		}
+
+		return array
+	}
+}
+
+exports.name = 'linspace'
+exports.factory = factory

--- a/src/function/matrix/logspace.js
+++ b/src/function/matrix/logspace.js
@@ -1,0 +1,75 @@
+'use strict'
+
+function factory (type, config, load, typed) {
+	const pow = load(require('../arithmetic/pow'))
+	const log10 = load(require('../arithmetic/log10'))
+	const equal = load(require('../relational/equal'))
+	const linspace = load(require('../matrix/linspace'))
+	
+  /**
+   * Create an array of logarithmically equally spaced points from 10^start to 10^end.
+   * By default, the logspace generates a array of 100 logarithmically equally spaced points from start 
+	 * to end. The number of points can be changed by the extra parameter `n`. For `n = 1` logspace returns 
+	 * the end. If end is pi, then the points are from 10^start to pi.
+   *
+   * Syntax:
+   *
+   *     math.logspace(start, end)                    // Create a logspace from start to 
+	 *																									// end with 100 points.
+   *     math.logspace(start, end [, n])        		  // Create a logspace from start to
+   *                                                  // end with n points.
+   *
+   * Where:
+   *
+   * - `start: number`
+   *   Start of the logspace
+   * - `end: number`
+   *   End of the logspace
+   * - `n: number`
+   *   Number of generated points. Default is 100.
+   *
+   * Examples:
+   *
+   *     math.logspace(-1,2)        	// [0.1, 0.1149..., 0.1232..., ..., 100]
+	 *		 math.logspace(-1,2,4)				// [0.1, 1, 10, 100]
+	 *		 math.logspace(-1,math.pi,3) 	// [0.1, 0.3155..., 0.9956..., ..., pi]
+   *
+   * See also:
+   *
+   *     linspace, range, ones, zeros
+   *
+   * @param {*} args   Parameters describing the logspace `start`, `end`, and optional `n`.
+   * @return {Array | Matrix} logspace
+   */
+  const logspace = typed('logspace', {
+    'number, number': function (start, end) {
+      return _logspace(start, end, 100);
+    },
+    'number, number, number': function (start, end, n) {
+      return _logspace(start, end, n)
+    }
+  })
+
+  logspace.toTex = undefined // use default template
+
+  return logspace
+
+  /**
+   * Create a logspace with numbers.
+   * @param {number} start
+   * @param {number} end
+   * @param {number} n
+   * @returns {Array} logspace
+   * @private
+   */
+  function _logspace (start, end, n) {
+		if (equal(end,Math.PI)) {
+			end = log10(end)
+		}
+
+		return linspace(start, end, n).map(function(x) { return pow(10,x); });
+  }
+}
+
+exports.name = 'logspace'
+exports.factory = factory

--- a/test/function/matrix/linspace.test.js
+++ b/test/function/matrix/linspace.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert')
+const math = require('../../../src/main')
+const linspace = math.linspace
+const matrix = math.matrix
+const complex = math.complex
+
+describe('linspace', function () {
+  it('should create a linspace if called with 3 numbers', function () {
+		assert.deepEqual(linspace(1,5,5), matrix([1, 2, 3, 4, 5]))
+		assert.deepEqual(linspace(-5,-4,5), matrix([-5, -4.75, -4.5, -4.25, -4]))
+		assert.deepEqual(linspace(2,-4,5), matrix([2, 0.5, -1, -2.5, -4]))
+		assert.deepEqual(linspace(-2,-2,5), matrix([-2, -2, -2, -2, -2]))
+  })
+
+  it('should return a empty array in case of n <= 0', function () {
+		assert.equal(linspace(1,5,0),matrix([]))
+		assert.equal(linspace(-2,-2,-2),matrix([]))
+	})
+	
+	it('should throw an error when n is not an integer', function () {
+    assert.throws(function () { linspace(1,5,2.5) }, /is no number of points/)
+		assert.throws(function () { linspace(1,5,complex(0,2)) }, /number of points can't be complex/)
+  })
+
+  it('should output an array when setting matrix==="array"', function () {
+    const math2 = math.create({
+      matrix: 'Array'
+    })
+
+    assert.deepEqual(math2.linspace(1,5,5), [1, 2, 3, 4, 5])
+    assert.deepEqual(math2.linspace(-5,-4,5), [-5, -4.75, -4.5, -4.25, -4])
+  })
+	
+	it('should create a linspace if called with complex number',function() {
+		assert.deepEqual(linspace(complex(3,0),complex(0,3),4), matrix([complex(3,0), complex(2,1), complex(1,2), complex(0,3)]))
+		assert.deepEqual(linspace(complex(-3,3),complex(-2,0),3), matrix([complex(-3,3), complex(-2.5,1.5), complex(-2,0)]))
+	})
+
+  it('should throw an error if called with an invalid number of arguments', function () {
+    assert.throws(function () { linspace() }, /TypeError: Too few arguments/)
+    assert.throws(function () { linspace(1, 2, 3, 5) }, /TypeError: Too many arguments/)
+  })
+
+  it('should LaTeX range', function () {
+    const expression = math.parse('linspace(1,10)')
+    assert.equal(expression.toTex(), '\\mathrm{linspace}\\left(1,10\\right)')
+  })
+})

--- a/test/function/matrix/logspace.test.js
+++ b/test/function/matrix/logspace.test.js
@@ -1,0 +1,43 @@
+const assert = require('assert')
+const math = require('../../../src/main')
+const logspace = math.logspace
+const matrix = math.matrix
+const complex = math.complex
+
+describe('logspace', function () {
+  it('should create a logspace if called with 3 numbers', function () {
+		assert.deepEqual(logspace(-1,2,4), matrix([0.1, 1, 10, 100]))
+		assert.deepEqual(logspace(2,-1,4), matrix([100, 10, 1, 0.1]))
+		assert.deepEqual(logspace(1,4,6), matrix([10,39.810717055349734,158.48931924611142,630.957344480193,2511.88643150958,10000]))
+		assert.deepEqual(logspace(-3,3,7), matrix([0.001, 0.01, 0.1, 1, 10, 100, 1000]))
+  })
+
+  it('should return a empty array in case of n <= 0', function () {
+		assert.equal(logspace(1,5,0),matrix([]))
+		assert.equal(logspace(-2,-2,-2),matrix([]))
+	})
+	
+	it('should throw an error when n is not an integer', function () {
+    assert.throws(function () { logspace(1,5,2.5) }, /is no number of points/)
+		assert.throws(function () { logspace(1,5,complex(0,2)) }, /number of points can't be complex/)
+  })
+
+  it('should output an array when setting matrix==="array"', function () {
+    const math2 = math.create({
+      matrix: 'Array'
+    })
+
+    assert.deepEqual(math2.logspace(-1,2,4), [0.1, 1, 10, 100])
+    assert.deepEqual(math2.logspace(-3,3,7), matrix([0.001, 0.01, 0.1, 1, 10, 100, 1000]))
+  })
+
+  it('should throw an error if called with an invalid number of arguments', function () {
+    assert.throws(function () { logspace() }, /TypeError: Too few arguments/)
+    assert.throws(function () { logspace(1, 2, 3, 5) }, /TypeError: Too many arguments/)
+  })
+
+  it('should LaTeX range', function () {
+    const expression = math.parse('logspace(-1,4)')
+    assert.equal(expression.toTex(), '\\mathrm{logspace}\\left(-1,4\\right)')
+  })
+})


### PR DESCRIPTION
Adding `linspace` and `logspace` for Mathjs, see also https://nl.mathworks.com/help/matlab/ref/linspace.html. 

First PR to this project. Hope to see some comments. Had to workout a bit how everything worked with GIT and how everything was programmed. 

`linspace` is closely related to the `range` function. But instead of setting a step you set the number of points you want. Actually wanted to use `range` to implement `linspace`. Because `linspace` 'should' be equivalent to `range` since the step is equal to `(end - start)/(n - 1)`. However `range` seems numerically less accurate since `math.range(1,5,(5-1)/(4-1),true)` gives `[ 1, 2.333333333333333, 3.666666666666666, 4.999999999999999 ]` while `math.linspace(1,5,4)` gives `[ 1, 2.3333333333333335, 3.6666666666666665, 5 ]`.