### PR TITLE
Fix object literal enable multiple lines (#1328)

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1511,6 +1511,7 @@ function factory (type, config, load, typed) {
    */
   function parseObject (state) {
     if (state.token === '{') {
+      openParams(state)
       let key
 
       const properties = {}
@@ -1545,6 +1546,7 @@ function factory (type, config, load, typed) {
       if (state.token !== '}') {
         throw createSyntaxError(state, 'Comma , or bracket } expected after object value')
       }
+      closeParams(state)
       getToken(state)
 
       let node = new ObjectNode(properties)

--- a/test/expression/parse.test.js
+++ b/test/expression/parse.test.js
@@ -815,6 +815,10 @@ describe('parse', function () {
       assert.deepStrictEqual(parseAndEval('{}'), {})
     })
 
+    it('should spread a object over multiple lines', function () {
+      assert.deepStrictEqual(parseAndEval('{\na:2+3,\nb:"foo"\n}'), { a: 5, b: 'foo' })
+    })
+
     it('should create an object with quoted keys', function () {
       assert.deepStrictEqual(parseAndEval('{"a":2+3,"b":"foo"}'), { a: 5, b: 'foo' })
     })


### PR DESCRIPTION
* Allow object literal expression be multiple lines

* Add test for multiple lines object literal