### PR TITLE
Fix negative dividend modulo for BigNumber and Fraction

### DIFF
--- a/src/function/arithmetic/mod.js
+++ b/src/function/arithmetic/mod.js
@@ -65,11 +65,18 @@ export const createMod = /* #__PURE__ */ factory(name, dependencies, ({ typed, m
     'number, number': modNumber,
 
     'BigNumber, BigNumber': function (x, y) {
+      if (y.isNeg()) {
+        throw new Error('Cannot calculate mod for a negative divisor')
+      }
       return y.isZero() ? x : x.mod(y)
     },
 
     'Fraction, Fraction': function (x, y) {
-      return x.mod(y)
+      if (y.compare(0) < 0) {
+        throw new Error('Cannot calculate mod for a negative divisor')
+      }
+      // Workaround suggested in Fraction.js library to calculate correct modulo for negative dividend
+      return x.compare(0) >= 0 ? x.mod(y) : x.mod(y).add(y).mod(y)
     },
 
     'SparseMatrix, SparseMatrix': function (x, y) {

--- a/src/type/bignumber/BigNumber.js
+++ b/src/type/bignumber/BigNumber.js
@@ -5,7 +5,8 @@ const name = 'BigNumber'
 const dependencies = ['?on', 'config']
 
 export const createBigNumberClass = /* #__PURE__ */ factory(name, dependencies, ({ on, config }) => {
-  const BigNumber = Decimal.clone({ precision: config.precision })
+  const EUCLID = 9 // Use euclidian division for mod calculation
+  const BigNumber = Decimal.clone({ precision: config.precision, modulo: EUCLID })
 
   /**
    * Attach type information

--- a/test/unit-tests/function/arithmetic/mod.test.js
+++ b/test/unit-tests/function/arithmetic/mod.test.js
@@ -30,9 +30,11 @@ describe('mod', function () {
     approx.equal(mod(8.2, 3), 2.2)
     approx.equal(mod(4, 1.5), 1)
     approx.equal(mod(0, 3), 0)
+    approx.equal(mod(-10, 4), 2)
+    approx.equal(mod(-5, 3), 1)
   })
 
-  it('should throw an error if the modulus is negative', function () {
+  it('should throw an error if the divisor is negative', function () {
     assert.throws(function () { mod(10, -4) })
   })
 
@@ -59,8 +61,13 @@ describe('mod', function () {
     assert.deepStrictEqual(mod(bignumber(7).div(3), bignumber(1).div(3)), bignumber(0))
   })
 
-  it.skip('should calculate the modulus of bignumbers for negative values', function () {
+  it('should calculate the modulus of bignumbers for negative dividend', function () {
     assert.deepStrictEqual(mod(bignumber(-10), bignumber(4)), bignumber(2))
+    assert.deepStrictEqual(mod(bignumber(-5), bignumber(3)), bignumber(1))
+  })
+
+  it('should throw an error if the divisor in modulus of bignumbers is negative', function () {
+    assert.throws(function () { mod(bignumber(10), bignumber(-4)) })
   })
 
   it('should calculate the modulus of mixed numbers and bignumbers', function () {
@@ -70,6 +77,8 @@ describe('mod', function () {
     assert.deepStrictEqual(mod(7, bignumber(0)), bignumber(7))
     assert.deepStrictEqual(mod(bignumber(0), 3), bignumber(0))
     assert.deepStrictEqual(mod(bignumber(7), 0), bignumber(7))
+    assert.deepStrictEqual(mod(bignumber(-5), 3), bignumber(1))
+    assert.deepStrictEqual(mod(-5, bignumber(3)), bignumber(1))
 
     assert.throws(function () { mod(7 / 3, bignumber(2)) }, /TypeError: Cannot implicitly convert a number with >15 significant digits to BigNumber/)
     assert.throws(function () { mod(bignumber(7).div(3), 1 / 3) }, /TypeError: Cannot implicitly convert a number with >15 significant digits to BigNumber/)
@@ -103,6 +112,15 @@ describe('mod', function () {
     assert(a instanceof math.Fraction)
 
     assert.strictEqual(mod(math.fraction(4.55), math.fraction(0.05)).toString(), '0')
+  })
+
+  it('should calculate the modulus of fractions for negative dividend', function () {
+    assert.strictEqual(mod(math.fraction(-10), math.fraction(4)).toString(), '2')
+    assert.strictEqual(mod(math.fraction(-5), math.fraction(3)).toString(), '1')
+  })
+
+  it('should throw an error if the divosor in modulus of fractions is negative', function () {
+    assert.throws(function () { mod(math.fraction(10), math.fraction(-4)) })
   })
 
   it('should calculate modulus of mixed fractions and numbers', function () {


### PR DESCRIPTION
This fixes incorrect `mod` behaviour for BigNumbers and Fractions, as described in issue #1964. 