### PR TITLE
Add unpkg and jsdelivr fields pointing to UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
   },
   "main": "main/es5",
   "module": "main/es6",
+  "unpkg": "dist/math.min.js",
+  "jsdelivr": "dist/math.min.js",
   "files": [
     "bin",
     "dist",


### PR DESCRIPTION
mathjs already has a UMD build, which is great, but JavaScript CDNs like unpkg and jdelivr aren't able to locate it off the bat. This PR adds the unpkg and jsdelivr fields they use to locate browser builds, so that folks using AMD loaders like `d3-require` can easily load mathjs.