### PR TITLE
factorial and prime speed test

### DIFF
--- a/test/benchmark/factorial.js
+++ b/test/benchmark/factorial.js
@@ -2,6 +2,8 @@ const Benchmark = require('benchmark')
 const BigNumber = require('decimal.js')
 const padRight = require('pad-right')
 
+BigNumber.set({ precision: 500, toExpPos: 3000 })
+
 function pad (text) {
   return padRight(text, 40, ' ')
 }
@@ -45,6 +47,44 @@ function betterFactorial (n) {
   return prod
 }
 
+function xFactorial(n) {
+  if (n < 7n) {
+    return {
+      comma: 0,
+      number: [1n, 1n, 2n, 6n, 24n, 120n, 720n][+`${n}`],
+      sign: false
+    };
+  }
+
+  let nostart = false;
+  const h = n / 2n;
+  let s = h + 1n;
+  let k = s + h;
+  let f = (n & 1n) === 1n ? k : 1n;
+
+  if ((h & 1n) === 1n) f = -f;
+  k += 4n;
+
+  function HyperFact(l) {
+    if (l > 1n) {
+      const m = l >> 1n;
+      return HyperFact(m) * HyperFact(l - m);
+    }
+
+    if (nostart) {
+      s -= k -= 4n;
+      return s;
+    }
+    nostart = true;
+
+    return f;
+  }
+
+  return HyperFact(h + 1n) << h;
+};
+
+console.log(xFactorial(300n));
+
 const suite = new Benchmark.Suite()
 suite
   .add(pad('bigFactorial for small numbers'), function () {
@@ -53,6 +93,10 @@ suite
   })
   .add(pad('new bigFactorial for small numbers'), function () {
     const res = betterFactorial(new BigNumber(8))
+    results.push(res)
+  })
+  .add(pad('xFactorial for small numbers'), function () {
+    const res = xFactorial(8n)
     results.push(res)
   })
 
@@ -64,6 +108,10 @@ suite
     const res = betterFactorial(new BigNumber(20))
     results.push(res)
   })
+  .add(pad('xFactorial for small numbers 2'), function () {
+    const res = xFactorial(20n)
+    results.push(res)
+  })
 
   .add(pad('bigFactorial for big numbers'), function () {
     const res = bigFactorial(new BigNumber(600))
@@ -71,6 +119,10 @@ suite
   })
   .add(pad('new bigFactorial for big numbers'), function () {
     const res = betterFactorial(new BigNumber(600))
+    results.push(res)
+  })
+  .add(pad('xFactorial for big numbers'), function () {
+    const res = xFactorial(600n)
     results.push(res)
   })
 
@@ -82,6 +134,10 @@ suite
     const res = betterFactorial(new BigNumber(1500))
     results.push(res)
   })
+  .add(pad('xFactorial for HUGE numbers'), function () {
+    const res = xFactorial(1500n)
+    results.push(res)
+  })
 
   .add(pad('bigFactorial for "HUGER" numbers'), function () {
     const res = bigFactorial(new BigNumber(10000))
@@ -89,6 +145,10 @@ suite
   })
   .add(pad('new bigFactorial for "HUGER" numbers'), function () {
     const res = betterFactorial(new BigNumber(10000))
+    results.push(res)
+  })
+  .add(pad('xFactorial for "HUGER" numbers'), function () {
+    const res = xFactorial(10000n)
     results.push(res)
   })
   .on('cycle', function (event) {

--- a/test/benchmark/prime.js
+++ b/test/benchmark/prime.js
@@ -6,13 +6,43 @@ const primes = [2147483647, 87178291199, 4398042316799]
 const notPrimes = [2199023255551, 8796093022207, 140737488355327]
 const carmichaels = [41041, 825265, 321197185] // more challenging numbers
 
+function isPrimeTest (x) {
+  if (x * 0 !== 0) {
+    return false
+  }
+  if (x <= 3) {
+    return x > 1
+  }
+  if (x % 2 === 0 || x % 3 === 0) {
+    return false
+  }
+  const sqrt = Math.sqrt(x);
+
+  for (let i = 5; i <= sqrt; i += 6) {
+    if (x % i === 0 || x % (i + 2) === 0) {
+      return false
+    }
+  }
+
+  return true
+}
+
 // validate that the function does what we think it does
 const primesResults = primes.map(num => isPrime(num))
 const notPrimesResults = notPrimes.map(num => isPrime(num))
 const carmichaelsResults = carmichaels.map(num => isPrime(num))
+
+const primesResultsTest = primes.map(num => isPrimeTest(num))
+const notPrimesResultsTest = notPrimes.map(num => isPrimeTest(num))
+const carmichaelsResultsTest = carmichaels.map(num => isPrimeTest(num))
+
 assert(primesResults.every(result => result === true))
 assert(notPrimesResults.every(result => result === false))
 assert(carmichaelsResults.every(result => result === false))
+
+assert(primesResultsTest.every(result => result === true))
+assert(notPrimesResultsTest.every(result => result === false))
+assert(carmichaelsResultsTest.every(result => result === false))
 
 new Suite()
   .add('primes', () => {
@@ -23,6 +53,15 @@ new Suite()
   })
   .add('carmichaels', () => {
     carmichaels.forEach(num => isPrime(num))
+  })
+  .add('primes', () => {
+    primes.forEach(num => isPrimeTest(num))
+  })
+  .add('not primes', () => {
+    notPrimes.forEach(num => isPrimeTest(num))
+  })
+  .add('carmichaels', () => {
+    carmichaels.forEach(num => isPrimeTest(num))
   })
   .on('cycle', function (event) {
     console.log(String(event.target))


### PR DESCRIPTION
Some testings about performance.

xFactorial is specifically good using BigInt  (BigNumber is only faster after n > 600 or so I think), using BigInt it is always faster (it is especially visible on bigger numbers though).

In isPrime I have tested if we could use 1 sqrt function instead of multiplying `i` several times. It seems it makes it just a bit faster, but it also increases our range since `i` can be bigger now and we won't overflow maxInteger limit (it is especially applicable in `isPrime BigNumber` version)

Going to work on other functions as well if I find the time.

This PR is rather informative than "merge it asap".