### PR TITLE
Fix #1808: `toNumber()` not working on a unitless unit

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -880,7 +880,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       other = this.clone()
     }
 
-    if (other._isDerived()) {
+    if (other._isDerived() || other.units.length === 0) {
       return other._denormalize(other.value)
     } else {
       return other._denormalize(other.value, other.units[0].prefix.value)

--- a/test/unit-tests/type/unit/Unit.test.js
+++ b/test/unit-tests/type/unit/Unit.test.js
@@ -231,6 +231,11 @@ describe('Unit', function () {
       const u = new Unit(math.fraction(5), 'cm')
       assert.strictEqual(u.toNumber('mm'), 50)
     })
+
+    it('should convert a unit with value only to a number', function () {
+      const u = Unit.parse('5', { allowNoUnits: true })
+      assert.strictEqual(u.toNumber(), 5)
+    })
   })
 
   describe('toNumeric', function () {
@@ -347,6 +352,11 @@ describe('Unit', function () {
       assert.strictEqual(u4.units[1].unit.name, 's')
       assert.strictEqual(u4.units[0].prefix.name, 'c')
       assert.strictEqual(u4.fixPrefix, true)
+    })
+
+    it('should convert a unitless quantity', function () {
+      const u = Unit.parse('5', { allowNoUnits: true })
+      assert.strictEqual(u.toNumeric(), 5)
     })
 
     it('should convert a binary prefixes (1)', function () {


### PR DESCRIPTION
Fix for #1808 

@ericman314 is this a proper fix? Or should we not allow unitless units in the first place? 