### PR TITLE
Copy IndexNode dotNotation property in map and clone methods

### DIFF
--- a/src/expression/node/IndexNode.js
+++ b/src/expression/node/IndexNode.js
@@ -182,7 +182,7 @@ export const createIndexNode = /* #__PURE__ */ factory(name, dependencies, ({ Ra
    * @return {IndexNode}
    */
   IndexNode.prototype.clone = function () {
-    return new IndexNode(this.dimensions.slice(0))
+    return new IndexNode(this.dimensions.slice(0), this.dotNotation)
   }
 
   /**

--- a/src/expression/node/IndexNode.js
+++ b/src/expression/node/IndexNode.js
@@ -174,7 +174,7 @@ export const createIndexNode = /* #__PURE__ */ factory(name, dependencies, ({ Ra
       dimensions[i] = this._ifNode(callback(this.dimensions[i], 'dimensions[' + i + ']', this))
     }
 
-    return new IndexNode(dimensions)
+    return new IndexNode(dimensions, this.dotNotation)
   }
 
   /**

--- a/test/unit-tests/expression/node/IndexNode.test.js
+++ b/test/unit-tests/expression/node/IndexNode.test.js
@@ -159,6 +159,14 @@ describe('IndexNode', function () {
     assert.strictEqual(d.dimensions[1], n.dimensions[1])
   })
 
+  it('should clone an IndexNode with dotNotation property', function () {
+    const b = new ConstantNode('objprop')
+    const n = new IndexNode([b], true)
+    const f = n.clone()
+
+    assert.strictEqual(n.dotNotation, f.dotNotation)
+  })
+
   it('test equality another Node', function () {
     const a = new IndexNode([new ConstantNode(2), new ConstantNode(1)])
     const b = new IndexNode([new ConstantNode(2), new ConstantNode(1)])

--- a/test/unit-tests/expression/node/IndexNode.test.js
+++ b/test/unit-tests/expression/node/IndexNode.test.js
@@ -96,6 +96,16 @@ describe('IndexNode', function () {
     assert.deepStrictEqual(f.dimensions[1], e)
   })
 
+  it('should copy dotNotation property when mapping an IndexNode', function () {
+    const b = new ConstantNode('objprop')
+    const n = new IndexNode([b], true)
+    const f = n.map(function (node, path, parent) {
+      return node
+    })
+
+    assert.strictEqual(n.dotNotation, f.dotNotation)
+  })
+
   it('should throw an error when the map callback does not return a node', function () {
     const b = new ConstantNode(2)
     const c = new ConstantNode(1)


### PR DESCRIPTION
This isn't currently happening.