### PR TITLE
Improve error handling if webpack errors.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,6 +107,17 @@ function bundle (done) {
   compiler.run(function (err, stats) {
     if (err) {
       gutil.log(err)
+      done(err)
+    }
+    const info = stats.toJson()
+
+    if (stats.hasWarnings()) {
+      gutil.log('Webpack warnings:\n' + info.warnings.join('\n'))
+    }
+
+    if (stats.hasErrors()) {
+      gutil.log('Webpack errors:\n' + info.errors.join('\n'))
+      done(new Error('Compile failed'))
     }
 
     gutil.log('bundled ' + MATH_JS)


### PR DESCRIPTION
It turns out webpack can error in two ways. This adds a check for the second way
and also surfaces any warnings.

Previously if webpack failed to build mathjs it silently failed and gulp crashed later on (when trying to minify).

See: https://webpack.js.org/api/node/#error-handling.