### PR TITLE
fix: mathjs requires node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "mathjs": "./bin/cli.js"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "bugs": {
     "url": "https://github.com/josdejong/mathjs/issues"


### PR DESCRIPTION
`package.json` suggested we support node 4. Alas we don't.