### PR TITLE
Clarify `eigs` documentation

### DIFF
--- a/src/function/matrix/eigs.js
+++ b/src/function/matrix/eigs.js
@@ -22,9 +22,10 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
    * Examples:
    *
    *     const H = [[5, 2.3], [2.3, 1]]
-   *     const ans = math.eigs(H) // returns {values: [E1,E2...sorted], vectors: [v1,v2.... corresponding vectors]}
+   *     const ans = math.eigs(H) // returns {values: [E1,E2...sorted], vectors: [v1,v2.... corresponding vectors as columns]}
    *     const E = ans.values
    *     const U = ans.vectors
+   *     math.multiply(H, math.column(U, 0)) // returns math.multiply(E[0], math.column(U, 0))
    *     const UTxHxU = math.multiply(math.transpose(U), H, U) // rotates H to the eigen-representation
    *     E[0] == UTxHxU[0][0]  // returns true
    * See also:
@@ -32,7 +33,7 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
    *     inv
    *
    * @param {Array | Matrix} x  Matrix to be diagonalized
-   * @return {{values: Array, vectors: Array} | {values: Matrix, vectors: Matrix}} Object containing eigenvalues (Array or Matrix) and eigenvectors (2D Array/Matrix).
+   * @return {{values: Array, vectors: Array} | {values: Matrix, vectors: Matrix}} Object containing eigenvalues (Array or Matrix) and eigenvectors (2D Array/Matrix with eigenvectors as columns).
    */
   const eigs = typed('eigs', {
 


### PR DESCRIPTION
The matrix `math.eigs(H).vectors` contains the eigenvectors as columns, not rows, as previously suggested.
Also includes example of how to access the relevant vectors using `math.column`.

Closes #1844 