### PR TITLE
Separating Binary Prefixes

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -1383,44 +1383,9 @@ function factory (type, config, load, typed, math) {
     }
   }
 
-  // Add a prefix list for both short and long prefixes (for example for ohm and bar which support both Mohm and megaohm, mbar and millibar):
-  PREFIXES.SHORTLONG = {}
-  for (let key in PREFIXES.SHORT) {
-    if (PREFIXES.SHORT.hasOwnProperty(key)) {
-      PREFIXES.SHORTLONG[key] = PREFIXES.SHORT[key]
-    }
-  }
-  for (let key in PREFIXES.LONG) {
-    if (PREFIXES.LONG.hasOwnProperty(key)) {
-      PREFIXES.SHORTLONG[key] = PREFIXES.LONG[key]
-    }
-  }
-
-  // Add a prefix list binary long (SI and IEC)
-  PREFIXES.BINARY_LONG = {}
-  for (let key in PREFIXES.BINARY_LONG_SI) {
-    if (PREFIXES.BINARY_LONG_SI.hasOwnProperty(key)) {
-      PREFIXES.BINARY_LONG[key] = PREFIXES.BINARY_LONG_SI[key]
-    }
-  }
-  for (let key in PREFIXES.BINARY_LONG_IEC) {
-    if (PREFIXES.BINARY_LONG_IEC.hasOwnProperty(key)) {
-      PREFIXES.BINARY_LONG[key] = PREFIXES.BINARY_LONG_IEC[key]
-    }
-  }
-
-  // Add a prefix list binary short (SI and IEC)
-  PREFIXES.BINARY_SHORT = {}
-  for (let key in PREFIXES.BINARY_SHORT_SI) {
-    if (PREFIXES.BINARY_SHORT_SI.hasOwnProperty(key)) {
-      PREFIXES.BINARY_SHORT[key] = PREFIXES.BINARY_SHORT_SI[key]
-    }
-  }
-  for (let key in PREFIXES.BINARY_SHORT_IEC) {
-    if (PREFIXES.BINARY_SHORT_IEC.hasOwnProperty(key)) {
-      PREFIXES.BINARY_SHORT[key] = PREFIXES.BINARY_SHORT_IEC[key]
-    }
-  }
+  PREFIXES.SHORTLONG = Object.assign(PREFIXES.SHORT, PREFIXES.LONG)
+  PREFIXES.BINARY_SHORT = Object.assign(PREFIXES.BINARY_SHORT_SI, PREFIXES.BINARY_SHORT_IEC)
+  PREFIXES.BINARY_LONG = Object.assign(PREFIXES.BINARY_LONG_SI, PREFIXES.BINARY_LONG_IEC)
 
   /* Internally, each unit is represented by a value and a dimension array. The elements of the dimensions array have the following meaning:
    * Index  Dimension

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -1333,7 +1333,7 @@ function factory (type, config, load, typed, math) {
       'z': { name: 'z', value: 1e-63, scientific: true },
       'y': { name: 'y', value: 1e-72, scientific: true }
     },
-    BINARY_SHORT: {
+    BINARY_SHORT_SI: {
       '': { name: '', value: 1, scientific: true },
       'k': { name: 'k', value: 1e3, scientific: true },
       'M': { name: 'M', value: 1e6, scientific: true },
@@ -1342,8 +1342,10 @@ function factory (type, config, load, typed, math) {
       'P': { name: 'P', value: 1e15, scientific: true },
       'E': { name: 'E', value: 1e18, scientific: true },
       'Z': { name: 'Z', value: 1e21, scientific: true },
-      'Y': { name: 'Y', value: 1e24, scientific: true },
-
+      'Y': { name: 'Y', value: 1e24, scientific: true }
+    },
+    BINARY_SHORT_IEC: {
+      '': { name: '', value: 1, scientific: true },
       'Ki': { name: 'Ki', value: 1024, scientific: true },
       'Mi': { name: 'Mi', value: Math.pow(1024, 2), scientific: true },
       'Gi': { name: 'Gi', value: Math.pow(1024, 3), scientific: true },
@@ -1353,7 +1355,7 @@ function factory (type, config, load, typed, math) {
       'Zi': { name: 'Zi', value: Math.pow(1024, 7), scientific: true },
       'Yi': { name: 'Yi', value: Math.pow(1024, 8), scientific: true }
     },
-    BINARY_LONG: {
+    BINARY_LONG_SI: {
       '': { name: '', value: 1, scientific: true },
       'kilo': { name: 'kilo', value: 1e3, scientific: true },
       'mega': { name: 'mega', value: 1e6, scientific: true },
@@ -1362,8 +1364,10 @@ function factory (type, config, load, typed, math) {
       'peta': { name: 'peta', value: 1e15, scientific: true },
       'exa': { name: 'exa', value: 1e18, scientific: true },
       'zetta': { name: 'zetta', value: 1e21, scientific: true },
-      'yotta': { name: 'yotta', value: 1e24, scientific: true },
-
+      'yotta': { name: 'yotta', value: 1e24, scientific: true }
+    },
+    BINARY_LONG_IEC: {
+      '': { name: '', value: 1, scientific: true },
       'kibi': { name: 'kibi', value: 1024, scientific: true },
       'mebi': { name: 'mebi', value: Math.pow(1024, 2), scientific: true },
       'gibi': { name: 'gibi', value: Math.pow(1024, 3), scientific: true },
@@ -1389,6 +1393,32 @@ function factory (type, config, load, typed, math) {
   for (let key in PREFIXES.LONG) {
     if (PREFIXES.LONG.hasOwnProperty(key)) {
       PREFIXES.SHORTLONG[key] = PREFIXES.LONG[key]
+    }
+  }
+
+  // Add a prefix list binary long (SI and IEC)
+  PREFIXES.BINARY_LONG = {}
+  for (let key in PREFIXES.BINARY_LONG_SI) {
+    if (PREFIXES.BINARY_LONG_SI.hasOwnProperty(key)) {
+      PREFIXES.BINARY_LONG[key] = PREFIXES.BINARY_LONG_SI[key]
+    }
+  }
+  for (let key in PREFIXES.BINARY_LONG_IEC) {
+    if (PREFIXES.BINARY_LONG_IEC.hasOwnProperty(key)) {
+      PREFIXES.BINARY_LONG[key] = PREFIXES.BINARY_LONG_IEC[key]
+    }
+  }
+
+  // Add a prefix list binary short (SI and IEC)
+  PREFIXES.BINARY_SHORT = {}
+  for (let key in PREFIXES.BINARY_SHORT_SI) {
+    if (PREFIXES.BINARY_SHORT_SI.hasOwnProperty(key)) {
+      PREFIXES.BINARY_SHORT[key] = PREFIXES.BINARY_SHORT_SI[key]
+    }
+  }
+  for (let key in PREFIXES.BINARY_SHORT_IEC) {
+    if (PREFIXES.BINARY_SHORT_IEC.hasOwnProperty(key)) {
+      PREFIXES.BINARY_SHORT[key] = PREFIXES.BINARY_SHORT_IEC[key]
     }
   }
 


### PR DESCRIPTION
Separate bit prefixes into SI (base 1000) and IEC (base1024). These are `BINARY_SHORT_SI`, `BINARY_SHORT_IEC`, `BINARY_LONG_SI` and `BINARY_LONG_IEC`. 

* `BINARY_LONG_SI` and `BINARY_LONG_IEC` are combined into `BINARY_LONG` 
* `BINARY_SHORT_SI` and `BINARY_SHORT_IEC` are combined into `BINARY_SHORT`

This is done in the same manner as combining `PREFIXES.SHORT` and `PREFIXES.LONG` into `PREFIXES.SHORTLONG`. This PR aims to progress towards a solution for #1300.
