### PR TITLE
Replace recursive calls in typed-functions with `this`-style calls

### DIFF
--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -65,7 +65,7 @@ Operator    | Name                    | Syntax      | Associativity | Example   
 `./`        | Element-wise divide     | `x ./ y`    | Left to right | `[9,6,4] ./ [3,2,2]`  | `[3,3,2]`
 `%`, `mod`  | Modulus                 | `x % y`     | Left to right | `8 % 3`               | `2`
 `^`         | Power                   | `x ^ y`     | Right to left | `2 ^ 3`               | `8`
-`.^`        | Element-wise power      | `x .^ y`    | Right to left | `[2,3] .^ [3,3]`      | `[9,27]`
+`.^`        | Element-wise power      | `x .^ y`    | Right to left | `[2,3] .^ [3,3]`      | `[8,27]`
 `'`         | Transpose               | `y'`        | Left to right | `[[1,2],[3,4]]'`      | `[[1,3],[2,4]]`
 `!`         | Factorial               | `y!`        | Left to right | `5!`                  | `120`
 `&`         | Bitwise and             | `x & y`     | Left to right | `5 & 3`               | `1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10727,9 +10727,9 @@
       }
     },
     "typed-function": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.1.tgz",
-      "integrity": "sha512-RbN7MaTQBZLJYzDENHPA0nUmWT0Ex80KHItprrgbTPufYhIlTePvCXZxyQK7wgn19FW5bnuaBIKcBb5mRWjB1Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "javascript-natural-sort": "^0.7.1",
     "seed-random": "^2.2.0",
     "tiny-emitter": "^2.1.0",
-    "typed-function": "^1.1.1"
+    "typed-function": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.10.3",

--- a/src/function/algebra/derivative.js
+++ b/src/function/algebra/derivative.js
@@ -77,28 +77,28 @@ export const createDerivative = /* #__PURE__ */ factory(name, dependencies, ({
       return options.simplify ? simplify(res) : res
     },
     'Node, SymbolNode': function (expr, variable) {
-      return derivative(expr, variable, { simplify: true })
+      return this(expr, variable, { simplify: true })
     },
 
     'string, SymbolNode': function (expr, variable) {
-      return derivative(parse(expr), variable)
+      return this(parse(expr), variable)
     },
     'string, SymbolNode, Object': function (expr, variable, options) {
-      return derivative(parse(expr), variable, options)
+      return this(parse(expr), variable, options)
     },
 
     'string, string': function (expr, variable) {
-      return derivative(parse(expr), parse(variable))
+      return this(parse(expr), parse(variable))
     },
     'string, string, Object': function (expr, variable, options) {
-      return derivative(parse(expr), parse(variable), options)
+      return this(parse(expr), parse(variable), options)
     },
 
     'Node, string': function (expr, variable) {
-      return derivative(expr, parse(variable))
+      return this(expr, parse(variable))
     },
     'Node, string, Object': function (expr, variable, options) {
-      return derivative(expr, parse(variable), options)
+      return this(expr, parse(variable), options)
     }
 
     // TODO: replace the 8 signatures above with 4 as soon as typed-function supports optional arguments

--- a/src/function/algebra/rationalize.js
+++ b/src/function/algebra/rationalize.js
@@ -127,31 +127,31 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
    */
   const rationalize = typed(name, {
     string: function (expr) {
-      return rationalize(parse(expr), {}, false)
+      return this(parse(expr), {}, false)
     },
 
     'string, boolean': function (expr, detailed) {
-      return rationalize(parse(expr), {}, detailed)
+      return this(parse(expr), {}, detailed)
     },
 
     'string, Object': function (expr, scope) {
-      return rationalize(parse(expr), scope, false)
+      return this(parse(expr), scope, false)
     },
 
     'string, Object, boolean': function (expr, scope, detailed) {
-      return rationalize(parse(expr), scope, detailed)
+      return this(parse(expr), scope, detailed)
     },
 
     Node: function (expr) {
-      return rationalize(expr, {}, false)
+      return this(expr, {}, false)
     },
 
     'Node, boolean': function (expr, detailed) {
-      return rationalize(expr, {}, detailed)
+      return this(expr, {}, detailed)
     },
 
     'Node, Object': function (expr, scope) {
-      return rationalize(expr, scope, false)
+      return this(expr, scope, false)
     },
 
     'Node, Object, boolean': function (expr, scope, detailed) {

--- a/src/function/algebra/rationalize.js
+++ b/src/function/algebra/rationalize.js
@@ -125,7 +125,7 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
    *           {Expression Node}  node simplified expression
    *
    */
-  const rationalize = typed(name, {
+  return typed(name, {
     string: function (expr) {
       return this(parse(expr), {}, false)
     },
@@ -643,6 +643,4 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
       } else { throw new Error('Type ' + tp + ' is not allowed') }
     } // End of recurPol
   } // End of polyToCanonical
-
-  return rationalize
 })

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -154,15 +154,15 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
    */
   const simplify = typed('simplify', {
     string: function (expr) {
-      return this(parse(expr), simplify.rules, {}, {})
+      return this(parse(expr), this.rules, {}, {})
     },
 
     'string, Object': function (expr, scope) {
-      return this(parse(expr), simplify.rules, scope, {})
+      return this(parse(expr), this.rules, scope, {})
     },
 
     'string, Object, Object': function (expr, scope, options) {
-      return this(parse(expr), simplify.rules, scope, options)
+      return this(parse(expr), this.rules, scope, options)
     },
 
     'string, Array': function (expr, rules) {
@@ -178,15 +178,15 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     },
 
     'Node, Object': function (expr, scope) {
-      return this(expr, simplify.rules, scope, {})
+      return this(expr, this.rules, scope, {})
     },
 
     'Node, Object, Object': function (expr, scope, options) {
-      return this(expr, simplify.rules, scope, options)
+      return this(expr, this.rules, scope, options)
     },
 
     Node: function (expr) {
-      return this(expr, simplify.rules, {}, {})
+      return this(expr, this.rules, {}, {})
     },
 
     'Node, Array': function (expr, rules) {

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -154,47 +154,47 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
    */
   const simplify = typed('simplify', {
     string: function (expr) {
-      return simplify(parse(expr), simplify.rules, {}, {})
+      return this(parse(expr), simplify.rules, {}, {})
     },
 
     'string, Object': function (expr, scope) {
-      return simplify(parse(expr), simplify.rules, scope, {})
+      return this(parse(expr), simplify.rules, scope, {})
     },
 
     'string, Object, Object': function (expr, scope, options) {
-      return simplify(parse(expr), simplify.rules, scope, options)
+      return this(parse(expr), simplify.rules, scope, options)
     },
 
     'string, Array': function (expr, rules) {
-      return simplify(parse(expr), rules, {}, {})
+      return this(parse(expr), rules, {}, {})
     },
 
     'string, Array, Object': function (expr, rules, scope) {
-      return simplify(parse(expr), rules, scope, {})
+      return this(parse(expr), rules, scope, {})
     },
 
     'string, Array, Object, Object': function (expr, rules, scope, options) {
-      return simplify(parse(expr), rules, scope, options)
+      return this(parse(expr), rules, scope, options)
     },
 
     'Node, Object': function (expr, scope) {
-      return simplify(expr, simplify.rules, scope, {})
+      return this(expr, simplify.rules, scope, {})
     },
 
     'Node, Object, Object': function (expr, scope, options) {
-      return simplify(expr, simplify.rules, scope, options)
+      return this(expr, simplify.rules, scope, options)
     },
 
     Node: function (expr) {
-      return simplify(expr, simplify.rules, {}, {})
+      return this(expr, simplify.rules, {}, {})
     },
 
     'Node, Array': function (expr, rules) {
-      return simplify(expr, rules, {}, {})
+      return this(expr, rules, {}, {})
     },
 
     'Node, Array, Object': function (expr, rules, scope) {
-      return simplify(expr, rules, scope, {})
+      return this(expr, rules, scope, {})
     },
 
     'Node, Array, Object, Object': function (expr, rules, scope, options) {

--- a/src/function/arithmetic/abs.js
+++ b/src/function/arithmetic/abs.js
@@ -30,7 +30,7 @@ export const createAbs = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix | Unit}
    *            Absolute value of `x`
    */
-  const abs = typed(name, {
+  return typed(name, {
     number: absNumber,
 
     Complex: function (x) {
@@ -47,13 +47,11 @@ export const createAbs = /* #__PURE__ */ factory(name, dependencies, ({ typed })
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since abs(0) = 0
-      return deepMap(x, abs, true)
+      return deepMap(x, this, true)
     },
 
     Unit: function (x) {
       return x.abs()
     }
   })
-
-  return abs
 })

--- a/src/function/arithmetic/add.js
+++ b/src/function/arithmetic/add.js
@@ -57,7 +57,7 @@ export const createAdd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
    * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} y Second value to add
    * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} Sum of `x` and `y`
    */
-  const add = typed(name, extend({
+  return typed(name, extend({
     // we extend the signatures of addScalar with signatures dealing with matrices
 
     'DenseMatrix, DenseMatrix': function (x, y) {
@@ -78,17 +78,17 @@ export const createAdd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return add(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return add(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return add(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'DenseMatrix, any': function (x, y) {
@@ -120,15 +120,13 @@ export const createAdd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     'any, any': addScalar,
 
     'any, any, ...any': function (x, y, rest) {
-      let result = add(x, y)
+      let result = this(x, y)
 
       for (let i = 0; i < rest.length; i++) {
-        result = add(result, rest[i])
+        result = this(result, rest[i])
       }
 
       return result
     }
   }, addScalar.signatures))
-
-  return add
 })

--- a/src/function/arithmetic/addScalar.js
+++ b/src/function/arithmetic/addScalar.js
@@ -17,7 +17,7 @@ export const createAddScalar = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @return {number | BigNumber | Fraction | Complex | Unit}     Sum of `x` and `y`
    * @private
    */
-  const addScalar = typed(name, {
+  return typed(name, {
 
     'number, number': addNumber,
 
@@ -39,11 +39,9 @@ export const createAddScalar = /* #__PURE__ */ factory(name, dependencies, ({ ty
       if (!x.equalBase(y)) throw new Error('Units do not match')
 
       const res = x.clone()
-      res.value = addScalar(res.value, y.value)
+      res.value = this(res.value, y.value)
       res.fixPrefix = false
       return res
     }
   })
-
-  return addScalar
 })

--- a/src/function/arithmetic/cbrt.js
+++ b/src/function/arithmetic/cbrt.js
@@ -55,7 +55,7 @@ export const createCbrt = /* #__PURE__ */ factory(name, dependencies, ({ config,
    * @return {number | BigNumber | Complex | Unit | Array | Matrix}
    *            Returns the cubic root of `x`
    */
-  const cbrt = typed(name, {
+  return typed(name, {
     number: cbrtNumber,
     // note: signature 'number, boolean' is also supported,
     //       created by typed as it knows how to convert number to Complex
@@ -72,7 +72,7 @@ export const createCbrt = /* #__PURE__ */ factory(name, dependencies, ({ config,
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since cbrt(0) = 0
-      return deepMap(x, cbrt, true)
+      return deepMap(x, this, true)
     }
   })
 
@@ -145,6 +145,4 @@ export const createCbrt = /* #__PURE__ */ factory(name, dependencies, ({ config,
       return result
     }
   }
-
-  return cbrt
 })

--- a/src/function/arithmetic/ceil.js
+++ b/src/function/arithmetic/ceil.js
@@ -36,7 +36,7 @@ export const createCeil = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param  {number | BigNumber | Fraction | Complex | Array | Matrix} x  Number to be rounded
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix} Rounded value
    */
-  const ceil = typed('ceil', {
+  return typed('ceil', {
     number: function (x) {
       if (nearlyEqual(x, round(x), config.epsilon)) {
         return round(x)
@@ -63,9 +63,7 @@ export const createCeil = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since ceil(0) = 0
-      return deepMap(x, ceil, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return ceil
 })

--- a/src/function/arithmetic/cube.js
+++ b/src/function/arithmetic/cube.js
@@ -30,7 +30,7 @@ export const createCube = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    * @param  {number | BigNumber | Fraction | Complex | Array | Matrix | Unit} x  Number for which to calculate the cube
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix | Unit} Cube of x
    */
-  const cube = typed(name, {
+  return typed(name, {
     number: cubeNumber,
 
     Complex: function (x) {
@@ -47,13 +47,11 @@ export const createCube = /* #__PURE__ */ factory(name, dependencies, ({ typed }
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since cube(0) = 0
-      return deepMap(x, cube, true)
+      return deepMap(x, this, true)
     },
 
     Unit: function (x) {
       return x.pow(3)
     }
   })
-
-  return cube
 })

--- a/src/function/arithmetic/divideScalar.js
+++ b/src/function/arithmetic/divideScalar.js
@@ -17,7 +17,7 @@ export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({
    * @return {number | BigNumber | Fraction | Complex | Unit}     Quotient, `x / y`
    * @private
    */
-  const divideScalar = typed(name, {
+  return typed(name, {
     'number, number': function (x, y) {
       return x / y
     },
@@ -38,7 +38,7 @@ export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({
       const res = x.clone()
       // TODO: move the divide function to Unit.js, it uses internals of Unit
       const one = numeric(1, typeOf(y))
-      res.value = divideScalar(((res.value === null) ? res._normalize(one) : res.value), y)
+      res.value = this(((res.value === null) ? res._normalize(one) : res.value), y)
       return res
     },
 
@@ -47,7 +47,7 @@ export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({
       res = res.pow(-1)
       // TODO: move the divide function to Unit.js, it uses internals of Unit
       const one = numeric(1, typeOf(x))
-      res.value = divideScalar(x, ((y.value === null) ? y._normalize(one) : y.value))
+      res.value = this(x, ((y.value === null) ? y._normalize(one) : y.value))
       return res
     },
 
@@ -55,6 +55,4 @@ export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({
       return x.divide(y)
     }
   })
-
-  return divideScalar
 })

--- a/src/function/arithmetic/dotDivide.js
+++ b/src/function/arithmetic/dotDivide.js
@@ -51,7 +51,7 @@ export const createDotDivide = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} y Denominator
    * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix}                    Quotient, `x ./ y`
    */
-  const dotDivide = typed(name, {
+  return typed(name, {
 
     'any, any': divideScalar,
 
@@ -73,17 +73,17 @@ export const createDotDivide = /* #__PURE__ */ factory(name, dependencies, ({ ty
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return dotDivide(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return dotDivide(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return dotDivide(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -112,6 +112,4 @@ export const createDotDivide = /* #__PURE__ */ factory(name, dependencies, ({ ty
       return algorithm14(matrix(y), x, divideScalar, true).valueOf()
     }
   })
-
-  return dotDivide
 })

--- a/src/function/arithmetic/dotMultiply.js
+++ b/src/function/arithmetic/dotMultiply.js
@@ -46,7 +46,7 @@ export const createDotMultiply = /* #__PURE__ */ factory(name, dependencies, ({ 
    * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} y Right hand value
    * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix}                    Multiplication of `x` and `y`
    */
-  const dotMultiply = typed(name, {
+  return typed(name, {
 
     'any, any': multiplyScalar,
 
@@ -68,17 +68,17 @@ export const createDotMultiply = /* #__PURE__ */ factory(name, dependencies, ({ 
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return dotMultiply(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return dotMultiply(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return dotMultiply(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -107,6 +107,4 @@ export const createDotMultiply = /* #__PURE__ */ factory(name, dependencies, ({ 
       return algorithm14(matrix(y), x, multiplyScalar, true).valueOf()
     }
   })
-
-  return dotMultiply
 })

--- a/src/function/arithmetic/dotPow.js
+++ b/src/function/arithmetic/dotPow.js
@@ -46,7 +46,7 @@ export const createDotPow = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param  {number | BigNumber | Complex | Unit | Array | Matrix} y  The exponent
    * @return {number | BigNumber | Complex | Unit | Array | Matrix}                     The value of `x` to the power `y`
    */
-  const dotPow = typed(name, {
+  return typed(name, {
 
     'any, any': pow,
 
@@ -68,45 +68,43 @@ export const createDotPow = /* #__PURE__ */ factory(name, dependencies, ({ typed
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return dotPow(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return dotPow(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return dotPow(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm11(x, y, dotPow, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, dotPow, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, dotPow, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, dotPow, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, dotPow, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, dotPow, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return dotPow
 })

--- a/src/function/arithmetic/exp.js
+++ b/src/function/arithmetic/exp.js
@@ -34,7 +34,7 @@ export const createExp = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @param {number | BigNumber | Complex | Array | Matrix} x  A number or matrix to exponentiate
    * @return {number | BigNumber | Complex | Array | Matrix} Exponent of `x`
    */
-  const exp = typed(name, {
+  return typed(name, {
     number: expNumber,
 
     Complex: function (x) {
@@ -47,9 +47,7 @@ export const createExp = /* #__PURE__ */ factory(name, dependencies, ({ typed })
 
     'Array | Matrix': function (x) {
       // TODO: exp(sparse) should return a dense matrix since exp(0)==1
-      return deepMap(x, exp)
+      return deepMap(x, this)
     }
   })
-
-  return exp
 })

--- a/src/function/arithmetic/expm1.js
+++ b/src/function/arithmetic/expm1.js
@@ -34,7 +34,7 @@ export const createExpm1 = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | BigNumber | Complex | Array | Matrix} x  A number or matrix to apply expm1
    * @return {number | BigNumber | Complex | Array | Matrix} Exponent of `x`
    */
-  const expm1 = typed(name, {
+  return typed(name, {
     number: expm1Number,
 
     Complex: function (x) {
@@ -50,9 +50,7 @@ export const createExpm1 = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, expm1)
+      return deepMap(x, this)
     }
   })
-
-  return expm1
 })

--- a/src/function/arithmetic/fix.js
+++ b/src/function/arithmetic/fix.js
@@ -32,7 +32,7 @@ export const createFix = /* #__PURE__ */ factory(name, dependencies, ({ typed, C
    * @param {number | BigNumber | Fraction | Complex | Array | Matrix} x Number to be rounded
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix}            Rounded value
    */
-  const fix = typed('fix', {
+  return typed('fix', {
     number: function (x) {
       return (x > 0) ? floor(x) : ceil(x)
     },
@@ -54,9 +54,7 @@ export const createFix = /* #__PURE__ */ factory(name, dependencies, ({ typed, C
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since fix(0) = 0
-      return deepMap(x, fix, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return fix
 })

--- a/src/function/arithmetic/floor.js
+++ b/src/function/arithmetic/floor.js
@@ -34,7 +34,7 @@ export const createFloor = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param  {number | BigNumber | Fraction | Complex | Array | Matrix} x  Number to be rounded
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix} Rounded value
    */
-  const floor = typed('floor', {
+  return typed('floor', {
     number: function (x) {
       if (nearlyEqual(x, round(x), config.epsilon)) {
         return round(x)
@@ -61,9 +61,7 @@ export const createFloor = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since floor(0) = 0
-      return deepMap(x, floor, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return floor
 })

--- a/src/function/arithmetic/gcd.js
+++ b/src/function/arithmetic/gcd.js
@@ -47,7 +47,7 @@ export const createGcd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
    * @param {... number | BigNumber | Fraction | Array | Matrix} args  Two or more integer numbers
    * @return {number | BigNumber | Fraction | Array | Matrix}                           The greatest common divisor
    */
-  const gcd = typed(name, {
+  return typed(name, {
 
     'number, number': gcdNumber,
 
@@ -58,73 +58,71 @@ export const createGcd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm04(x, y, gcd)
+      return algorithm04(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm01(y, x, gcd, true)
+      return algorithm01(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm01(x, y, gcd, false)
+      return algorithm01(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, gcd)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return gcd(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return gcd(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return gcd(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
-      return algorithm10(x, y, gcd, false)
+      return algorithm10(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
-      return algorithm14(x, y, gcd, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
-      return algorithm10(y, x, gcd, true)
+      return algorithm10(y, x, this, true)
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, gcd, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, gcd, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, gcd, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     },
 
     // TODO: need a smarter notation here
     'Array | Matrix | number | BigNumber, Array | Matrix | number | BigNumber, ...Array | Matrix | number | BigNumber': function (a, b, args) {
-      let res = gcd(a, b)
+      let res = this(a, b)
       for (let i = 0; i < args.length; i++) {
-        res = gcd(res, args[i])
+        res = this(res, args[i])
       }
       return res
     }
   })
-
-  return gcd
 
   /**
    * Calculate gcd for BigNumbers

--- a/src/function/arithmetic/hypot.js
+++ b/src/function/arithmetic/hypot.js
@@ -42,15 +42,15 @@ export const createHypot = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    *                                                          single number for the whole matrix.
    * @return {number | BigNumber} Returns the hypothenusa of the input values.
    */
-  const hypot = typed(name, {
+  return typed(name, {
     '... number | BigNumber': _hypot,
 
     Array: function (x) {
-      return hypot.apply(hypot, flatten(x))
+      return this.apply(this, flatten(x))
     },
 
     Matrix: function (x) {
-      return hypot.apply(hypot, flatten(x.toArray()))
+      return this.apply(this, flatten(x.toArray()))
     }
   })
 
@@ -82,6 +82,4 @@ export const createHypot = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     return multiplyScalar(largest, sqrt(result))
   }
-
-  return hypot
 })

--- a/src/function/arithmetic/lcm.js
+++ b/src/function/arithmetic/lcm.js
@@ -49,7 +49,7 @@ export const createLcm = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
    * @param {... number | BigNumber | Array | Matrix} args  Two or more integer numbers
    * @return {number | BigNumber | Array | Matrix}                           The least common multiple
    */
-  const lcm = typed(name, {
+  return typed(name, {
     'number, number': lcmNumber,
 
     'BigNumber, BigNumber': _lcmBigNumber,
@@ -59,73 +59,71 @@ export const createLcm = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm06(x, y, lcm)
+      return algorithm06(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, lcm, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm02(x, y, lcm, false)
+      return algorithm02(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, lcm)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return lcm(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return lcm(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return lcm(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
-      return algorithm11(x, y, lcm, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
-      return algorithm14(x, y, lcm, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
-      return algorithm11(y, x, lcm, true)
+      return algorithm11(y, x, this, true)
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, lcm, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, lcm, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, lcm, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     },
 
     // TODO: need a smarter notation here
     'Array | Matrix | number | BigNumber, Array | Matrix | number | BigNumber, ...Array | Matrix | number | BigNumber': function (a, b, args) {
-      let res = lcm(a, b)
+      let res = this(a, b)
       for (let i = 0; i < args.length; i++) {
-        res = lcm(res, args[i])
+        res = this(res, args[i])
       }
       return res
     }
   })
-
-  return lcm
 
   /**
    * Calculate lcm for two BigNumbers

--- a/src/function/arithmetic/log.js
+++ b/src/function/arithmetic/log.js
@@ -40,7 +40,7 @@ export const createLog = /* #__PURE__ */ factory(name, dependencies, ({ typed, c
    * @return {number | BigNumber | Complex | Array | Matrix}
    *            Returns the logarithm of `x`
    */
-  const log = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x >= 0 || config.predictable) {
         return logNumber(x)
@@ -64,14 +64,12 @@ export const createLog = /* #__PURE__ */ factory(name, dependencies, ({ typed, c
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, log)
+      return deepMap(x, this)
     },
 
     'any, any': function (x, base) {
       // calculate logarithm for a specified base, log(x, base)
-      return divideScalar(log(x), log(base))
+      return divideScalar(this(x), this(base))
     }
   })
-
-  return log
 })

--- a/src/function/arithmetic/log10.js
+++ b/src/function/arithmetic/log10.js
@@ -31,7 +31,7 @@ export const createLog10 = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @return {number | BigNumber | Complex | Array | Matrix}
    *            Returns the 10-base logarithm of `x`
    */
-  const log10 = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x >= 0 || config.predictable) {
         return log10Number(x)
@@ -55,9 +55,7 @@ export const createLog10 = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, log10)
+      return deepMap(x, this)
     }
   })
-
-  return log10
 })

--- a/src/function/arithmetic/log1p.js
+++ b/src/function/arithmetic/log1p.js
@@ -37,7 +37,7 @@ export const createLog1p = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @return {number | BigNumber | Complex | Array | Matrix}
    *            Returns the logarithm of `x+1`
    */
-  const log1p = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x >= -1 || config.predictable) {
         return _log1p(x)
@@ -60,12 +60,12 @@ export const createLog1p = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, log1p)
+      return deepMap(x, this)
     },
 
     'any, any': function (x, base) {
       // calculate logarithm for a specified base, log1p(x, base)
-      return divideScalar(log1p(x), log(base))
+      return divideScalar(this(x), log(base))
     }
   })
 
@@ -82,6 +82,4 @@ export const createLog1p = /* #__PURE__ */ factory(name, dependencies, ({ typed,
       Math.atan2(x.im, xRe1p)
     )
   }
-
-  return log1p
 })

--- a/src/function/arithmetic/log2.js
+++ b/src/function/arithmetic/log2.js
@@ -31,7 +31,7 @@ export const createLog2 = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @return {number | BigNumber | Complex | Array | Matrix}
    *            Returns the 2-base logarithm of `x`
    */
-  const log2 = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x >= 0 || config.predictable) {
         return log2Number(x)
@@ -53,7 +53,7 @@ export const createLog2 = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, log2)
+      return deepMap(x, this)
     }
   })
 
@@ -70,6 +70,4 @@ export const createLog2 = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
       Math.atan2(x.im, x.re) / Math.LN2
     )
   }
-
-  return log2
 })

--- a/src/function/arithmetic/mod.js
+++ b/src/function/arithmetic/mod.js
@@ -60,7 +60,7 @@ export const createMod = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
    * @param  {number | BigNumber | Fraction | Array | Matrix} y Divisor
    * @return {number | BigNumber | Fraction | Array | Matrix} Returns the remainder of `x` divided by `y`.
    */
-  const mod = typed(name, {
+  return typed(name, {
 
     'number, number': modNumber,
 
@@ -73,62 +73,60 @@ export const createMod = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm05(x, y, mod, false)
+      return algorithm05(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, mod, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, mod, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, mod)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return mod(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return mod(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return mod(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm11(x, y, mod, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, mod, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, mod, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, mod, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, mod, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, mod, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return mod
 })

--- a/src/function/arithmetic/multiply.js
+++ b/src/function/arithmetic/multiply.js
@@ -19,128 +19,6 @@ export const createMultiply = /* #__PURE__ */ factory(name, dependencies, ({ typ
   const algorithm11 = createAlgorithm11({ typed, equalScalar })
   const algorithm14 = createAlgorithm14({ typed })
 
-  /**
-   * Multiply two or more values, `x * y`.
-   * For matrices, the matrix product is calculated.
-   *
-   * Syntax:
-   *
-   *    math.multiply(x, y)
-   *    math.multiply(x, y, z, ...)
-   *
-   * Examples:
-   *
-   *    math.multiply(4, 5.2)        // returns number 20.8
-   *    math.multiply(2, 3, 4)       // returns number 24
-   *
-   *    const a = math.complex(2, 3)
-   *    const b = math.complex(4, 1)
-   *    math.multiply(a, b)          // returns Complex 5 + 14i
-   *
-   *    const c = [[1, 2], [4, 3]]
-   *    const d = [[1, 2, 3], [3, -4, 7]]
-   *    math.multiply(c, d)          // returns Array [[7, -6, 17], [13, -4, 33]]
-   *
-   *    const e = math.unit('2.1 km')
-   *    math.multiply(3, e)          // returns Unit 6.3 km
-   *
-   * See also:
-   *
-   *    divide, prod, cross, dot
-   *
-   * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} x First value to multiply
-   * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} y Second value to multiply
-   * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} Multiplication of `x` and `y`
-   */
-  const multiply = typed(name, extend({
-    // we extend the signatures of multiplyScalar with signatures dealing with matrices
-
-    'Array, Array': function (x, y) {
-      // check dimensions
-      _validateMatrixDimensions(arraySize(x), arraySize(y))
-
-      // use dense matrix implementation
-      const m = this(matrix(x), matrix(y))
-      // return array or scalar
-      return isMatrix(m) ? m.valueOf() : m
-    },
-
-    'Matrix, Matrix': function (x, y) {
-      // dimensions
-      const xsize = x.size()
-      const ysize = y.size()
-
-      // check dimensions
-      _validateMatrixDimensions(xsize, ysize)
-
-      // process dimensions
-      if (xsize.length === 1) {
-        // process y dimensions
-        if (ysize.length === 1) {
-          // Vector * Vector
-          return _multiplyVectorVector(x, y, xsize[0])
-        }
-        // Vector * Matrix
-        return _multiplyVectorMatrix(x, y)
-      }
-      // process y dimensions
-      if (ysize.length === 1) {
-        // Matrix * Vector
-        return _multiplyMatrixVector(x, y)
-      }
-      // Matrix * Matrix
-      return _multiplyMatrixMatrix(x, y)
-    },
-
-    'Matrix, Array': function (x, y) {
-      // use Matrix * Matrix implementation
-      return this(x, matrix(y))
-    },
-
-    'Array, Matrix': function (x, y) {
-      // use Matrix * Matrix implementation
-      return this(matrix(x, y.storage()), y)
-    },
-
-    'SparseMatrix, any': function (x, y) {
-      return algorithm11(x, y, multiplyScalar, false)
-    },
-
-    'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, multiplyScalar, false)
-    },
-
-    'any, SparseMatrix': function (x, y) {
-      return algorithm11(y, x, multiplyScalar, true)
-    },
-
-    'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, multiplyScalar, true)
-    },
-
-    'Array, any': function (x, y) {
-      // use matrix implementation
-      return algorithm14(matrix(x), y, multiplyScalar, false).valueOf()
-    },
-
-    'any, Array': function (x, y) {
-      // use matrix implementation
-      return algorithm14(matrix(y), x, multiplyScalar, true).valueOf()
-    },
-
-    'any, any': multiplyScalar,
-
-    'any, any, ...any': function (x, y, rest) {
-      let result = this(x, y)
-
-      for (let i = 0; i < rest.length; i++) {
-        result = this(result, rest[i])
-      }
-
-      return result
-    }
-  }, multiplyScalar.signatures))
-
   function _validateMatrixDimensions (size1, size2) {
     // check left operand dimensions
     switch (size1.length) {
@@ -883,5 +761,125 @@ export const createMultiply = /* #__PURE__ */ factory(name, dependencies, ({ typ
     return c
   }
 
-  return multiply
+  /**
+   * Multiply two or more values, `x * y`.
+   * For matrices, the matrix product is calculated.
+   *
+   * Syntax:
+   *
+   *    math.multiply(x, y)
+   *    math.multiply(x, y, z, ...)
+   *
+   * Examples:
+   *
+   *    math.multiply(4, 5.2)        // returns number 20.8
+   *    math.multiply(2, 3, 4)       // returns number 24
+   *
+   *    const a = math.complex(2, 3)
+   *    const b = math.complex(4, 1)
+   *    math.multiply(a, b)          // returns Complex 5 + 14i
+   *
+   *    const c = [[1, 2], [4, 3]]
+   *    const d = [[1, 2, 3], [3, -4, 7]]
+   *    math.multiply(c, d)          // returns Array [[7, -6, 17], [13, -4, 33]]
+   *
+   *    const e = math.unit('2.1 km')
+   *    math.multiply(3, e)          // returns Unit 6.3 km
+   *
+   * See also:
+   *
+   *    divide, prod, cross, dot
+   *
+   * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} x First value to multiply
+   * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} y Second value to multiply
+   * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} Multiplication of `x` and `y`
+   */
+  return typed(name, extend({
+    // we extend the signatures of multiplyScalar with signatures dealing with matrices
+
+    'Array, Array': function (x, y) {
+      // check dimensions
+      _validateMatrixDimensions(arraySize(x), arraySize(y))
+
+      // use dense matrix implementation
+      const m = this(matrix(x), matrix(y))
+      // return array or scalar
+      return isMatrix(m) ? m.valueOf() : m
+    },
+
+    'Matrix, Matrix': function (x, y) {
+      // dimensions
+      const xsize = x.size()
+      const ysize = y.size()
+
+      // check dimensions
+      _validateMatrixDimensions(xsize, ysize)
+
+      // process dimensions
+      if (xsize.length === 1) {
+        // process y dimensions
+        if (ysize.length === 1) {
+          // Vector * Vector
+          return _multiplyVectorVector(x, y, xsize[0])
+        }
+        // Vector * Matrix
+        return _multiplyVectorMatrix(x, y)
+      }
+      // process y dimensions
+      if (ysize.length === 1) {
+        // Matrix * Vector
+        return _multiplyMatrixVector(x, y)
+      }
+      // Matrix * Matrix
+      return _multiplyMatrixMatrix(x, y)
+    },
+
+    'Matrix, Array': function (x, y) {
+      // use Matrix * Matrix implementation
+      return this(x, matrix(y))
+    },
+
+    'Array, Matrix': function (x, y) {
+      // use Matrix * Matrix implementation
+      return this(matrix(x, y.storage()), y)
+    },
+
+    'SparseMatrix, any': function (x, y) {
+      return algorithm11(x, y, multiplyScalar, false)
+    },
+
+    'DenseMatrix, any': function (x, y) {
+      return algorithm14(x, y, multiplyScalar, false)
+    },
+
+    'any, SparseMatrix': function (x, y) {
+      return algorithm11(y, x, multiplyScalar, true)
+    },
+
+    'any, DenseMatrix': function (x, y) {
+      return algorithm14(y, x, multiplyScalar, true)
+    },
+
+    'Array, any': function (x, y) {
+      // use matrix implementation
+      return algorithm14(matrix(x), y, multiplyScalar, false).valueOf()
+    },
+
+    'any, Array': function (x, y) {
+      // use matrix implementation
+      return algorithm14(matrix(y), x, multiplyScalar, true).valueOf()
+    },
+
+    'any, any': multiplyScalar,
+
+    'any, any, ...any': function (x, y, rest) {
+      let result = this(x, y)
+
+      for (let i = 0; i < rest.length; i++) {
+        result = this(result, rest[i])
+      }
+
+      return result
+    }
+  }, multiplyScalar.signatures))
 })

--- a/src/function/arithmetic/multiply.js
+++ b/src/function/arithmetic/multiply.js
@@ -60,7 +60,7 @@ export const createMultiply = /* #__PURE__ */ factory(name, dependencies, ({ typ
       _validateMatrixDimensions(arraySize(x), arraySize(y))
 
       // use dense matrix implementation
-      const m = multiply(matrix(x), matrix(y))
+      const m = this(matrix(x), matrix(y))
       // return array or scalar
       return isMatrix(m) ? m.valueOf() : m
     },
@@ -94,12 +94,12 @@ export const createMultiply = /* #__PURE__ */ factory(name, dependencies, ({ typ
 
     'Matrix, Array': function (x, y) {
       // use Matrix * Matrix implementation
-      return multiply(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'Array, Matrix': function (x, y) {
       // use Matrix * Matrix implementation
-      return multiply(matrix(x, y.storage()), y)
+      return this(matrix(x, y.storage()), y)
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -131,10 +131,10 @@ export const createMultiply = /* #__PURE__ */ factory(name, dependencies, ({ typ
     'any, any': multiplyScalar,
 
     'any, any, ...any': function (x, y, rest) {
-      let result = multiply(x, y)
+      let result = this(x, y)
 
       for (let i = 0; i < rest.length; i++) {
-        result = multiply(result, rest[i])
+        result = this(result, rest[i])
       }
 
       return result

--- a/src/function/arithmetic/multiplyScalar.js
+++ b/src/function/arithmetic/multiplyScalar.js
@@ -17,7 +17,7 @@ export const createMultiplyScalar = /* #__PURE__ */ factory(name, dependencies, 
    * @return {number | BigNumber | Fraction | Complex | Unit}     Multiplication of `x` and `y`
    * @private
    */
-  const multiplyScalar = typed('multiplyScalar', {
+  return typed('multiplyScalar', {
 
     'number, number': multiplyNumber,
 
@@ -35,13 +35,13 @@ export const createMultiplyScalar = /* #__PURE__ */ factory(name, dependencies, 
 
     'number | Fraction | BigNumber | Complex, Unit': function (x, y) {
       const res = y.clone()
-      res.value = (res.value === null) ? res._normalize(x) : multiplyScalar(res.value, x)
+      res.value = (res.value === null) ? res._normalize(x) : this(res.value, x)
       return res
     },
 
     'Unit, number | Fraction | BigNumber | Complex': function (x, y) {
       const res = x.clone()
-      res.value = (res.value === null) ? res._normalize(y) : multiplyScalar(res.value, y)
+      res.value = (res.value === null) ? res._normalize(y) : this(res.value, y)
       return res
     },
 
@@ -50,6 +50,4 @@ export const createMultiplyScalar = /* #__PURE__ */ factory(name, dependencies, 
     }
 
   })
-
-  return multiplyScalar
 })

--- a/src/function/arithmetic/norm.js
+++ b/src/function/arithmetic/norm.js
@@ -54,7 +54,7 @@ export const createNorm = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    *            Supported strings are: 'inf', '-inf', and 'fro' (The Frobenius norm)
    * @return {number | BigNumber} the p-norm
    */
-  const norm = typed(name, {
+  return typed(name, {
     number: Math.abs,
 
     Complex: function (x) {
@@ -81,7 +81,7 @@ export const createNorm = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
 
     'number | Complex | BigNumber | boolean, number | BigNumber | string': function (x) {
       // ignore second parameter, TODO: remove the option of second parameter for these types
-      return norm(x)
+      return this(x)
     },
 
     'Array, number | BigNumber | string': function (x, p) {
@@ -204,6 +204,4 @@ export const createNorm = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
       throw new Error('Unsupported parameter value')
     }
   }
-
-  return norm
 })

--- a/src/function/arithmetic/nthRoot.js
+++ b/src/function/arithmetic/nthRoot.js
@@ -56,7 +56,7 @@ export const createNthRoot = /* #__PURE__ */ factory(name, dependencies, ({ type
     'Complex number not supported in function nthRoot. ' +
     'Use nthRoots instead.'
   )
-  const nthRoot = typed(name, {
+  return typed(name, {
 
     number: function (x) {
       return nthRootNumber(x, 2)
@@ -76,14 +76,14 @@ export const createNthRoot = /* #__PURE__ */ factory(name, dependencies, ({ type
     'BigNumber, BigNumber': _bigNthRoot,
 
     'Array | Matrix': function (x) {
-      return nthRoot(x, 2)
+      return this(x, 2)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
       // density must be one (no zeros in matrix)
       if (y.density() === 1) {
         // sparse + sparse
-        return algorithm06(x, y, nthRoot)
+        return algorithm06(x, y, this)
       } else {
         // throw exception
         throw new Error('Root must be non-zero')
@@ -91,14 +91,14 @@ export const createNthRoot = /* #__PURE__ */ factory(name, dependencies, ({ type
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, nthRoot, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
       // density must be one (no zeros in matrix)
       if (y.density() === 1) {
         // dense + sparse
-        return algorithm01(x, y, nthRoot, false)
+        return algorithm01(x, y, this, false)
       } else {
         // throw exception
         throw new Error('Root must be non-zero')
@@ -106,37 +106,37 @@ export const createNthRoot = /* #__PURE__ */ factory(name, dependencies, ({ type
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, nthRoot)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return nthRoot(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return nthRoot(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return nthRoot(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
-      return algorithm11(x, y, nthRoot, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
-      return algorithm14(x, y, nthRoot, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
       // density must be one (no zeros in matrix)
       if (y.density() === 1) {
         // sparse - scalar
-        return algorithm11(y, x, nthRoot, true)
+        return algorithm11(y, x, this, true)
       } else {
         // throw exception
         throw new Error('Root must be non-zero')
@@ -144,21 +144,19 @@ export const createNthRoot = /* #__PURE__ */ factory(name, dependencies, ({ type
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, nthRoot, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return nthRoot(matrix(x), y).valueOf()
+      return this(matrix(x), y).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return nthRoot(x, matrix(y)).valueOf()
+      return this(x, matrix(y)).valueOf()
     }
   })
-
-  return nthRoot
 
   /**
    * Calculate the nth root of a for BigNumbers, solve x^root == a

--- a/src/function/arithmetic/nthRoots.js
+++ b/src/function/arithmetic/nthRoots.js
@@ -5,45 +5,6 @@ const dependencies = ['config', 'typed', 'divideScalar', 'Complex']
 
 export const createNthRoots = /* #__PURE__ */ factory(name, dependencies, ({ typed, config, divideScalar, Complex }) => {
   /**
-   * Calculate the nth roots of a value.
-   * An nth root of a positive real number A,
-   * is a positive real solution of the equation "x^root = A".
-   * This function returns an array of complex values.
-   *
-   * Syntax:
-   *
-   *    math.nthRoots(x)
-   *    math.nthRoots(x, root)
-   *
-   * Examples:
-   *
-   *    math.nthRoots(1)
-   *    // returns [
-   *    //   {re: 1, im: 0},
-   *    //   {re: -1, im: 0}
-   *    // ]
-   *    nthRoots(1, 3)
-   *    // returns [
-   *    //   { re: 1, im: 0 },
-   *    //   { re: -0.4999999999999998, im: 0.8660254037844387 },
-   *    //   { re: -0.5000000000000004, im: -0.8660254037844385 }
-   *    ]
-   *
-   * See also:
-   *
-   *    nthRoot, pow, sqrt
-   *
-   * @param {number | BigNumber | Fraction | Complex} x Number to be rounded
-   * @return {number | BigNumber | Fraction | Complex}            Rounded value
-   */
-  const nthRoots = typed(name, {
-    Complex: function (x) {
-      return _nthComplexRoots(x, 2)
-    },
-    'Complex, number': _nthComplexRoots
-  })
-
-  /**
    * Each function here returns a real multiple of i as a Complex value.
    * @param  {number} val
    * @return {Complex} val, i*val, -val or -i*val for index 0, 1, 2, 3
@@ -98,5 +59,42 @@ export const createNthRoots = /* #__PURE__ */ factory(name, dependencies, ({ typ
     return roots
   }
 
-  return nthRoots
+  /**
+   * Calculate the nth roots of a value.
+   * An nth root of a positive real number A,
+   * is a positive real solution of the equation "x^root = A".
+   * This function returns an array of complex values.
+   *
+   * Syntax:
+   *
+   *    math.nthRoots(x)
+   *    math.nthRoots(x, root)
+   *
+   * Examples:
+   *
+   *    math.nthRoots(1)
+   *    // returns [
+   *    //   {re: 1, im: 0},
+   *    //   {re: -1, im: 0}
+   *    // ]
+   *    nthRoots(1, 3)
+   *    // returns [
+   *    //   { re: 1, im: 0 },
+   *    //   { re: -0.4999999999999998, im: 0.8660254037844387 },
+   *    //   { re: -0.5000000000000004, im: -0.8660254037844385 }
+   *    ]
+   *
+   * See also:
+   *
+   *    nthRoot, pow, sqrt
+   *
+   * @param {number | BigNumber | Fraction | Complex} x Number to be rounded
+   * @return {number | BigNumber | Fraction | Complex}            Rounded value
+   */
+  return typed(name, {
+    Complex: function (x) {
+      return _nthComplexRoots(x, 2)
+    },
+    'Complex, number': _nthComplexRoots
+  })
 })

--- a/src/function/arithmetic/round.js
+++ b/src/function/arithmetic/round.js
@@ -54,7 +54,7 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param  {number | BigNumber | Array} [n=0]                            Number of decimals
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix} Rounded value
    */
-  const round = typed(name, {
+  return typed(name, {
     ...roundNumberSignatures,
 
     Complex: function (x) {
@@ -101,15 +101,15 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since round(0) = 0
-      return deepMap(x, round, true)
+      return deepMap(x, this, true)
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
-      return algorithm11(x, y, round, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
-      return algorithm14(x, y, round, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | Complex | BigNumber, SparseMatrix': function (x, y) {
@@ -118,7 +118,7 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
         // do not execute algorithm, result will be a zero matrix
         return zeros(y.size(), y.storage())
       }
-      return algorithm12(y, x, round, true)
+      return algorithm12(y, x, this, true)
     },
 
     'number | Complex | BigNumber, DenseMatrix': function (x, y) {
@@ -127,21 +127,19 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
         // do not execute algorithm, result will be a zero matrix
         return zeros(y.size(), y.storage())
       }
-      return algorithm14(y, x, round, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, round, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'number | Complex | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, round, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return round
 })
 
 const roundNumberSignatures = {

--- a/src/function/arithmetic/sign.js
+++ b/src/function/arithmetic/sign.js
@@ -36,7 +36,7 @@ export const createSign = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix | Unit}e
    *            The sign of `x`
    */
-  const sign = typed(name, {
+  return typed(name, {
     number: signNumber,
 
     Complex: function (x) {
@@ -53,13 +53,11 @@ export const createSign = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since sign(0) = 0
-      return deepMap(x, sign, true)
+      return deepMap(x, this, true)
     },
 
     Unit: function (x) {
-      return sign(x.value)
+      return this(x.value)
     }
   })
-
-  return sign
 })

--- a/src/function/arithmetic/sqrt.js
+++ b/src/function/arithmetic/sqrt.js
@@ -29,7 +29,7 @@ export const createSqrt = /* #__PURE__ */ factory(name, dependencies, ({ config,
    * @return {number | BigNumber | Complex | Array | Matrix | Unit}
    *            Returns the square root of `x`
    */
-  const sqrt = typed('sqrt', {
+  return typed('sqrt', {
     number: _sqrtNumber,
 
     Complex: function (x) {
@@ -47,7 +47,7 @@ export const createSqrt = /* #__PURE__ */ factory(name, dependencies, ({ config,
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since sqrt(0) = 0
-      return deepMap(x, sqrt, true)
+      return deepMap(x, this, true)
     },
 
     Unit: function (x) {
@@ -72,6 +72,4 @@ export const createSqrt = /* #__PURE__ */ factory(name, dependencies, ({ config,
       return new Complex(x, 0).sqrt()
     }
   }
-
-  return sqrt
 })

--- a/src/function/arithmetic/square.js
+++ b/src/function/arithmetic/square.js
@@ -32,7 +32,7 @@ export const createSquare = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @return {number | BigNumber | Fraction | Complex | Array | Matrix | Unit}
    *            Squared value
    */
-  const square = typed(name, {
+  return typed(name, {
     number: squareNumber,
 
     Complex: function (x) {
@@ -49,13 +49,11 @@ export const createSquare = /* #__PURE__ */ factory(name, dependencies, ({ typed
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since square(0) = 0
-      return deepMap(x, square, true)
+      return deepMap(x, this, true)
     },
 
     Unit: function (x) {
       return x.pow(2)
     }
   })
-
-  return square
 })

--- a/src/function/arithmetic/subtract.js
+++ b/src/function/arithmetic/subtract.js
@@ -60,7 +60,7 @@ export const createSubtract = /* #__PURE__ */ factory(name, dependencies, ({ typ
    * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix}
    *            Subtraction of `x` and `y`
    */
-  const subtract = typed(name, {
+  return typed(name, {
 
     'number, number': function (x, y) {
       return x - y
@@ -92,7 +92,7 @@ export const createSubtract = /* #__PURE__ */ factory(name, dependencies, ({ typ
       }
 
       const res = x.clone()
-      res.value = subtract(res.value, y.value)
+      res.value = this(res.value, y.value)
       res.fixPrefix = false
 
       return res
@@ -100,37 +100,37 @@ export const createSubtract = /* #__PURE__ */ factory(name, dependencies, ({ typ
 
     'SparseMatrix, SparseMatrix': function (x, y) {
       checkEqualDimensions(x, y)
-      return algorithm05(x, y, subtract)
+      return algorithm05(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
       checkEqualDimensions(x, y)
-      return algorithm03(y, x, subtract, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
       checkEqualDimensions(x, y)
-      return algorithm01(x, y, subtract, false)
+      return algorithm01(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
       checkEqualDimensions(x, y)
-      return algorithm13(x, y, subtract)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return subtract(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return subtract(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return subtract(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -138,29 +138,27 @@ export const createSubtract = /* #__PURE__ */ factory(name, dependencies, ({ typ
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, subtract)
+      return algorithm14(x, y, this)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm10(y, x, subtract, true)
+      return algorithm10(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, subtract, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, subtract, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, subtract, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return subtract
 })
 
 /**

--- a/src/function/arithmetic/unaryMinus.js
+++ b/src/function/arithmetic/unaryMinus.js
@@ -29,7 +29,7 @@ export const createUnaryMinus = /* #__PURE__ */ factory(name, dependencies, ({ t
    * @param  {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} x Number to be inverted.
    * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix} Returns the value with inverted sign.
    */
-  const unaryMinus = typed(name, {
+  return typed(name, {
     number: unaryMinusNumber,
 
     Complex: function (x) {
@@ -46,17 +46,15 @@ export const createUnaryMinus = /* #__PURE__ */ factory(name, dependencies, ({ t
 
     Unit: function (x) {
       const res = x.clone()
-      res.value = unaryMinus(x.value)
+      res.value = this(x.value)
       return res
     },
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since unaryMinus(0) = 0
-      return deepMap(x, unaryMinus, true)
+      return deepMap(x, this, true)
     }
 
     // TODO: add support for string
   })
-
-  return unaryMinus
 })

--- a/src/function/arithmetic/unaryPlus.js
+++ b/src/function/arithmetic/unaryPlus.js
@@ -30,7 +30,7 @@ export const createUnaryPlus = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @return {number | BigNumber | Fraction | Complex | Unit | Array | Matrix}
    *            Returns the input value when numeric, converts to a number when input is non-numeric.
    */
-  const unaryPlus = typed(name, {
+  return typed(name, {
     number: unaryPlusNumber,
 
     Complex: function (x) {
@@ -51,7 +51,7 @@ export const createUnaryPlus = /* #__PURE__ */ factory(name, dependencies, ({ ty
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since unaryPlus(0) = 0
-      return deepMap(x, unaryPlus, true)
+      return deepMap(x, this, true)
     },
 
     'boolean | string': function (x) {
@@ -59,6 +59,4 @@ export const createUnaryPlus = /* #__PURE__ */ factory(name, dependencies, ({ ty
       return (config.number === 'BigNumber') ? new BigNumber(+x) : +x
     }
   })
-
-  return unaryPlus
 })

--- a/src/function/bitwise/bitAnd.js
+++ b/src/function/bitwise/bitAnd.js
@@ -43,69 +43,67 @@ export const createBitAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param  {number | BigNumber | Array | Matrix} y Second value to and
    * @return {number | BigNumber | Array | Matrix} AND of `x` and `y`
    */
-  const bitAnd = typed(name, {
+  return typed(name, {
 
     'number, number': bitAndNumber,
 
     'BigNumber, BigNumber': bitAndBigNumber,
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm06(x, y, bitAnd, false)
+      return algorithm06(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, bitAnd, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm02(x, y, bitAnd, false)
+      return algorithm02(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, bitAnd)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return bitAnd(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return bitAnd(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return bitAnd(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm11(x, y, bitAnd, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, bitAnd, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm11(y, x, bitAnd, true)
+      return algorithm11(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, bitAnd, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, bitAnd, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, bitAnd, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return bitAnd
 })

--- a/src/function/bitwise/bitNot.js
+++ b/src/function/bitwise/bitNot.js
@@ -29,15 +29,13 @@ export const createBitNot = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param  {number | BigNumber | Array | Matrix} x Value to not
    * @return {number | BigNumber | Array | Matrix} NOT of `x`
    */
-  const bitNot = typed(name, {
+  return typed(name, {
     number: bitNotNumber,
 
     BigNumber: bitNotBigNumber,
 
     'Array | Matrix': function (x) {
-      return deepMap(x, bitNot)
+      return deepMap(x, this)
     }
   })
-
-  return bitNot
 })

--- a/src/function/bitwise/bitOr.js
+++ b/src/function/bitwise/bitOr.js
@@ -45,69 +45,67 @@ export const createBitOr = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param  {number | BigNumber | Array | Matrix} y Second value to or
    * @return {number | BigNumber | Array | Matrix} OR of `x` and `y`
    */
-  const bitOr = typed(name, {
+  return typed(name, {
 
     'number, number': bitOrNumber,
 
     'BigNumber, BigNumber': bitOrBigNumber,
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm04(x, y, bitOr)
+      return algorithm04(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm01(y, x, bitOr, true)
+      return algorithm01(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm01(x, y, bitOr, false)
+      return algorithm01(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, bitOr)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return bitOr(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return bitOr(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return bitOr(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm10(x, y, bitOr, false)
+      return algorithm10(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, bitOr, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm10(y, x, bitOr, true)
+      return algorithm10(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, bitOr, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, bitOr, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, bitOr, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return bitOr
 })

--- a/src/function/bitwise/bitXor.js
+++ b/src/function/bitwise/bitXor.js
@@ -43,69 +43,67 @@ export const createBitXor = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param  {number | BigNumber | Array | Matrix} y Second value to xor
    * @return {number | BigNumber | Array | Matrix} XOR of `x` and `y`
    */
-  const bitXor = typed(name, {
+  return typed(name, {
 
     'number, number': bitXorNumber,
 
     'BigNumber, BigNumber': bigBitXor,
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm07(x, y, bitXor)
+      return algorithm07(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, bitXor, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, bitXor, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, bitXor)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return bitXor(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return bitXor(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return bitXor(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, bitXor, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, bitXor, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, bitXor, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, bitXor, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, bitXor, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, bitXor, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return bitXor
 })

--- a/src/function/bitwise/leftShift.js
+++ b/src/function/bitwise/leftShift.js
@@ -50,41 +50,41 @@ export const createLeftShift = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @param  {number | BigNumber} y Amount of shifts
    * @return {number | BigNumber | Array | Matrix} `x` shifted left `y` times
    */
-  const leftShift = typed(name, {
+  return typed(name, {
 
     'number, number': leftShiftNumber,
 
     'BigNumber, BigNumber': leftShiftBigNumber,
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm08(x, y, leftShift, false)
+      return algorithm08(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, leftShift, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm01(x, y, leftShift, false)
+      return algorithm01(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, leftShift)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return leftShift(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return leftShift(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return leftShift(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
@@ -92,7 +92,7 @@ export const createLeftShift = /* #__PURE__ */ factory(name, dependencies, ({ ty
       if (equalScalar(y, 0)) {
         return x.clone()
       }
-      return algorithm11(x, y, leftShift, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
@@ -100,7 +100,7 @@ export const createLeftShift = /* #__PURE__ */ factory(name, dependencies, ({ ty
       if (equalScalar(y, 0)) {
         return x.clone()
       }
-      return algorithm14(x, y, leftShift, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
@@ -108,7 +108,7 @@ export const createLeftShift = /* #__PURE__ */ factory(name, dependencies, ({ ty
       if (equalScalar(x, 0)) {
         return zeros(y.size(), y.storage())
       }
-      return algorithm10(y, x, leftShift, true)
+      return algorithm10(y, x, this, true)
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
@@ -116,19 +116,17 @@ export const createLeftShift = /* #__PURE__ */ factory(name, dependencies, ({ ty
       if (equalScalar(x, 0)) {
         return zeros(y.size(), y.storage())
       }
-      return algorithm14(y, x, leftShift, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return leftShift(matrix(x), y).valueOf()
+      return this(matrix(x), y).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return leftShift(x, matrix(y)).valueOf()
+      return this(x, matrix(y)).valueOf()
     }
   })
-
-  return leftShift
 })

--- a/src/function/bitwise/rightArithShift.js
+++ b/src/function/bitwise/rightArithShift.js
@@ -50,41 +50,41 @@ export const createRightArithShift = /* #__PURE__ */ factory(name, dependencies,
    * @param  {number | BigNumber} y Amount of shifts
    * @return {number | BigNumber | Array | Matrix} `x` sign-filled shifted right `y` times
    */
-  const rightArithShift = typed(name, {
+  return typed(name, {
 
     'number, number': rightArithShiftNumber,
 
     'BigNumber, BigNumber': rightArithShiftBigNumber,
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm08(x, y, rightArithShift, false)
+      return algorithm08(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, rightArithShift, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm01(x, y, rightArithShift, false)
+      return algorithm01(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, rightArithShift)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return rightArithShift(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return rightArithShift(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return rightArithShift(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
@@ -92,7 +92,7 @@ export const createRightArithShift = /* #__PURE__ */ factory(name, dependencies,
       if (equalScalar(y, 0)) {
         return x.clone()
       }
-      return algorithm11(x, y, rightArithShift, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
@@ -100,7 +100,7 @@ export const createRightArithShift = /* #__PURE__ */ factory(name, dependencies,
       if (equalScalar(y, 0)) {
         return x.clone()
       }
-      return algorithm14(x, y, rightArithShift, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
@@ -108,7 +108,7 @@ export const createRightArithShift = /* #__PURE__ */ factory(name, dependencies,
       if (equalScalar(x, 0)) {
         return zeros(y.size(), y.storage())
       }
-      return algorithm10(y, x, rightArithShift, true)
+      return algorithm10(y, x, this, true)
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
@@ -116,19 +116,17 @@ export const createRightArithShift = /* #__PURE__ */ factory(name, dependencies,
       if (equalScalar(x, 0)) {
         return zeros(y.size(), y.storage())
       }
-      return algorithm14(y, x, rightArithShift, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return rightArithShift(matrix(x), y).valueOf()
+      return this(matrix(x), y).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return rightArithShift(x, matrix(y)).valueOf()
+      return this(x, matrix(y)).valueOf()
     }
   })
-
-  return rightArithShift
 })

--- a/src/function/bitwise/rightLogShift.js
+++ b/src/function/bitwise/rightLogShift.js
@@ -50,41 +50,41 @@ export const createRightLogShift = /* #__PURE__ */ factory(name, dependencies, (
    * @return {number | Array | Matrix} `x` zero-filled shifted right `y` times
    */
 
-  const rightLogShift = typed(name, {
+  return typed(name, {
 
     'number, number': rightLogShiftNumber,
 
     // 'BigNumber, BigNumber': ..., // TODO: implement BigNumber support for rightLogShift
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm08(x, y, rightLogShift, false)
+      return algorithm08(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, rightLogShift, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm01(x, y, rightLogShift, false)
+      return algorithm01(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, rightLogShift)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return rightLogShift(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return rightLogShift(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return rightLogShift(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
@@ -92,7 +92,7 @@ export const createRightLogShift = /* #__PURE__ */ factory(name, dependencies, (
       if (equalScalar(y, 0)) {
         return x.clone()
       }
-      return algorithm11(x, y, rightLogShift, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
@@ -100,7 +100,7 @@ export const createRightLogShift = /* #__PURE__ */ factory(name, dependencies, (
       if (equalScalar(y, 0)) {
         return x.clone()
       }
-      return algorithm14(x, y, rightLogShift, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
@@ -108,7 +108,7 @@ export const createRightLogShift = /* #__PURE__ */ factory(name, dependencies, (
       if (equalScalar(x, 0)) {
         return zeros(y.size(), y.storage())
       }
-      return algorithm10(y, x, rightLogShift, true)
+      return algorithm10(y, x, this, true)
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
@@ -116,19 +116,17 @@ export const createRightLogShift = /* #__PURE__ */ factory(name, dependencies, (
       if (equalScalar(x, 0)) {
         return zeros(y.size(), y.storage())
       }
-      return algorithm14(y, x, rightLogShift, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
       // use matrix implementation
-      return rightLogShift(matrix(x), y).valueOf()
+      return this(matrix(x), y).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
       // use matrix implementation
-      return rightLogShift(x, matrix(y)).valueOf()
+      return this(x, matrix(y)).valueOf()
     }
   })
-
-  return rightLogShift
 })

--- a/src/function/complex/arg.js
+++ b/src/function/complex/arg.js
@@ -32,7 +32,7 @@ export const createArg = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    *            A complex number or array with complex numbers
    * @return {number | BigNumber | Array | Matrix} The argument of x
    */
-  const arg = typed(name, {
+  return typed(name, {
     number: function (x) {
       return Math.atan2(0, x)
     },
@@ -48,9 +48,7 @@ export const createArg = /* #__PURE__ */ factory(name, dependencies, ({ typed })
     // TODO: implement BigNumber support for function arg
 
     'Array | Matrix': function (x) {
-      return deepMap(x, arg)
+      return deepMap(x, this)
     }
   })
-
-  return arg
 })

--- a/src/function/complex/conj.js
+++ b/src/function/complex/conj.js
@@ -30,7 +30,7 @@ export const createConj = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    * @return {number | BigNumber | Complex | Array | Matrix}
    *            The complex conjugate of x
    */
-  const conj = typed(name, {
+  return typed(name, {
     number: function (x) {
       return x
     },
@@ -44,9 +44,7 @@ export const createConj = /* #__PURE__ */ factory(name, dependencies, ({ typed }
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, conj)
+      return deepMap(x, this)
     }
   })
-
-  return conj
 })

--- a/src/function/complex/im.js
+++ b/src/function/complex/im.js
@@ -32,7 +32,7 @@ export const createIm = /* #__PURE__ */ factory(name, dependencies, ({ typed }) 
    *            A complex number or array with complex numbers
    * @return {number | BigNumber | Array | Matrix} The imaginary part of x
    */
-  const im = typed(name, {
+  return typed(name, {
     number: function (x) {
       return 0
     },
@@ -46,9 +46,7 @@ export const createIm = /* #__PURE__ */ factory(name, dependencies, ({ typed }) 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, im)
+      return deepMap(x, this)
     }
   })
-
-  return im
 })

--- a/src/function/complex/re.js
+++ b/src/function/complex/re.js
@@ -32,7 +32,7 @@ export const createRe = /* #__PURE__ */ factory(name, dependencies, ({ typed }) 
    *            A complex number or array with complex numbers
    * @return {number | BigNumber | Array | Matrix} The real part of x
    */
-  const re = typed(name, {
+  return typed(name, {
     number: function (x) {
       return x
     },
@@ -46,9 +46,7 @@ export const createRe = /* #__PURE__ */ factory(name, dependencies, ({ typed }) 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, re)
+      return deepMap(x, this)
     }
   })
-
-  return re
 })

--- a/src/function/geometry/intersect.js
+++ b/src/function/geometry/intersect.js
@@ -34,7 +34,7 @@ export const createIntersect = /* #__PURE__ */ factory(name, dependencies, ({ ty
    *                              OR null if the calculation is for line and plane
    * @return {Array}              Returns the point of intersection of lines/lines-planes
    */
-  const intersect = typed('intersect', {
+  return typed('intersect', {
     'Array, Array, Array': function (x, y, plane) {
       if (!_3d(x)) { throw new TypeError('Array with 3 numbers or BigNumbers expected for first argument') }
       if (!_3d(y)) { throw new TypeError('Array with 3 numbers or BigNumbers expected for second argument') }
@@ -157,6 +157,4 @@ export const createIntersect = /* #__PURE__ */ factory(name, dependencies, ({ ty
     //       (a) no intersection,
     //       (b) line contained in plane
   }
-
-  return intersect
 })

--- a/src/function/geometry/intersect.js
+++ b/src/function/geometry/intersect.js
@@ -64,12 +64,12 @@ export const createIntersect = /* #__PURE__ */ factory(name, dependencies, ({ ty
     },
 
     'Matrix, Matrix, Matrix': function (x, y, plane) {
-      return matrix(intersect(x.valueOf(), y.valueOf(), plane.valueOf()))
+      return matrix(this(x.valueOf(), y.valueOf(), plane.valueOf()))
     },
 
     'Matrix, Matrix, Matrix, Matrix': function (w, x, y, z) {
       // TODO: output matrix type should match input matrix type
-      return matrix(intersect(w.valueOf(), x.valueOf(), y.valueOf(), z.valueOf()))
+      return matrix(this(w.valueOf(), x.valueOf(), y.valueOf(), z.valueOf()))
     }
   })
 

--- a/src/function/logical/and.js
+++ b/src/function/logical/and.js
@@ -50,7 +50,7 @@ export const createAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
    * @return {boolean | Array | Matrix}
    *            Returns true when both inputs are defined with a nonzero/nonempty value.
    */
-  const and = typed(name, {
+  return typed(name, {
 
     'number, number': andNumber,
 
@@ -63,38 +63,38 @@ export const createAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     },
 
     'Unit, Unit': function (x, y) {
-      return and(x.value || 0, y.value || 0)
+      return this(x.value || 0, y.value || 0)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm06(x, y, and, false)
+      return algorithm06(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm02(y, x, and, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm02(x, y, and, false)
+      return algorithm02(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, and)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return and(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return and(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return and(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -103,7 +103,7 @@ export const createAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
         // return zero matrix
         return zeros(x.size(), x.storage())
       }
-      return algorithm11(x, y, and, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
@@ -112,7 +112,7 @@ export const createAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
         // return zero matrix
         return zeros(x.size(), x.storage())
       }
-      return algorithm14(x, y, and, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
@@ -121,7 +121,7 @@ export const createAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
         // return zero matrix
         return zeros(x.size(), x.storage())
       }
-      return algorithm11(y, x, and, true)
+      return algorithm11(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
@@ -130,19 +130,17 @@ export const createAnd = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
         // return zero matrix
         return zeros(x.size(), x.storage())
       }
-      return algorithm14(y, x, and, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return and(matrix(x), y).valueOf()
+      return this(matrix(x), y).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return and(x, matrix(y)).valueOf()
+      return this(x, matrix(y)).valueOf()
     }
   })
-
-  return and
 })

--- a/src/function/logical/not.js
+++ b/src/function/logical/not.js
@@ -31,7 +31,7 @@ export const createNot = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @return {boolean | Array | Matrix}
    *            Returns true when input is a zero or empty value.
    */
-  const not = typed(name, {
+  return typed(name, {
     number: notNumber,
 
     Complex: function (x) {
@@ -43,13 +43,11 @@ export const createNot = /* #__PURE__ */ factory(name, dependencies, ({ typed })
     },
 
     Unit: function (x) {
-      return x.value !== null ? not(x.value) : true
+      return x.value !== null ? this(x.value) : true
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, not)
+      return deepMap(x, this)
     }
   })
-
-  return not
 })

--- a/src/function/logical/or.js
+++ b/src/function/logical/or.js
@@ -49,7 +49,7 @@ export const createOr = /* #__PURE__ */ factory(name, dependencies, ({ typed, ma
    * @return {boolean | Array | Matrix}
    *            Returns true when one of the inputs is defined with a nonzero/nonempty value.
    */
-  const or = typed(name, {
+  return typed(name, {
 
     'number, number': orNumber,
 
@@ -62,66 +62,64 @@ export const createOr = /* #__PURE__ */ factory(name, dependencies, ({ typed, ma
     },
 
     'Unit, Unit': function (x, y) {
-      return or(x.value || 0, y.value || 0)
+      return this(x.value || 0, y.value || 0)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm05(x, y, or)
+      return algorithm05(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, or, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, or, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, or)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return or(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return or(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return or(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, or, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, or, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, or, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, or, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, or, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, or, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return or
 })

--- a/src/function/logical/xor.js
+++ b/src/function/logical/xor.js
@@ -48,7 +48,7 @@ export const createXor = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
    * @return {boolean | Array | Matrix}
    *            Returns true when one and only one input is defined with a nonzero/nonempty value.
    */
-  const xor = typed(name, {
+  return typed(name, {
 
     'number, number': xorNumber,
 
@@ -61,66 +61,64 @@ export const createXor = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     },
 
     'Unit, Unit': function (x, y) {
-      return xor(x.value || 0, y.value || 0)
+      return this(x.value || 0, y.value || 0)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm07(x, y, xor)
+      return algorithm07(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, xor, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, xor, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, xor)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return xor(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return xor(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return xor(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, xor, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, xor, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, xor, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, xor, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, xor, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, xor, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return xor
 })

--- a/src/function/matrix/apply.js
+++ b/src/function/matrix/apply.js
@@ -39,7 +39,7 @@ export const createApply = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    *                                 return a number.
    * @return {Array | Matrix} res    The residual matrix with the function applied over some dimension.
    */
-  const apply = typed(name, {
+  return typed(name, {
     'Array | Matrix, number | BigNumber, function': function (mat, dim, callback) {
       if (!isInteger(dim)) {
         throw new TypeError('Integer number expected for dimension')
@@ -57,8 +57,6 @@ export const createApply = /* #__PURE__ */ factory(name, dependencies, ({ typed,
       }
     }
   })
-
-  return apply
 })
 
 /**

--- a/src/function/matrix/column.js
+++ b/src/function/matrix/column.js
@@ -27,15 +27,13 @@ export const createColumn = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param {number} column           The index of the column
    * @return {Array | Matrix}         The retrieved column
    */
-  const column = typed(name, {
+  return typed(name, {
     'Matrix, number': _column,
 
     'Array, number': function (value, column) {
       return _column(matrix(clone(value)), column).valueOf()
     }
   })
-
-  return column
 
   /**
    * Retrieve a column of a matrix

--- a/src/function/matrix/eigs.js
+++ b/src/function/matrix/eigs.js
@@ -35,7 +35,7 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
    * @param {Array | Matrix} x  Matrix to be diagonalized
    * @return {{values: Array, vectors: Array} | {values: Matrix, vectors: Matrix}} Object containing eigenvalues (Array or Matrix) and eigenvectors (2D Array/Matrix with eigenvectors as columns).
    */
-  const eigs = typed('eigs', {
+  return typed('eigs', {
 
     Array: function (x) {
       // check array size
@@ -370,6 +370,4 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
 
     return array
   }
-
-  return eigs
 })

--- a/src/function/matrix/row.js
+++ b/src/function/matrix/row.js
@@ -27,15 +27,13 @@ export const createRow = /* #__PURE__ */ factory(name, dependencies, ({ typed, I
    * @param {number} row              The index of the row
    * @return {Array | Matrix}         The retrieved row
    */
-  const row = typed(name, {
+  return typed(name, {
     'Matrix, number': _row,
 
     'Array, number': function (value, row) {
       return _row(matrix(clone(value)), row).valueOf()
     }
   })
-
-  return row
 
   /**
    * Retrieve a row of a matrix

--- a/src/function/matrix/sqrtm.js
+++ b/src/function/matrix/sqrtm.js
@@ -7,56 +7,6 @@ const name = 'sqrtm'
 const dependencies = ['typed', 'abs', 'add', 'multiply', 'sqrt', 'subtract', 'inv', 'size', 'max', 'identity']
 
 export const createSqrtm = /* #__PURE__ */ factory(name, dependencies, ({ typed, abs, add, multiply, sqrt, subtract, inv, size, max, identity }) => {
-  /**
-   * Calculate the principal square root of a square matrix.
-   * The principal square root matrix `X` of another matrix `A` is such that `X * X = A`.
-   *
-   * https://en.wikipedia.org/wiki/Square_root_of_a_matrix
-   *
-   * Syntax:
-   *
-   *     X = math.sqrtm(A)
-   *
-   * Examples:
-   *
-   *     math.sqrtm([[1, 2], [3, 4]]) // returns [[-2, 1], [1.5, -0.5]]
-   *
-   * See also:
-   *
-   *     sqrt, pow
-   *
-   * @param  {Array | Matrix} A   The square matrix `A`
-   * @return {Array | Matrix}     The principal square root of matrix `A`
-   */
-  const sqrtm = typed(name, {
-    'Array | Matrix': function (A) {
-      const size = isMatrix(A) ? A.size() : arraySize(A)
-      switch (size.length) {
-        case 1:
-          // Single element Array | Matrix
-          if (size[0] === 1) {
-            return sqrt(A)
-          } else {
-            throw new RangeError('Matrix must be square ' +
-            '(size: ' + format(size) + ')')
-          }
-
-        case 2:
-        {
-          // Two-dimensional Array | Matrix
-          const rows = size[0]
-          const cols = size[1]
-          if (rows === cols) {
-            return _denmanBeavers(A)
-          } else {
-            throw new RangeError('Matrix must be square ' +
-              '(size: ' + format(size) + ')')
-          }
-        }
-      }
-    }
-  })
-
   const _maxIterations = 1e3
   const _tolerance = 1e-6
 
@@ -91,5 +41,53 @@ export const createSqrtm = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     return Y
   }
 
-  return sqrtm
+  /**
+   * Calculate the principal square root of a square matrix.
+   * The principal square root matrix `X` of another matrix `A` is such that `X * X = A`.
+   *
+   * https://en.wikipedia.org/wiki/Square_root_of_a_matrix
+   *
+   * Syntax:
+   *
+   *     X = math.sqrtm(A)
+   *
+   * Examples:
+   *
+   *     math.sqrtm([[1, 2], [3, 4]]) // returns [[-2, 1], [1.5, -0.5]]
+   *
+   * See also:
+   *
+   *     sqrt, pow
+   *
+   * @param  {Array | Matrix} A   The square matrix `A`
+   * @return {Array | Matrix}     The principal square root of matrix `A`
+   */
+  return typed(name, {
+    'Array | Matrix': function (A) {
+      const size = isMatrix(A) ? A.size() : arraySize(A)
+      switch (size.length) {
+        case 1:
+          // Single element Array | Matrix
+          if (size[0] === 1) {
+            return sqrt(A)
+          } else {
+            throw new RangeError('Matrix must be square ' +
+            '(size: ' + format(size) + ')')
+          }
+
+        case 2:
+        {
+          // Two-dimensional Array | Matrix
+          const rows = size[0]
+          const cols = size[1]
+          if (rows === cols) {
+            return _denmanBeavers(A)
+          } else {
+            throw new RangeError('Matrix must be square ' +
+              '(size: ' + format(size) + ')')
+          }
+        }
+      }
+    }
+  })
 })

--- a/src/function/matrix/transpose.js
+++ b/src/function/matrix/transpose.js
@@ -28,7 +28,7 @@ export const createTranspose = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @param {Array | Matrix} x  Matrix to be transposed
    * @return {Array | Matrix}   The transposed matrix
    */
-  const transpose = typed('transpose', {
+  return typed('transpose', {
 
     Array: function (x) {
       // use dense matrix implementation
@@ -163,6 +163,4 @@ export const createTranspose = /* #__PURE__ */ factory(name, dependencies, ({ ty
       datatype: m._datatype
     })
   }
-
-  return transpose
 })

--- a/src/function/matrix/transpose.js
+++ b/src/function/matrix/transpose.js
@@ -32,7 +32,7 @@ export const createTranspose = /* #__PURE__ */ factory(name, dependencies, ({ ty
 
     Array: function (x) {
       // use dense matrix implementation
-      return transpose(matrix(x)).valueOf()
+      return this(matrix(x)).valueOf()
     },
 
     Matrix: function (x) {

--- a/src/function/probability/factorial.js
+++ b/src/function/probability/factorial.js
@@ -27,7 +27,7 @@ export const createFactorial = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @param {number | BigNumber | Array | Matrix} n   An integer number
    * @return {number | BigNumber | Array | Matrix}    The factorial of `n`
    */
-  const factorial = typed(name, {
+  return typed(name, {
     number: function (n) {
       if (n < 0) {
         throw new Error('Value must be non-negative')
@@ -45,9 +45,7 @@ export const createFactorial = /* #__PURE__ */ factory(name, dependencies, ({ ty
     },
 
     'Array | Matrix': function (n) {
-      return deepMap(n, factorial)
+      return deepMap(n, this)
     }
   })
-
-  return factorial
 })

--- a/src/function/probability/gamma.js
+++ b/src/function/probability/gamma.js
@@ -30,7 +30,7 @@ export const createGamma = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @return {number | Array | Matrix}    The gamma of `n`
    */
 
-  const gamma = typed(name, {
+  return typed(name, {
 
     number: gammaNumber,
 
@@ -123,6 +123,4 @@ export const createGamma = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     return new BigNumber(prod.toPrecision(BigNumber.precision))
   }
-
-  return gamma
 })

--- a/src/function/probability/gamma.js
+++ b/src/function/probability/gamma.js
@@ -36,7 +36,7 @@ export const createGamma = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     Complex: function (n) {
       if (n.im === 0) {
-        return gamma(n.re)
+        return this(n.re)
       }
 
       n = new Complex(n.re - 1, n.im)
@@ -90,7 +90,7 @@ export const createGamma = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (n) {
-      return deepMap(n, gamma)
+      return deepMap(n, this)
     }
   })
 

--- a/src/function/relational/compare.js
+++ b/src/function/relational/compare.js
@@ -62,7 +62,7 @@ export const createCompare = /* #__PURE__ */ factory(name, dependencies, ({ type
    * @return {number | BigNumber | Fraction | Array | Matrix} Returns the result of the comparison:
    *                                                          1 when x > y, -1 when x < y, and 0 when x == y.
    */
-  const compare = typed(name, {
+  return typed(name, {
 
     'boolean, boolean': function (x, y) {
       return x === y ? 0 : (x > y ? 1 : -1)
@@ -92,68 +92,66 @@ export const createCompare = /* #__PURE__ */ factory(name, dependencies, ({ type
       if (!x.equalBase(y)) {
         throw new Error('Cannot compare units with different base')
       }
-      return compare(x.value, y.value)
+      return this(x.value, y.value)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm05(x, y, compare)
+      return algorithm05(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, compare, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, compare, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, compare)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return compare(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return compare(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return compare(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, compare, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, compare, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, compare, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, compare, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, compare, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, compare, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return compare
 })
 
 export const createCompareNumber = /* #__PURE__ */ factory(name, ['typed', 'config'], ({ typed, config }) => {

--- a/src/function/relational/compareNatural.js
+++ b/src/function/relational/compareNatural.js
@@ -79,7 +79,7 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
    * @return {number} Returns the result of the comparison:
    *                  1 when x > y, -1 when x < y, and 0 when x == y.
    */
-  const compareNatural = typed(name, {
+  return typed(name, {
     'any, any': function (x, y) {
       const typeX = typeOf(x)
       const typeY = typeOf(y)
@@ -100,7 +100,7 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
       // matrix types
       if (typeX === 'Array' || typeX === 'Matrix' ||
           typeY === 'Array' || typeY === 'Matrix') {
-        c = compareMatricesAndArrays(x, y)
+        c = compareMatricesAndArrays(this, x, y)
         if (c !== 0) {
           return c
         } else {
@@ -123,7 +123,7 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
         }
 
         // compare by units
-        return compareArrays(x.formatUnits(), y.formatUnits())
+        return compareArrays(this, x.formatUnits(), y.formatUnits())
       }
 
       if (typeX === 'boolean') {
@@ -135,7 +135,7 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
       }
 
       if (typeX === 'Object') {
-        return compareObjects(x, y)
+        return compareObjects(this, x, y)
       }
 
       if (typeX === 'null') {
@@ -158,36 +158,36 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
    * @param {Array | SparseMatrix | DenseMatrix | *} y
    * @returns {number} Returns the comparison result: -1, 0, or 1
    */
-  function compareMatricesAndArrays (x, y) {
+  function compareMatricesAndArrays (compareNatural, x, y) {
     if (isSparseMatrix(x) && isSparseMatrix(y)) {
-      return compareArrays(x.toJSON().values, y.toJSON().values)
+      return compareArrays(compareNatural, x.toJSON().values, y.toJSON().values)
     }
     if (isSparseMatrix(x)) {
       // note: convert to array is expensive
-      return compareMatricesAndArrays(x.toArray(), y)
+      return compareMatricesAndArrays(compareNatural, x.toArray(), y)
     }
     if (isSparseMatrix(y)) {
       // note: convert to array is expensive
-      return compareMatricesAndArrays(x, y.toArray())
+      return compareMatricesAndArrays(compareNatural, x, y.toArray())
     }
 
     // convert DenseArray into Array
     if (isDenseMatrix(x)) {
-      return compareMatricesAndArrays(x.toJSON().data, y)
+      return compareMatricesAndArrays(compareNatural, x.toJSON().data, y)
     }
     if (isDenseMatrix(y)) {
-      return compareMatricesAndArrays(x, y.toJSON().data)
+      return compareMatricesAndArrays(compareNatural, x, y.toJSON().data)
     }
 
     // convert scalars to array
     if (!Array.isArray(x)) {
-      return compareMatricesAndArrays([x], y)
+      return compareMatricesAndArrays(compareNatural, [x], y)
     }
     if (!Array.isArray(y)) {
-      return compareMatricesAndArrays(x, [y])
+      return compareMatricesAndArrays(compareNatural, x, [y])
     }
 
-    return compareArrays(x, y)
+    return compareArrays(compareNatural, x, y)
   }
 
   /**
@@ -201,7 +201,7 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
    * @param {Array} y
    * @returns {number} Returns the comparison result: -1, 0, or 1
    */
-  function compareArrays (x, y) {
+  function compareArrays (compareNatural, x, y) {
     // compare each value
     for (let i = 0, ii = Math.min(x.length, y.length); i < ii; i++) {
       const v = compareNatural(x[i], y[i])
@@ -228,14 +228,14 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
    * @param {Object} y
    * @returns {number} Returns the comparison result: -1, 0, or 1
    */
-  function compareObjects (x, y) {
+  function compareObjects (compareNatural, x, y) {
     const keysX = Object.keys(x)
     const keysY = Object.keys(y)
 
     // compare keys
     keysX.sort(naturalSort)
     keysY.sort(naturalSort)
-    const c = compareArrays(keysX, keysY)
+    const c = compareArrays(compareNatural, keysX, keysY)
     if (c !== 0) {
       return c
     }
@@ -250,8 +250,6 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
 
     return 0
   }
-
-  return compareNatural
 })
 
 /**

--- a/src/function/relational/compareNatural.js
+++ b/src/function/relational/compareNatural.js
@@ -119,7 +119,7 @@ export const createCompareNatural = /* #__PURE__ */ factory(name, dependencies, 
 
       if (typeX === 'Unit') {
         if (x.equalBase(y)) {
-          return compareNatural(x.value, y.value)
+          return this(x.value, y.value)
         }
 
         // compare by units

--- a/src/function/relational/compareText.js
+++ b/src/function/relational/compareText.js
@@ -41,7 +41,7 @@ export const createCompareText = /* #__PURE__ */ factory(name, dependencies, ({ 
    * @return {number | Array | DenseMatrix} Returns the result of the comparison:
    *                                        1 when x > y, -1 when x < y, and 0 when x == y.
    */
-  const compareText = typed(name, {
+  return typed(name, {
 
     'any, any': _compareText,
 
@@ -51,17 +51,17 @@ export const createCompareText = /* #__PURE__ */ factory(name, dependencies, ({ 
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return compareText(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return compareText(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return compareText(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'DenseMatrix, any': function (x, y) {
@@ -82,8 +82,6 @@ export const createCompareText = /* #__PURE__ */ factory(name, dependencies, ({ 
       return algorithm14(matrix(y), x, _compareText, true).valueOf()
     }
   })
-
-  return compareText
 })
 
 export const createCompareTextNumber = /* #__PURE__ */ factory(name, ['typed'], ({ typed }) => {

--- a/src/function/relational/equal.js
+++ b/src/function/relational/equal.js
@@ -64,7 +64,7 @@ export const createEqual = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param  {number | BigNumber | boolean | Complex | Unit | string | Array | Matrix} y Second value to compare
    * @return {boolean | Array | Matrix} Returns true when the compared values are equal, else returns false
    */
-  const equal = typed(name, {
+  return typed(name, {
 
     'any, any': function (x, y) {
       // strict equality for null and undefined?
@@ -94,17 +94,17 @@ export const createEqual = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return equal(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return equal(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return equal(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -133,8 +133,6 @@ export const createEqual = /* #__PURE__ */ factory(name, dependencies, ({ typed,
       return algorithm14(matrix(y), x, equalScalar, true).valueOf()
     }
   })
-
-  return equal
 })
 
 export const createEqualNumber = factory(name, ['typed', 'equalScalar'], ({ typed, equalScalar }) => {

--- a/src/function/relational/equalScalar.js
+++ b/src/function/relational/equalScalar.js
@@ -15,7 +15,7 @@ export const createEqualScalar = /* #__PURE__ */ factory(name, dependencies, ({ 
    * @return {boolean}                                                  Returns true when the compared values are equal, else returns false
    * @private
    */
-  const equalScalar = typed(name, {
+  return typed(name, {
 
     'boolean, boolean': function (x, y) {
       return x === y
@@ -41,11 +41,9 @@ export const createEqualScalar = /* #__PURE__ */ factory(name, dependencies, ({ 
       if (!x.equalBase(y)) {
         throw new Error('Cannot compare units with different base')
       }
-      return equalScalar(x.value, y.value)
+      return this(x.value, y.value)
     }
   })
-
-  return equalScalar
 })
 
 export const createEqualScalarNumber = factory(name, ['typed', 'config'], ({ typed, config }) => {

--- a/src/function/relational/larger.js
+++ b/src/function/relational/larger.js
@@ -53,7 +53,7 @@ export const createLarger = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param  {number | BigNumber | Fraction | boolean | Unit | string | Array | Matrix} y Second value to compare
    * @return {boolean | Array | Matrix} Returns true when the x is larger than y, else returns false
    */
-  const larger = typed(name, {
+  return typed(name, {
 
     'boolean, boolean': function (x, y) {
       return x > y
@@ -79,68 +79,66 @@ export const createLarger = /* #__PURE__ */ factory(name, dependencies, ({ typed
       if (!x.equalBase(y)) {
         throw new Error('Cannot compare units with different base')
       }
-      return larger(x.value, y.value)
+      return this(x.value, y.value)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm07(x, y, larger)
+      return algorithm07(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, larger, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, larger, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, larger)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return larger(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return larger(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return larger(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, larger, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, larger, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, larger, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, larger, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, larger, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, larger, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return larger
 })
 
 export const createLargerNumber = /* #__PURE__ */ factory(name, ['typed', 'config'], ({ typed, config }) => {

--- a/src/function/relational/largerEq.js
+++ b/src/function/relational/largerEq.js
@@ -49,7 +49,7 @@ export const createLargerEq = /* #__PURE__ */ factory(name, dependencies, ({ typ
    * @param  {number | BigNumber | Fraction | boolean | Unit | string | Array | Matrix} y Second value to compare
    * @return {boolean | Array | Matrix} Returns true when the x is larger or equal to y, else returns false
    */
-  const largerEq = typed(name, {
+  return typed(name, {
 
     'boolean, boolean': function (x, y) {
       return x >= y
@@ -75,68 +75,66 @@ export const createLargerEq = /* #__PURE__ */ factory(name, dependencies, ({ typ
       if (!x.equalBase(y)) {
         throw new Error('Cannot compare units with different base')
       }
-      return largerEq(x.value, y.value)
+      return this(x.value, y.value)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm07(x, y, largerEq)
+      return algorithm07(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, largerEq, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, largerEq, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, largerEq)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return largerEq(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return largerEq(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return largerEq(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, largerEq, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, largerEq, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, largerEq, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, largerEq, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, largerEq, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, largerEq, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return largerEq
 })
 
 export const createLargerEqNumber = /* #__PURE__ */ factory(name, ['typed', 'config'], ({ typed, config }) => {

--- a/src/function/relational/smaller.js
+++ b/src/function/relational/smaller.js
@@ -53,7 +53,7 @@ export const createSmaller = /* #__PURE__ */ factory(name, dependencies, ({ type
    * @param  {number | BigNumber | Fraction | boolean | Unit | string | Array | Matrix} y Second value to compare
    * @return {boolean | Array | Matrix} Returns true when the x is smaller than y, else returns false
    */
-  const smaller = typed(name, {
+  return typed(name, {
 
     'boolean, boolean': function (x, y) {
       return x < y
@@ -79,68 +79,66 @@ export const createSmaller = /* #__PURE__ */ factory(name, dependencies, ({ type
       if (!x.equalBase(y)) {
         throw new Error('Cannot compare units with different base')
       }
-      return smaller(x.value, y.value)
+      return this(x.value, y.value)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm07(x, y, smaller)
+      return algorithm07(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, smaller, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, smaller, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, smaller)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return smaller(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return smaller(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return smaller(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, smaller, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, smaller, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, smaller, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, smaller, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, smaller, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, smaller, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return smaller
 })
 
 export const createSmallerNumber = /* #__PURE__ */ factory(name, ['typed', 'config'], ({ typed, config }) => {

--- a/src/function/relational/smallerEq.js
+++ b/src/function/relational/smallerEq.js
@@ -49,7 +49,7 @@ export const createSmallerEq = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @param  {number | BigNumber | Fraction | boolean | Unit | string | Array | Matrix} y Second value to compare
    * @return {boolean | Array | Matrix} Returns true when the x is smaller than y, else returns false
    */
-  const smallerEq = typed(name, {
+  return typed(name, {
 
     'boolean, boolean': function (x, y) {
       return x <= y
@@ -75,68 +75,66 @@ export const createSmallerEq = /* #__PURE__ */ factory(name, dependencies, ({ ty
       if (!x.equalBase(y)) {
         throw new Error('Cannot compare units with different base')
       }
-      return smallerEq(x.value, y.value)
+      return this(x.value, y.value)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm07(x, y, smallerEq)
+      return algorithm07(x, y, this)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
-      return algorithm03(y, x, smallerEq, true)
+      return algorithm03(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, smallerEq, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, smallerEq)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return smallerEq(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return smallerEq(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return smallerEq(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
-      return algorithm12(x, y, smallerEq, false)
+      return algorithm12(x, y, this, false)
     },
 
     'DenseMatrix, any': function (x, y) {
-      return algorithm14(x, y, smallerEq, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, SparseMatrix': function (x, y) {
-      return algorithm12(y, x, smallerEq, true)
+      return algorithm12(y, x, this, true)
     },
 
     'any, DenseMatrix': function (x, y) {
-      return algorithm14(y, x, smallerEq, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, smallerEq, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, smallerEq, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return smallerEq
 })
 
 export const createSmallerEqNumber = /* #__PURE__ */ factory(name, ['typed', 'config'], ({ typed, config }) => {

--- a/src/function/relational/unequal.js
+++ b/src/function/relational/unequal.js
@@ -64,7 +64,7 @@ export const createUnequal = /* #__PURE__ */ factory(name, dependencies, ({ type
    * @param  {number | BigNumber | Fraction | boolean | Complex | Unit | string | Array | Matrix | undefined} y Second value to compare
    * @return {boolean | Array | Matrix} Returns true when the compared values are unequal, else returns false
    */
-  const unequal = typed('unequal', {
+  return typed('unequal', {
 
     'any, any': function (x, y) {
       // strict equality for null and undefined?
@@ -94,17 +94,17 @@ export const createUnequal = /* #__PURE__ */ factory(name, dependencies, ({ type
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return unequal(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return unequal(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return unequal(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, any': function (x, y) {
@@ -137,8 +137,6 @@ export const createUnequal = /* #__PURE__ */ factory(name, dependencies, ({ type
   function _unequal (x, y) {
     return !equalScalar(x, y)
   }
-
-  return unequal
 })
 
 export const createUnequalNumber = factory(name, ['typed', 'equalScalar'], ({ typed, equalScalar }) => {

--- a/src/function/special/erf.js
+++ b/src/function/special/erf.js
@@ -32,7 +32,7 @@ export const createErf = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @param {number | Array | Matrix} x   A real number
    * @return {number | Array | Matrix}    The erf of `x`
    */
-  const erf = typed('name', {
+  return typed('name', {
     number: function (x) {
       const y = Math.abs(x)
 
@@ -123,8 +123,6 @@ export const createErf = /* #__PURE__ */ factory(name, dependencies, ({ typed })
     const del = (y - ysq) * (y + ysq)
     return Math.exp(-ysq * ysq) * Math.exp(-del) * result
   }
-
-  return erf
 })
 
 /**

--- a/src/function/special/erf.js
+++ b/src/function/special/erf.js
@@ -49,7 +49,7 @@ export const createErf = /* #__PURE__ */ factory(name, dependencies, ({ typed })
     },
 
     'Array | Matrix': function (n) {
-      return deepMap(n, erf)
+      return deepMap(n, this)
     }
 
     // TODO: For complex numbers, use the approximation for the Faddeeva function

--- a/src/function/statistics/median.js
+++ b/src/function/statistics/median.js
@@ -8,53 +8,6 @@ const dependencies = ['typed', 'add', 'divide', 'compare', 'partitionSelect']
 
 export const createMedian = /* #__PURE__ */ factory(name, dependencies, ({ typed, add, divide, compare, partitionSelect }) => {
   /**
-   * Compute the median of a matrix or a list with values. The values are
-   * sorted and the middle value is returned. In case of an even number of
-   * values, the average of the two middle values is returned.
-   * Supported types of values are: Number, BigNumber, Unit
-   *
-   * In case of a (multi dimensional) array or matrix, the median of all
-   * elements will be calculated.
-   *
-   * Syntax:
-   *
-   *     math.median(a, b, c, ...)
-   *     math.median(A)
-   *
-   * Examples:
-   *
-   *     math.median(5, 2, 7)        // returns 5
-   *     math.median([3, -1, 5, 7])  // returns 4
-   *
-   * See also:
-   *
-   *     mean, min, max, sum, prod, std, variance, quantileSeq
-   *
-   * @param {... *} args  A single matrix or or multiple scalar values
-   * @return {*} The median
-   */
-  const median = typed(name, {
-    // median([a, b, c, d, ...])
-    'Array | Matrix': _median,
-
-    // median([a, b, c, d, ...], dim)
-    'Array | Matrix, number | BigNumber': function (array, dim) {
-      // TODO: implement median(A, dim)
-      throw new Error('median(A, dim) is not yet supported')
-      // return reduce(arguments[0], arguments[1], ...)
-    },
-
-    // median(a, b, c, d, ...)
-    '...': function (args) {
-      if (containsCollections(args)) {
-        throw new TypeError('Scalar values expected in function median')
-      }
-
-      return _median(args)
-    }
-  })
-
-  /**
    * Recursively calculate the median of an n-dimensional array
    * @param {Array} array
    * @return {Number} median
@@ -108,5 +61,50 @@ export const createMedian = /* #__PURE__ */ factory(name, dependencies, ({ typed
     }
   })
 
-  return median
+  /**
+   * Compute the median of a matrix or a list with values. The values are
+   * sorted and the middle value is returned. In case of an even number of
+   * values, the average of the two middle values is returned.
+   * Supported types of values are: Number, BigNumber, Unit
+   *
+   * In case of a (multi dimensional) array or matrix, the median of all
+   * elements will be calculated.
+   *
+   * Syntax:
+   *
+   *     math.median(a, b, c, ...)
+   *     math.median(A)
+   *
+   * Examples:
+   *
+   *     math.median(5, 2, 7)        // returns 5
+   *     math.median([3, -1, 5, 7])  // returns 4
+   *
+   * See also:
+   *
+   *     mean, min, max, sum, prod, std, variance, quantileSeq
+   *
+   * @param {... *} args  A single matrix or or multiple scalar values
+   * @return {*} The median
+   */
+  return typed(name, {
+    // median([a, b, c, d, ...])
+    'Array | Matrix': _median,
+
+    // median([a, b, c, d, ...], dim)
+    'Array | Matrix, number | BigNumber': function (array, dim) {
+      // TODO: implement median(A, dim)
+      throw new Error('median(A, dim) is not yet supported')
+      // return reduce(arguments[0], arguments[1], ...)
+    },
+
+    // median(a, b, c, d, ...)
+    '...': function (args) {
+      if (containsCollections(args)) {
+        throw new TypeError('Scalar values expected in function median')
+      }
+
+      return _median(args)
+    }
+  })
 })

--- a/src/function/trigonometry/acos.js
+++ b/src/function/trigonometry/acos.js
@@ -28,7 +28,7 @@ export const createAcos = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | BigNumber | Complex | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} The arc cosine of x
    */
-  const acos = typed(name, {
+  return typed(name, {
     number: function (x) {
       if ((x >= -1 && x <= 1) || config.predictable) {
         return Math.acos(x)
@@ -46,9 +46,7 @@ export const createAcos = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, acos)
+      return deepMap(x, this)
     }
   })
-
-  return acos
 })

--- a/src/function/trigonometry/acosh.js
+++ b/src/function/trigonometry/acosh.js
@@ -27,7 +27,7 @@ export const createAcosh = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic arccosine of x
    */
-  const acosh = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x >= 1 || config.predictable) {
         return acoshNumber(x)
@@ -47,9 +47,7 @@ export const createAcosh = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, acosh)
+      return deepMap(x, this)
     }
   })
-
-  return acosh
 })

--- a/src/function/trigonometry/acot.js
+++ b/src/function/trigonometry/acot.js
@@ -29,7 +29,7 @@ export const createAcot = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | Complex | Array | Matrix} x   Function input
    * @return {number | Complex | Array | Matrix} The arc cotangent of x
    */
-  const acot = typed(name, {
+  return typed(name, {
     number: acotNumber,
 
     Complex: function (x) {
@@ -41,9 +41,7 @@ export const createAcot = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, acot)
+      return deepMap(x, this)
     }
   })
-
-  return acot
 })

--- a/src/function/trigonometry/acoth.js
+++ b/src/function/trigonometry/acoth.js
@@ -27,7 +27,7 @@ export const createAcoth = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | Complex | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic arccotangent of x
    */
-  const acoth = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x >= 1 || x <= -1 || config.predictable) {
         return acothNumber(x)
@@ -44,9 +44,7 @@ export const createAcoth = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, acoth)
+      return deepMap(x, this)
     }
   })
-
-  return acoth
 })

--- a/src/function/trigonometry/acsc.js
+++ b/src/function/trigonometry/acsc.js
@@ -29,7 +29,7 @@ export const createAcsc = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | Complex | Array | Matrix} x   Function input
    * @return {number | Complex | Array | Matrix} The arc cosecant of x
    */
-  const acsc = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x <= -1 || x >= 1 || config.predictable) {
         return acscNumber(x)
@@ -46,9 +46,7 @@ export const createAcsc = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, acsc)
+      return deepMap(x, this)
     }
   })
-
-  return acsc
 })

--- a/src/function/trigonometry/acsch.js
+++ b/src/function/trigonometry/acsch.js
@@ -27,7 +27,7 @@ export const createAcsch = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | Complex | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic arccosecant of x
    */
-  const acsch = typed(name, {
+  return typed(name, {
     number: acschNumber,
 
     Complex: function (x) {
@@ -39,9 +39,7 @@ export const createAcsch = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, acsch)
+      return deepMap(x, this)
     }
   })
-
-  return acsch
 })

--- a/src/function/trigonometry/asec.js
+++ b/src/function/trigonometry/asec.js
@@ -29,7 +29,7 @@ export const createAsec = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | Complex | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} The arc secant of x
    */
-  const asec = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x <= -1 || x >= 1 || config.predictable) {
         return asecNumber(x)
@@ -46,9 +46,7 @@ export const createAsec = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, asec)
+      return deepMap(x, this)
     }
   })
-
-  return asec
 })

--- a/src/function/trigonometry/asech.js
+++ b/src/function/trigonometry/asech.js
@@ -27,7 +27,7 @@ export const createAsech = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | Complex | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic arcsecant of x
    */
-  const asech = typed(name, {
+  return typed(name, {
     number: function (x) {
       if ((x <= 1 && x >= -1) || config.predictable) {
         const xInv = 1 / x
@@ -51,9 +51,7 @@ export const createAsech = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, asech)
+      return deepMap(x, this)
     }
   })
-
-  return asech
 })

--- a/src/function/trigonometry/asin.js
+++ b/src/function/trigonometry/asin.js
@@ -28,7 +28,7 @@ export const createAsin = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | BigNumber | Complex | Array | Matrix} x   Function input
    * @return {number | BigNumber | Complex | Array | Matrix} The arc sine of x
    */
-  const asin = typed(name, {
+  return typed(name, {
     number: function (x) {
       if ((x >= -1 && x <= 1) || config.predictable) {
         return Math.asin(x)
@@ -47,9 +47,7 @@ export const createAsin = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since asin(0) = 0
-      return deepMap(x, asin, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return asin
 })

--- a/src/function/trigonometry/asinh.js
+++ b/src/function/trigonometry/asinh.js
@@ -27,7 +27,7 @@ export const createAsinh = /* #__PURE__ */ factory(name, dependencies, ({ typed 
    * @param {number | Complex | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic arcsine of x
    */
-  const asinh = typed('asinh', {
+  return typed('asinh', {
     number: asinhNumber,
 
     Complex: function (x) {
@@ -40,9 +40,7 @@ export const createAsinh = /* #__PURE__ */ factory(name, dependencies, ({ typed 
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since asinh(0) = 0
-      return deepMap(x, asinh, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return asinh
 })

--- a/src/function/trigonometry/atan.js
+++ b/src/function/trigonometry/atan.js
@@ -28,7 +28,7 @@ export const createAtan = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    * @param {number | BigNumber | Complex | Array | Matrix} x   Function input
    * @return {number | BigNumber | Complex | Array | Matrix} The arc tangent of x
    */
-  const atan = typed('atan', {
+  return typed('atan', {
     number: function (x) {
       return Math.atan(x)
     },
@@ -43,9 +43,7 @@ export const createAtan = /* #__PURE__ */ factory(name, dependencies, ({ typed }
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since atan(0) = 0
-      return deepMap(x, atan, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return atan
 })

--- a/src/function/trigonometry/atan2.js
+++ b/src/function/trigonometry/atan2.js
@@ -54,7 +54,7 @@ export const createAtan2 = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | Array | Matrix} x  First dimension
    * @return {number | Array | Matrix} Four-quadrant inverse tangent
    */
-  const atan2 = typed(name, {
+  return typed(name, {
 
     'number, number': Math.atan2,
 
@@ -67,60 +67,58 @@ export const createAtan2 = /* #__PURE__ */ factory(name, dependencies, ({ typed,
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {
-      return algorithm09(x, y, atan2, false)
+      return algorithm09(x, y, this, false)
     },
 
     'SparseMatrix, DenseMatrix': function (x, y) {
       // mind the order of y and x!
-      return algorithm02(y, x, atan2, true)
+      return algorithm02(y, x, this, true)
     },
 
     'DenseMatrix, SparseMatrix': function (x, y) {
-      return algorithm03(x, y, atan2, false)
+      return algorithm03(x, y, this, false)
     },
 
     'DenseMatrix, DenseMatrix': function (x, y) {
-      return algorithm13(x, y, atan2)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
-      return atan2(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
-      return atan2(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
-      return atan2(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'SparseMatrix, number | BigNumber': function (x, y) {
-      return algorithm11(x, y, atan2, false)
+      return algorithm11(x, y, this, false)
     },
 
     'DenseMatrix, number | BigNumber': function (x, y) {
-      return algorithm14(x, y, atan2, false)
+      return algorithm14(x, y, this, false)
     },
 
     'number | BigNumber, SparseMatrix': function (x, y) {
       // mind the order of y and x
-      return algorithm12(y, x, atan2, true)
+      return algorithm12(y, x, this, true)
     },
 
     'number | BigNumber, DenseMatrix': function (x, y) {
       // mind the order of y and x
-      return algorithm14(y, x, atan2, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, number | BigNumber': function (x, y) {
-      return algorithm14(matrix(x), y, atan2, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'number | BigNumber, Array': function (x, y) {
-      return algorithm14(matrix(y), x, atan2, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return atan2
 })

--- a/src/function/trigonometry/atanh.js
+++ b/src/function/trigonometry/atanh.js
@@ -27,7 +27,7 @@ export const createAtanh = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    * @param {number | Complex | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic arctangent of x
    */
-  const atanh = typed(name, {
+  return typed(name, {
     number: function (x) {
       if ((x <= 1 && x >= -1) || config.predictable) {
         return atanhNumber(x)
@@ -45,9 +45,7 @@ export const createAtanh = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since atanh(0) = 0
-      return deepMap(x, atanh, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return atanh
 })

--- a/src/function/trigonometry/cos.js
+++ b/src/function/trigonometry/cos.js
@@ -31,7 +31,7 @@ export const createCos = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @param {number | BigNumber | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} Cosine of x
    */
-  const cos = typed(name, {
+  return typed(name, {
     number: Math.cos,
 
     Complex: function (x) {
@@ -46,13 +46,11 @@ export const createCos = /* #__PURE__ */ factory(name, dependencies, ({ typed })
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function cos is no angle')
       }
-      return cos(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, cos)
+      return deepMap(x, this)
     }
   })
-
-  return cos
 })

--- a/src/function/trigonometry/cosh.js
+++ b/src/function/trigonometry/cosh.js
@@ -27,7 +27,7 @@ export const createCosh = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    * @param {number | BigNumber | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} Hyperbolic cosine of x
    */
-  const cosh = typed(name, {
+  return typed(name, {
     number: coshNumber,
 
     Complex: function (x) {
@@ -42,13 +42,11 @@ export const createCosh = /* #__PURE__ */ factory(name, dependencies, ({ typed }
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function cosh is no angle')
       }
-      return cosh(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, cosh)
+      return deepMap(x, this)
     }
   })
-
-  return cosh
 })

--- a/src/function/trigonometry/cot.js
+++ b/src/function/trigonometry/cot.js
@@ -27,7 +27,7 @@ export const createCot = /* #__PURE__ */ factory(name, dependencies, ({ typed, B
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Cotangent of x
    */
-  const cot = typed(name, {
+  return typed(name, {
     number: cotNumber,
 
     Complex: function (x) {
@@ -42,13 +42,11 @@ export const createCot = /* #__PURE__ */ factory(name, dependencies, ({ typed, B
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function cot is no angle')
       }
-      return cot(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, cot)
+      return deepMap(x, this)
     }
   })
-
-  return cot
 })

--- a/src/function/trigonometry/coth.js
+++ b/src/function/trigonometry/coth.js
@@ -29,7 +29,7 @@ export const createCoth = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic cotangent of x
    */
-  const coth = typed(name, {
+  return typed(name, {
     number: cothNumber,
 
     Complex: function (x) {
@@ -44,13 +44,11 @@ export const createCoth = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function coth is no angle')
       }
-      return coth(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, coth)
+      return deepMap(x, this)
     }
   })
-
-  return coth
 })

--- a/src/function/trigonometry/csc.js
+++ b/src/function/trigonometry/csc.js
@@ -27,7 +27,7 @@ export const createCsc = /* #__PURE__ */ factory(name, dependencies, ({ typed, B
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Cosecant of x
    */
-  const csc = typed(name, {
+  return typed(name, {
     number: cscNumber,
 
     Complex: function (x) {
@@ -42,13 +42,11 @@ export const createCsc = /* #__PURE__ */ factory(name, dependencies, ({ typed, B
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function csc is no angle')
       }
-      return csc(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, csc)
+      return deepMap(x, this)
     }
   })
-
-  return csc
 })

--- a/src/function/trigonometry/csch.js
+++ b/src/function/trigonometry/csch.js
@@ -29,7 +29,7 @@ export const createCsch = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic cosecant of x
    */
-  const csch = typed(name, {
+  return typed(name, {
     number: cschNumber,
 
     Complex: function (x) {
@@ -44,13 +44,11 @@ export const createCsch = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function csch is no angle')
       }
-      return csch(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, csch)
+      return deepMap(x, this)
     }
   })
-
-  return csch
 })

--- a/src/function/trigonometry/sec.js
+++ b/src/function/trigonometry/sec.js
@@ -27,7 +27,7 @@ export const createSec = /* #__PURE__ */ factory(name, dependencies, ({ typed, B
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Secant of x
    */
-  const sec = typed(name, {
+  return typed(name, {
     number: secNumber,
 
     Complex: function (x) {
@@ -42,13 +42,11 @@ export const createSec = /* #__PURE__ */ factory(name, dependencies, ({ typed, B
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function sec is no angle')
       }
-      return sec(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, sec)
+      return deepMap(x, this)
     }
   })
-
-  return sec
 })

--- a/src/function/trigonometry/sech.js
+++ b/src/function/trigonometry/sech.js
@@ -29,7 +29,7 @@ export const createSech = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    * @param {number | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | Complex | Array | Matrix} Hyperbolic secant of x
    */
-  const sech = typed(name, {
+  return typed(name, {
     number: sechNumber,
 
     Complex: function (x) {
@@ -44,13 +44,11 @@ export const createSech = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function sech is no angle')
       }
-      return sech(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, sech)
+      return deepMap(x, this)
     }
   })
-
-  return sech
 })

--- a/src/function/trigonometry/sin.js
+++ b/src/function/trigonometry/sin.js
@@ -31,7 +31,7 @@ export const createSin = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @param {number | BigNumber | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} Sine of x
    */
-  const sin = typed(name, {
+  return typed(name, {
     number: Math.sin,
 
     Complex: function (x) {
@@ -46,14 +46,12 @@ export const createSin = /* #__PURE__ */ factory(name, dependencies, ({ typed })
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function sin is no angle')
       }
-      return sin(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since sin(0) = 0
-      return deepMap(x, sin, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return sin
 })

--- a/src/function/trigonometry/sinh.js
+++ b/src/function/trigonometry/sinh.js
@@ -27,7 +27,7 @@ export const createSinh = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    * @param {number | BigNumber | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} Hyperbolic sine of x
    */
-  const sinh = typed(name, {
+  return typed(name, {
     number: sinhNumber,
 
     Complex: function (x) {
@@ -42,14 +42,12 @@ export const createSinh = /* #__PURE__ */ factory(name, dependencies, ({ typed }
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function sinh is no angle')
       }
-      return sinh(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since sinh(0) = 0
-      return deepMap(x, sinh, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return sinh
 })

--- a/src/function/trigonometry/tan.js
+++ b/src/function/trigonometry/tan.js
@@ -28,7 +28,7 @@ export const createTan = /* #__PURE__ */ factory(name, dependencies, ({ typed })
    * @param {number | BigNumber | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} Tangent of x
    */
-  const tan = typed(name, {
+  return typed(name, {
     number: Math.tan,
 
     Complex: function (x) {
@@ -43,14 +43,12 @@ export const createTan = /* #__PURE__ */ factory(name, dependencies, ({ typed })
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function tan is no angle')
       }
-      return tan(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since tan(0) = 0
-      return deepMap(x, tan, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return tan
 })

--- a/src/function/trigonometry/tanh.js
+++ b/src/function/trigonometry/tanh.js
@@ -30,7 +30,7 @@ export const createTanh = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    * @param {number | BigNumber | Complex | Unit | Array | Matrix} x  Function input
    * @return {number | BigNumber | Complex | Array | Matrix} Hyperbolic tangent of x
    */
-  const tanh = typed('tanh', {
+  return typed('tanh', {
     number: _tanh,
 
     Complex: function (x) {
@@ -45,14 +45,12 @@ export const createTanh = /* #__PURE__ */ factory(name, dependencies, ({ typed }
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
         throw new TypeError('Unit in function tanh is no angle')
       }
-      return tanh(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
       // deep map collection, skip zeros since tanh(0) = 0
-      return deepMap(x, tanh, true)
+      return deepMap(x, this, true)
     }
   })
-
-  return tanh
 })

--- a/src/function/unit/to.js
+++ b/src/function/unit/to.js
@@ -36,52 +36,49 @@ export const createTo = /* #__PURE__ */ factory(name, dependencies, ({ typed, ma
    *                                      or a unit without value.
    * @return {Unit | Array | Matrix} value with changed, fixed unit.
    */
-  const to = typed(name, {
-
+  return typed(name, {
     'Unit, Unit | string': function (x, unit) {
       return x.to(unit)
     },
 
     'Matrix, Matrix': function (x, y) {
       // SparseMatrix does not support Units
-      return algorithm13(x, y, to)
+      return algorithm13(x, y, this)
     },
 
     'Array, Array': function (x, y) {
       // use matrix implementation
-      return to(matrix(x), matrix(y)).valueOf()
+      return this(matrix(x), matrix(y)).valueOf()
     },
 
     'Array, Matrix': function (x, y) {
       // use matrix implementation
-      return to(matrix(x), y)
+      return this(matrix(x), y)
     },
 
     'Matrix, Array': function (x, y) {
       // use matrix implementation
-      return to(x, matrix(y))
+      return this(x, matrix(y))
     },
 
     'Matrix, any': function (x, y) {
       // SparseMatrix does not support Units
-      return algorithm14(x, y, to, false)
+      return algorithm14(x, y, this, false)
     },
 
     'any, Matrix': function (x, y) {
       // SparseMatrix does not support Units
-      return algorithm14(y, x, to, true)
+      return algorithm14(y, x, this, true)
     },
 
     'Array, any': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(x), y, to, false).valueOf()
+      return algorithm14(matrix(x), y, this, false).valueOf()
     },
 
     'any, Array': function (x, y) {
       // use matrix implementation
-      return algorithm14(matrix(y), x, to, true).valueOf()
+      return algorithm14(matrix(y), x, this, true).valueOf()
     }
   })
-
-  return to
 })

--- a/src/function/utils/isInteger.js
+++ b/src/function/utils/isInteger.js
@@ -35,7 +35,7 @@ export const createIsInteger = /* #__PURE__ */ factory(name, dependencies, ({ ty
    * @return {boolean}  Returns true when `x` contains a numeric, integer value.
    *                    Throws an error in case of an unknown data type.
    */
-  const isInteger = typed(name, {
+  return typed(name, {
     number: isIntegerNumber, // TODO: what to do with isInteger(add(0.1, 0.2))  ?
 
     BigNumber: function (x) {
@@ -47,9 +47,7 @@ export const createIsInteger = /* #__PURE__ */ factory(name, dependencies, ({ ty
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, isInteger)
+      return deepMap(x, this)
     }
   })
-
-  return isInteger
 })

--- a/src/function/utils/isNegative.js
+++ b/src/function/utils/isNegative.js
@@ -35,7 +35,7 @@ export const createIsNegative = /* #__PURE__ */ factory(name, dependencies, ({ t
    * @return {boolean}  Returns true when `x` is larger than zero.
    *                    Throws an error in case of an unknown data type.
    */
-  const isNegative = typed(name, {
+  return typed(name, {
     number: isNegativeNumber,
 
     BigNumber: function (x) {
@@ -47,13 +47,11 @@ export const createIsNegative = /* #__PURE__ */ factory(name, dependencies, ({ t
     },
 
     Unit: function (x) {
-      return isNegative(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, isNegative)
+      return deepMap(x, this)
     }
   })
-
-  return isNegative
 })

--- a/src/function/utils/isNumeric.js
+++ b/src/function/utils/isNumeric.js
@@ -34,7 +34,7 @@ export const createIsNumeric = /* #__PURE__ */ factory(name, dependencies, ({ ty
    *                    `Fraction`, or `boolean`. Returns false for other types.
    *                    Throws an error in case of unknown types.
    */
-  const isNumeric = typed(name, {
+  return typed(name, {
     'number | BigNumber | Fraction | boolean': function () {
       return true
     },
@@ -44,9 +44,7 @@ export const createIsNumeric = /* #__PURE__ */ factory(name, dependencies, ({ ty
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, isNumeric)
+      return deepMap(x, this)
     }
   })
-
-  return isNumeric
 })

--- a/src/function/utils/isPositive.js
+++ b/src/function/utils/isPositive.js
@@ -37,7 +37,7 @@ export const createIsPositive = /* #__PURE__ */ factory(name, dependencies, ({ t
    * @return {boolean}  Returns true when `x` is larger than zero.
    *                    Throws an error in case of an unknown data type.
    */
-  const isPositive = typed(name, {
+  return typed(name, {
     number: isPositiveNumber,
 
     BigNumber: function (x) {
@@ -49,13 +49,11 @@ export const createIsPositive = /* #__PURE__ */ factory(name, dependencies, ({ t
     },
 
     Unit: function (x) {
-      return isPositive(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, isPositive)
+      return deepMap(x, this)
     }
   })
-
-  return isPositive
 })

--- a/src/function/utils/isPrime.js
+++ b/src/function/utils/isPrime.js
@@ -33,7 +33,7 @@ export const createIsPrime = /* #__PURE__ */ factory(name, dependencies, ({ type
    * @return {boolean}  Returns true when `x` is larger than zero.
    *                    Throws an error in case of an unknown data type.
    */
-  const isPrime = typed(name, {
+  return typed(name, {
     number: function (x) {
       if (x * 0 !== 0) {
         return false
@@ -69,9 +69,7 @@ export const createIsPrime = /* #__PURE__ */ factory(name, dependencies, ({ type
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, isPrime)
+      return deepMap(x, this)
     }
   })
-
-  return isPrime
 })

--- a/src/function/utils/isZero.js
+++ b/src/function/utils/isZero.js
@@ -39,7 +39,7 @@ export const createIsZero = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @return {boolean}  Returns true when `x` is zero.
    *                    Throws an error in case of an unknown data type.
    */
-  const isZero = typed(name, {
+  return typed(name, {
     number: isZeroNumber,
 
     BigNumber: function (x) {
@@ -55,13 +55,11 @@ export const createIsZero = /* #__PURE__ */ factory(name, dependencies, ({ typed
     },
 
     Unit: function (x) {
-      return isZero(x.value)
+      return this(x.value)
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, isZero)
+      return deepMap(x, this)
     }
   })
-
-  return isZero
 })

--- a/src/type/bignumber/function/bignumber.js
+++ b/src/type/bignumber/function/bignumber.js
@@ -30,7 +30,7 @@ export const createBignumber = /* #__PURE__ */ factory(name, dependencies, ({ ty
    *                                                    0 by default.
    * @returns {BigNumber} The created bignumber
    */
-  const bignumber = typed('bignumber', {
+  return typed('bignumber', {
     '': function () {
       return new BigNumber(0)
     },
@@ -58,9 +58,7 @@ export const createBignumber = /* #__PURE__ */ factory(name, dependencies, ({ ty
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, bignumber)
+      return deepMap(x, this)
     }
   })
-
-  return bignumber
 })

--- a/src/type/boolean.js
+++ b/src/type/boolean.js
@@ -32,7 +32,7 @@ export const createBoolean = /* #__PURE__ */ factory(name, dependencies, ({ type
    * @param {string | number | boolean | Array | Matrix | null} value  A value of any type
    * @return {boolean | Array | Matrix} The boolean value
    */
-  const bool = typed(name, {
+  return typed(name, {
     '': function () {
       return false
     },
@@ -72,9 +72,7 @@ export const createBoolean = /* #__PURE__ */ factory(name, dependencies, ({ type
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, bool)
+      return deepMap(x, this)
     }
   })
-
-  return bool
 })

--- a/src/type/complex/function/complex.js
+++ b/src/type/complex/function/complex.js
@@ -43,7 +43,7 @@ export const createComplex = /* #__PURE__ */ factory(name, dependencies, ({ type
    *            Arguments specifying the real and imaginary part of the complex number
    * @return {Complex | Array | Matrix} Returns a complex value
    */
-  const complex = typed('complex', {
+  return typed('complex', {
     '': function () {
       return Complex.ZERO
     },
@@ -90,9 +90,7 @@ export const createComplex = /* #__PURE__ */ factory(name, dependencies, ({ type
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, complex)
+      return deepMap(x, this)
     }
   })
-
-  return complex
 })

--- a/src/type/fraction/function/fraction.js
+++ b/src/type/fraction/function/fraction.js
@@ -30,7 +30,7 @@ export const createFraction = /* #__PURE__ */ factory(name, dependencies, ({ typ
    *            the fraction
    * @return {Fraction | Array | Matrix} Returns a fraction
    */
-  const fraction = typed('fraction', {
+  return typed('fraction', {
     number: function (x) {
       if (!isFinite(x) || isNaN(x)) {
         throw new Error(x + ' cannot be represented as a fraction')
@@ -64,9 +64,7 @@ export const createFraction = /* #__PURE__ */ factory(name, dependencies, ({ typ
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, fraction)
+      return deepMap(x, this)
     }
   })
-
-  return fraction
 })

--- a/src/type/number.js
+++ b/src/type/number.js
@@ -69,7 +69,7 @@ export const createNumber = /* #__PURE__ */ factory(name, dependencies, ({ typed
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, number)
+      return deepMap(x, this)
     }
   })
 

--- a/src/type/string.js
+++ b/src/type/string.js
@@ -31,7 +31,7 @@ export const createString = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * @param {* | Array | Matrix | null} [value]  A value to convert to a string
    * @return {string | Array | Matrix} The created string
    */
-  const string = typed(name, {
+  return typed(name, {
     '': function () {
       return ''
     },
@@ -51,13 +51,11 @@ export const createString = /* #__PURE__ */ factory(name, dependencies, ({ typed
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, string)
+      return deepMap(x, this)
     },
 
     any: function (x) {
       return String(x)
     }
   })
-
-  return string
 })

--- a/src/type/unit/function/unit.js
+++ b/src/type/unit/function/unit.js
@@ -30,7 +30,7 @@ export const createUnitFunction = /* #__PURE__ */ factory(name, dependencies, ({
    * @return {Unit | Array | Matrix}    The created unit
    */
 
-  const unit = typed(name, {
+  return typed(name, {
     Unit: function (x) {
       return x.clone()
     },
@@ -48,9 +48,7 @@ export const createUnitFunction = /* #__PURE__ */ factory(name, dependencies, ({
     },
 
     'Array | Matrix': function (x) {
-      return deepMap(x, unit)
+      return deepMap(x, this)
     }
   })
-
-  return unit
 })


### PR DESCRIPTION
As described in the issue here: https://github.com/josdejong/mathjs/issues/1885, if a typed function invokes itself from within a local context, as is done in many of math functions in the library, it will not have access to signatures merged in later on.  The `typed-function` library now supports self invocation using `this` to address this issue.

This PR attempts to replace all the instances of recursion with the new `this`-style call.