### PR TITLE
Fix typo in sign.md

### DIFF
--- a/docs/reference/functions/sign.md
+++ b/docs/reference/functions/sign.md
@@ -8,7 +8,7 @@ layout: default
 
 Compute the sign of a value. The sign of a value x is:
 
--  1 when x > 1
+-  1 when x > 0
 - -1 when x < 0
 -  0 when x == 0
 


### PR DESCRIPTION
Hello, just wanted to correct a minor typo in [sign.md](https://github.com/josdejong/mathjs/blob/gh-pages/docs/reference/functions/sign.md): it says that 1 is returned when x > 1, but it should also include x > 0.

(apologies in advance if my pull request is done incorrectly, this is my first time doing this)