### PR TITLE
Update clone.js with doc about deep copying arrays

### DIFF
--- a/src/function/utils/clone.js
+++ b/src/function/utils/clone.js
@@ -6,7 +6,7 @@ const dependencies = ['typed']
 
 export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed }) => {
   /**
-   * Clone an object. Arrays will be deep copied.
+   * Clone an object. Will make a deep copy of the data.
    *
    * Syntax:
    *
@@ -17,7 +17,7 @@ export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed 
    *    math.clone(3.5)                   // returns number 3.5
    *    math.clone(math.complex('2-4i') // returns Complex 2 - 4i
    *    math.clone(math.unit(45, 'deg'))  // returns Unit 45 deg
-   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]], as a deep copy
+   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]]
    *    math.clone("hello world")         // returns string "hello world"
    *
    * @param {*} x   Object to be cloned

--- a/src/function/utils/clone.js
+++ b/src/function/utils/clone.js
@@ -6,7 +6,7 @@ const dependencies = ['typed']
 
 export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed }) => {
   /**
-   * Clone an object.
+   * Clone an object. Arrays will be deep copied.
    *
    * Syntax:
    *
@@ -17,7 +17,7 @@ export const createClone = /* #__PURE__ */ factory(name, dependencies, ({ typed 
    *    math.clone(3.5)                   // returns number 3.5
    *    math.clone(math.complex('2-4i') // returns Complex 2 - 4i
    *    math.clone(math.unit(45, 'deg'))  // returns Unit 45 deg
-   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]]
+   *    math.clone([[1, 2], [3, 4]])      // returns Array [[1, 2], [3, 4]], as a deep copy
    *    math.clone("hello world")         // returns string "hello world"
    *
    * @param {*} x   Object to be cloned


### PR DESCRIPTION
Since it was missing, and it is important documentation for anyone using math.clone for arrays of arrays (matrices). The deep copying was inferred from the test case, but it shouldn't have been necessary. Now it will hopefully be shown in the doc on the webpage, too.