### PR TITLE
Check node 12 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 6
   - 8
   - 10
+  - 12
 
 script: npm run test:src
 


### PR DESCRIPTION
Next major version of mathjs we should drop node 6.