### PR TITLE
`toHTML()` method example corrected.

### DIFF
--- a/docs/expressions/expression_trees.md
+++ b/docs/expressions/expression_trees.md
@@ -141,7 +141,7 @@ All nodes have the following methods:
 
     ```js
     const node = math.parse('sqrt(2/3)')
-    node.toString()
+    node.toHTML()
 	// returns
 	// <span class="math-function">sqrt</span>
 	// <span class="math-paranthesis math-round-parenthesis">(</span>


### PR DESCRIPTION
This PR corrects the example provided for `toHTML()` method in the  `docs/expressions/expression_trees.md`.

Earlier `toString()` was written in place of `toHTML()`.