### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,7 @@ node_js:
   - 8
   - 10
 
-before_install:
-  - npm install -g npm@6
-  - npm install -g greenkeeper-lockfile@1
-
-install: npm install
-
-before_script: greenkeeper-lockfile-update
-
 script: npm run test:src
-
-after_script: greenkeeper-lockfile-upload
 
 # NAME env var is purely cosmetic, only way to identify builds until
 # https://github.com/travis-ci/travis-ci/issues/5898 is fixed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,24 +6,21 @@ node_js:
 
 script: npm run test:src
 
-# NAME env var is purely cosmetic, only way to identify builds until
-# https://github.com/travis-ci/travis-ci/issues/5898 is fixed.
-
 jobs:
   include:
     - stage: other
       script: npm run lint
       node_js: lts/*
-      env: NAME=lint
+      name: Lint
     - script: npm run test:browser
       node_js: lts/*
-      env: NAME=local browser test
+      name: Local Browser Test
     - script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:browserstack; else true; fi'
       node_js: lts/*
-      env: NAME=browserstack test
+      name: Browserstack Test
     - script: npm run build && npm run test:dist
       node_js: lts/*
-      env: NAME=bundling test
+      name: Bundling Test
 
 git:
   depth: 5


### PR DESCRIPTION
Updates Travis:
 - Reverts changes in #1189 as greenkeeper is now smart enough not to need them.
 - Uses named jobs in Travis rather than dummy environment variables.

References:
 - https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0
 - https://docs.travis-ci.com/user/customizing-the-build/#naming-jobs-within-matrices

![image](https://user-images.githubusercontent.com/16308754/45497542-01402000-b770-11e8-9173-6933df795560.png)
