### PR TITLE
Fix banner/license for custom bundling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ const REF_SRC = './lib/'
 const REF_DEST = './docs/reference/functions'
 const REF_ROOT = './docs/reference'
 const MATH_JS = DIST + '/' + FILE
+const COMPILED_HEADER = COMPILE_LIB + '/header.js'
 
 // read the version number from package.json
 function getVersion () {
@@ -133,6 +134,10 @@ function compile () {
     .pipe(babel())
     .pipe(gulp.dest(COMPILE_LIB))
 }
+function addBanner(cb) {
+  fs.writeFileSync(COMPILED_HEADER, createBanner());
+  cb();
+}
 
 function minify (done) {
   const oldCwd = process.cwd()
@@ -220,7 +225,7 @@ gulp.task('watch', function watch () {
     delay: 100
   }
 
-  gulp.watch(files, options, gulp.parallel(bundle, compile))
+  gulp.watch(files, options, gulp.parallel(bundle, gulp.series(compile, addBanner)))
 })
 
 // The default task (called when you run `gulp`)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,7 +134,7 @@ function compile () {
     .pipe(babel())
     .pipe(gulp.dest(COMPILE_LIB))
 }
-function addBanner(cb) {
+function writeBanner(cb) {
   fs.writeFileSync(COMPILED_HEADER, createBanner());
   cb();
 }
@@ -225,8 +225,8 @@ gulp.task('watch', function watch () {
     delay: 100
   }
 
-  gulp.watch(files, options, gulp.parallel(bundle, gulp.series(compile, addBanner)))
+  gulp.watch(files, options, gulp.parallel(bundle, compile))
 })
 
 // The default task (called when you run `gulp`)
-gulp.task('default', gulp.series(bundle, compile, minify, validate, generateDocs))
+gulp.task('default', gulp.series(bundle, compile, writeBanner, minify, validate, generateDocs))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,9 +134,9 @@ function compile () {
     .pipe(babel())
     .pipe(gulp.dest(COMPILE_LIB))
 }
-function writeBanner(cb) {
-  fs.writeFileSync(COMPILED_HEADER, createBanner());
-  cb();
+function writeBanner (cb) {
+  fs.writeFileSync(COMPILED_HEADER, createBanner())
+  cb()
 }
 
 function minify (done) {


### PR DESCRIPTION
Replace placeholders @date and @version with their appropriate values in `lib/header.js`
This is to support custom bundling, so the license won't have unresolved placeholder values.

Related: https://github.com/josdejong/mathjs/issues/1442