### PR TITLE
<rootDir>/number.js `export` to `module.exports`

### DIFF
--- a/number.js
+++ b/number.js
@@ -1,1 +1,1 @@
-export * from './main/esm/number' // eslint-disable-line
+module.exports = require('./lib/entry/mainNumber')


### PR DESCRIPTION
### Related issues
Fix #1766

When execute **Jest** in my project, this error was displayed.
```
  ● Test suite failed to run

    /path/to/project/node_modules/mathjs/number.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){export * from './main/esm/number' // eslint-disable-line
                                                                                             ^^^^^^

    SyntaxError: Unexpected token 'export'
```

### Why changes
In mathjs/index.js using `module.exports`.

https://github.com/josdejong/mathjs/blob/86606dc7bedf742e7d6af1423a99552ec0711139/index.js#L5

But mathjs/number.js using `export * from ''`.

https://github.com/josdejong/mathjs/blob/86606dc7bedf742e7d6af1423a99552ec0711139/number.js#L1

So, I change the mathjs/number.js, **Jest test was passed!**
```diff
- export * from './main/esm/number' // eslint-disable-line
+ module.exports = require('./lib/entry/mainNumber') 
```