### PR TITLE
Replace seed-random by seedrandom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9482,10 +9482,10 @@
         "ajv-keywords": "^3.4.1"
       }
     },
-    "seed-random": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
-      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "escape-latex": "^1.2.0",
     "fraction.js": "^4.0.12",
     "javascript-natural-sort": "^0.7.1",
-    "seed-random": "^2.2.0",
+    "seedrandom": "^3.0.5",
     "tiny-emitter": "^2.1.0",
     "typed-function": "^2.0.0"
   },

--- a/src/function/probability/util/seededRNG.js
+++ b/src/function/probability/util/seededRNG.js
@@ -1,12 +1,6 @@
-// create a random seed here to prevent an infinite loop from seed-random
-// inside the factory. Reason is that math.random is defined as a getter/setter
-// and seed-random generates a seed from the local entropy by reading every
-// defined object including `math` itself. That means that whilst getting
-// math.random, it tries to get math.random, etc... an infinite loop.
-// See https://github.com/ForbesLindesay/seed-random/issues/6
-import seedrandom from 'seed-random'
+import seedrandom from 'seedrandom'
 
-const singletonRandom = /* #__PURE__ */ seedrandom()
+const singletonRandom = /* #__PURE__ */ seedrandom(Date.now())
 
 export function createRng (randomSeed) {
   let random

--- a/test/node-tests/treeShaking/treeShaking.test.js
+++ b/test/node-tests/treeShaking/treeShaking.test.js
@@ -63,7 +63,7 @@ describe('tree shaking', function () {
       // this may grow or shrink in the future
       assert.strictEqual(info.assets[0].name, bundleName)
       const size = info.assets[0].size
-      const maxSize = 100000
+      const maxSize = 110000
       assert(size < maxSize,
         'bundled size must be small enough ' +
         '(actual size: ' + size + ' bytes, max size: ' + maxSize + ' bytes)')


### PR DESCRIPTION
For issue #1949 , replace the seed-random by seedrandom.

- I have no idea about which is better of [the fast PRNG algorithms](https://github.com/davidbau/seedrandom#other-fast-prng-algorithms) supported by seedrandom, so I choose the default.
- The bundle size increases a little, so I change the `maxSize` up.

I've run the `build-and-test` locally. Looks no error.