### PR TITLE
Fixed tonne and candela units, added bel and dB

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -1515,6 +1515,10 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     },
     BIT: {
       dimensions: [0, 0, 0, 0, 0, 0, 0, 0, 1]
+    },
+
+    SOUND_VOLUME: {
+      dimensions: [0, 0, 0, 0, 0, 0, 0, 0, 0]
     }
   }
 
@@ -1983,10 +1987,17 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       value: 907.18474,
       offset: 0
     },
+    t: {
+      name: 't',
+      base: BASE_UNITS.MASS,
+      prefixes: PREFIXES.SHORT,
+      value: 1000,
+      offset: 0
+    },
     tonne: {
       name: 'tonne',
       base: BASE_UNITS.MASS,
-      prefixes: PREFIXES.SHORT,
+      prefixes: PREFIXES.LONG,
       value: 1000,
       offset: 0
     },
@@ -2362,14 +2373,14 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     cd: {
       name: 'cd',
       base: BASE_UNITS.LUMINOUS_INTENSITY,
-      prefixes: PREFIXES.NONE,
+      prefixes: PREFIXES.SHORT,
       value: 1,
       offset: 0
     },
     candela: {
       name: 'candela',
       base: BASE_UNITS.LUMINOUS_INTENSITY,
-      prefixes: PREFIXES.NONE,
+      prefixes: PREFIXES.LONG,
       value: 1,
       offset: 0
     },
@@ -2729,6 +2740,29 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       prefixes: PREFIXES.BINARY_LONG,
       value: 8,
       offset: 0
+    },
+
+    //other dimensionless units
+    bel: {
+      name: 'bel',
+      base: BASE_UNITS.SOUND_VOLUME,
+      prefixes: PREFIXES.NONE,
+      value: 1,
+      offset: 0
+    },
+    decibel: {
+      name: 'decibel',
+      base: BASE_UNITS.SOUND_VOLUME,
+      prefixes: PREFIXES.NONE,
+      value: 0.1,
+      offset: 0
+    },
+    dB: {
+      name: 'dB',
+      base: BASE_UNITS.SOUND_VOLUME,
+      prefixes: PREFIXES.NONE,
+      value: 0.1,
+      offset: 0
     }
   }
 
@@ -2826,8 +2860,10 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     webers: 'weber',
     teslas: 'tesla',
     electronvolts: 'electronvolt',
-    moles: 'mole'
+    moles: 'mole',
 
+    bels: 'bel',
+    decibels: 'decibel',
   }
 
   /**

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -2742,7 +2742,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       offset: 0
     },
 
-    //other dimensionless units
+    // Other dimensionless units
     bel: {
       name: 'bel',
       base: BASE_UNITS.SOUND_VOLUME,
@@ -2863,7 +2863,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     moles: 'mole',
 
     bels: 'bel',
-    decibels: 'decibel',
+    decibels: 'decibel'
   }
 
   /**

--- a/test/type/unit/function/unit.test.js
+++ b/test/type/unit/function/unit.test.js
@@ -13,6 +13,15 @@ describe('unit', function () {
     assert.deepStrictEqual(unit('5 cm').toString(), '5 cm')
     assert.deepStrictEqual(unit('5000 cm').toString(), '50 m')
     assert.deepStrictEqual(unit('10 kg').toString(), '10 kg')
+    assert.deepStrictEqual(unit('5Mcd').toString(), '5 Mcd')
+    assert.deepStrictEqual(unit('12mcd').toString(), '12 mcd')
+    assert.deepStrictEqual(unit('10 millicandela').toString(), '10 millicandela')
+    assert.deepStrictEqual(unit('3t').toString(), '3 t')
+    assert.deepStrictEqual(unit('3mt').toString(), '3 mt')
+    assert.deepStrictEqual(unit('6 tonne').toString(), '6 tonne')
+    assert.deepStrictEqual(unit('4 megatonne').toString(), '4 megatonne')
+    assert.deepStrictEqual(unit('1 bel').toString(), '1 bel')
+    assert.deepStrictEqual(unit('4dB').toString(), '4 dB')
   })
 
   it('should clone a unit', function () {


### PR DESCRIPTION
This PR implements #1209 and #1043

In a few words:
- added new `BASE_UNITS.SOUND_VOLUME` base
- added bel and decibel units
- added tonne (equals to t)
- fixed candela prefixes