### PR TITLE
sqrtm - throw an error for matrices with dimension greater than two

### DIFF
--- a/src/function/matrix/sqrtm.js
+++ b/src/function/matrix/sqrtm.js
@@ -87,6 +87,10 @@ export const createSqrtm = /* #__PURE__ */ factory(name, dependencies, ({ typed,
               '(size: ' + format(size) + ')')
           }
         }
+        default:
+          // Multi dimensional array
+          throw new RangeError('Matrix must be at most two dimensional ' +
+          '(size: ' + format(size) + ')')
       }
     }
   })

--- a/test/unit-tests/function/matrix/sqrtm.test.js
+++ b/test/unit-tests/function/matrix/sqrtm.test.js
@@ -52,6 +52,13 @@ describe('sqrtm', function () {
     assert.throws(function () { math.sqrtm([[1, 2, 3], [4, 5, 6]]) }, /Matrix must be square/)
   })
 
+  it('should throw an error in case of matrices with dimension greater than two', function () {
+    const errorRegex = /Matrix must be at most two dimensional/
+    assert.throws(function () { math.sqrtm(math.zeros(1, 1, 1)) }, errorRegex)
+    assert.throws(function () { math.sqrtm(math.zeros(2, 2, 2)) }, errorRegex)
+    assert.throws(function () { math.sqrtm(math.zeros(3, 3, 3, 3)) }, errorRegex)
+  })
+
   it('should LaTeX sqrtm', function () {
     const expression = math.parse('sqrtm([[33, 24], [48, 57]])')
     assert.strictEqual(expression.toTex(), '{\\begin{bmatrix}33&24\\\\48&57\\\\\\end{bmatrix}}^{\\frac{1}{2}}')


### PR DESCRIPTION
Fixes #1597
Just used this https://github.com/josdejong/mathjs/issues/1597#issuecomment-522934657