### PR TITLE
Improve performance of _findUnit

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -1,5 +1,6 @@
 import { isComplex, isUnit, typeOf } from '../../utils/is.js'
 import { factory } from '../../utils/factory.js'
+import { memoize } from '../../utils/function.js'
 import { endsWith } from '../../utils/string.js'
 import { clone, hasOwnProperty } from '../../utils/object.js'
 import { createBigNumberPi as createPi } from '../../utils/bignumber/constants.js'
@@ -567,7 +568,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    *                                  prefix is returned. Else, null is returned.
    * @private
    */
-  function _findUnit (str) {
+  const _findUnit = memoize((str) => {
     // First, match units names exactly. For example, a user could define 'mm' as 10^-4 m, which is silly, but then we would want 'mm' to match the user-defined unit.
     if (hasOwnProperty(UNITS, str)) {
       const unit = UNITS[str]
@@ -599,7 +600,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     }
 
     return null
-  }
+  }, { hasher: (args) => args[0], limit: 100 })
 
   /**
    * Test if the given expression is a unit.
@@ -3290,6 +3291,9 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       alias.name = aliasName
       Unit.UNITS[aliasName] = alias
     }
+    // delete the memoization cache, since adding a new unit to the array
+    // invalidates all old results
+    delete _findUnit.cache
 
     return new Unit(null, name)
   }

--- a/src/utils/bignumber/constants.js
+++ b/src/utils/bignumber/constants.js
@@ -7,7 +7,7 @@ import { memoize } from '../function.js'
  */
 export const createBigNumberE = memoize(function (BigNumber) {
   return new BigNumber(1).exp()
-}, hasher)
+}, { hasher })
 
 /**
  * Calculate BigNumber golden ratio, phi = (1+sqrt(5))/2
@@ -16,7 +16,7 @@ export const createBigNumberE = memoize(function (BigNumber) {
  */
 export const createBigNumberPhi = memoize(function (BigNumber) {
   return new BigNumber(1).plus(new BigNumber(5).sqrt()).div(2)
-}, hasher)
+}, { hasher })
 
 /**
  * Calculate BigNumber pi.
@@ -25,7 +25,7 @@ export const createBigNumberPhi = memoize(function (BigNumber) {
  */
 export const createBigNumberPi = memoize(function (BigNumber) {
   return BigNumber.acos(-1)
-}, hasher)
+}, { hasher })
 
 /**
  * Calculate BigNumber tau, tau = 2 * pi
@@ -34,7 +34,7 @@ export const createBigNumberPi = memoize(function (BigNumber) {
  */
 export const createBigNumberTau = memoize(function (BigNumber) {
   return createBigNumberPi(BigNumber).times(2)
-}, hasher)
+}, { hasher })
 
 /**
  * Create a hash for a BigNumber constructor function. The created has is

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -1,5 +1,7 @@
 // function utils
 
+import { lruQueue } from './lruQueue.js'
+
 /**
  * Memoize a given function by caching the computed result.
  * The cache of a memoized function can be cleared by deleting the `cache`
@@ -7,26 +9,39 @@
  *
  * @param {function} fn                     The function to be memoized.
  *                                          Must be a pure function.
- * @param {function(args: Array)} [hasher]  A custom hash builder.
- *                                          Is JSON.stringify by default.
+ * @param {Object} [options]
+ * @param {function(args: Array): string} [options.hasher]
+ *    A custom hash builder. Is JSON.stringify by default.
+ * @param {number | undefined} [options.limit]
+ *    Maximum number of values that may be cached. Undefined indicates
+ *    unlimited (default)
  * @return {function}                       Returns the memoized function
  */
-export function memoize (fn, hasher) {
+export function memoize (fn, { hasher, limit } = {}) {
+  limit = limit == null ? Number.POSITIVE_INFINITY : limit
+  hasher = hasher == null ? JSON.stringify : hasher
+
   return function memoize () {
     if (typeof memoize.cache !== 'object') {
-      memoize.cache = {}
+      memoize.cache = {
+        values: {},
+        lru: lruQueue(limit || Number.POSITIVE_INFINITY)
+      }
     }
 
-    const args = []
-    for (let i = 0; i < arguments.length; i++) {
-      args[i] = arguments[i]
+    const args = [...arguments]
+    const hash = hasher(args)
+
+    if (hash in memoize.cache.values) {
+      memoize.cache.lru.hit(hash)
+      return memoize.cache.values[hash]
     }
 
-    const hash = hasher ? hasher(args) : JSON.stringify(args)
-    if (!(hash in memoize.cache)) {
-      memoize.cache[hash] = fn.apply(fn, args)
-    }
-    return memoize.cache[hash]
+    const newVal = fn.apply(fn, args)
+    memoize.cache.values[hash] = newVal
+    delete memoize.cache.values[memoize.cache.lru.hit(hash)]
+
+    return newVal
   }
 }
 

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -24,22 +24,24 @@ export function memoize (fn, { hasher, limit } = {}) {
   return function memoize () {
     if (typeof memoize.cache !== 'object') {
       memoize.cache = {
-        values: {},
+        values: new Map(),
         lru: lruQueue(limit || Number.POSITIVE_INFINITY)
       }
     }
-
-    const args = [...arguments]
+    const args = []
+    for (let i = 0; i < arguments.length; i++) {
+      args[i] = arguments[i]
+    }
     const hash = hasher(args)
 
-    if (hash in memoize.cache.values) {
+    if (memoize.cache.values.has(hash)) {
       memoize.cache.lru.hit(hash)
-      return memoize.cache.values[hash]
+      return memoize.cache.values.get(hash)
     }
 
     const newVal = fn.apply(fn, args)
-    memoize.cache.values[hash] = newVal
-    delete memoize.cache.values[memoize.cache.lru.hit(hash)]
+    memoize.cache.values.set(hash, newVal)
+    memoize.cache.values.delete(memoize.cache.lru.hit(hash))
 
     return newVal
   }

--- a/src/utils/lruQueue.js
+++ b/src/utils/lruQueue.js
@@ -1,0 +1,50 @@
+// (c) 2018, Mariusz Nowak
+// SPDX-License-Identifier: ISC
+// Derived from https://github.com/medikoo/lru-queue
+export function lruQueue (limit) {
+  let size = 0
+  let base = 1
+  let queue = Object.create(null)
+  let map = Object.create(null)
+  let index = 0
+  const del = function (id) {
+    const oldIndex = map[id]
+    if (!oldIndex) return
+    delete queue[oldIndex]
+    delete map[id]
+    --size
+    if (base !== oldIndex) return
+    if (!size) {
+      index = 0
+      base = 1
+      return
+    }
+    while (!hasOwnProperty.call(queue, ++base)) continue
+  }
+  limit = Math.abs(limit)
+  return {
+    hit: function (id) {
+      const oldIndex = map[id]; const nuIndex = ++index
+      queue[nuIndex] = id
+      map[id] = nuIndex
+      if (!oldIndex) {
+        ++size
+        if (size <= limit) return undefined
+        id = queue[base]
+        del(id)
+        return id
+      }
+      delete queue[oldIndex]
+      if (base !== oldIndex) return undefined
+      while (!hasOwnProperty.call(queue, ++base)) continue
+      return undefined
+    },
+    delete: del,
+    clear: function () {
+      size = index = 0
+      base = 1
+      queue = Object.create(null)
+      map = Object.create(null)
+    }
+  }
+};

--- a/test/benchmark/unit_parser.js
+++ b/test/benchmark/unit_parser.js
@@ -1,0 +1,40 @@
+// test performance of the unit expression parser in node.js
+
+// browserify benchmark/unit_parser.js -o ./benchmark_unit_parser.js
+
+const Benchmark = require('benchmark')
+const math = require('../..')
+
+// expose on window when using bundled in a browser
+if (typeof window !== 'undefined') {
+  window.Benchmark = Benchmark
+}
+
+const expr = '[1mm, 2mm, 3mm, 4mm, 5mm, 6mm, 7mm, 8mm, 9mm, 10mm]'
+
+console.log('Unit.parse expression: mm')
+console.log('evaluate expression:', expr)
+
+let total = 0
+
+const suite = new Benchmark.Suite()
+suite
+  .add('Unit.parse', function () {
+    total += math.Unit.parse('mm').dimensions[0]
+  })
+  .add('evaluate', function () {
+    total += math.evaluate(expr).size()[0]
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    // we count at total to prevent the browsers from not executing
+    // the benchmarks ("dead code") when the results would not be used.
+    if (total > 5) {
+      console.log('')
+    } else {
+      console.log('')
+    }
+  })
+  .run()

--- a/test/unit-tests/type/unit/Unit.test.js
+++ b/test/unit-tests/type/unit/Unit.test.js
@@ -926,6 +926,15 @@ describe('Unit', function () {
       const unit3 = math3.Unit.parse('5kg')
       assert(isBigNumber(unit3.value))
     })
+
+    it('should parse new units that override old units', function () {
+      const math2 = math.create()
+      const oldMm = math2.Unit.parse('mm')
+      const newMm = math2.createUnit('mm', '2 A')
+      assert.notDeepStrictEqual(oldMm, newMm)
+      assert.deepStrictEqual(newMm, math2.Unit.parse('mm'))
+      console.log(oldMm.units, newMm.units)
+    })
   })
 
   describe('prefixes', function () {

--- a/test/unit-tests/utils/function.test.js
+++ b/test/unit-tests/utils/function.test.js
@@ -31,8 +31,8 @@ describe('util.function', function () {
       const m = memoize(f)
 
       assert.strictEqual(m({ x: 2, y: 3 }), 6)
-      assert.deepStrictEqual(Object.keys(m.cache.values), ['[{"x":2,"y":3}]'])
-      assert.strictEqual(m.cache.values['[{"x":2,"y":3}]'], 6)
+      assert.deepStrictEqual([...m.cache.values.keys()], ['[{"x":2,"y":3}]'])
+      assert.strictEqual(m.cache.values.get('[{"x":2,"y":3}]'), 6)
     })
 
     it('should memoize a function with a custom hashIt function', function () {
@@ -44,8 +44,8 @@ describe('util.function', function () {
       const m = memoize(f, { hasher: hashIt })
 
       assert.strictEqual(m({ id: 2 }), 2)
-      assert.deepStrictEqual(Object.keys(m.cache.values), ['id:2'])
-      assert.strictEqual(m.cache.values['id:2'], 2)
+      assert.deepStrictEqual([...m.cache.values.keys()], ['id:2'])
+      assert.strictEqual(m.cache.values.get('id:2'), 2)
     })
 
     it('should really return the cached result', function () {

--- a/test/unit-tests/utils/function.test.js
+++ b/test/unit-tests/utils/function.test.js
@@ -31,8 +31,8 @@ describe('util.function', function () {
       const m = memoize(f)
 
       assert.strictEqual(m({ x: 2, y: 3 }), 6)
-      assert.deepStrictEqual(Object.keys(m.cache), ['[{"x":2,"y":3}]'])
-      assert.strictEqual(m.cache['[{"x":2,"y":3}]'], 6)
+      assert.deepStrictEqual(Object.keys(m.cache.values), ['[{"x":2,"y":3}]'])
+      assert.strictEqual(m.cache.values['[{"x":2,"y":3}]'], 6)
     })
 
     it('should memoize a function with a custom hashIt function', function () {
@@ -41,11 +41,11 @@ describe('util.function', function () {
         return 'id:' + args[0].id
       }
 
-      const m = memoize(f, hashIt)
+      const m = memoize(f, { hasher: hashIt })
 
       assert.strictEqual(m({ id: 2 }), 2)
-      assert.deepStrictEqual(Object.keys(m.cache), ['id:2'])
-      assert.strictEqual(m.cache['id:2'], 2)
+      assert.deepStrictEqual(Object.keys(m.cache.values), ['id:2'])
+      assert.strictEqual(m.cache.values['id:2'], 2)
     })
 
     it('should really return the cached result', function () {
@@ -58,6 +58,20 @@ describe('util.function', function () {
       a = 3
       assert.strictEqual(m(4), 2)
     })
+  })
+
+  it('should limit the number of values stored', function () {
+    let a = 1
+    const f = function (x) { a++; return a } // trick: no pure function
+
+    const m = memoize(f, { limit: 2 })
+
+    assert.strictEqual(m(1), 2)
+    assert.strictEqual(m(2), 3)
+    // this should evict m(1)
+    assert.strictEqual(m(3), 4)
+
+    assert.strictEqual(m(1), 5)
   })
 
   describe('memoizeCompare', function () {


### PR DESCRIPTION
This fixes some performance issues in my heavily-unit-parsing app.

Another idea might be to do an index of reversed unit names, and search in that, but this is much easier to implement and still should provide an improvement in the majority of cases (since I'd imagine that most users tend to prefer a few units at a time, depending on their application).