### PR TITLE
Support for parsing non decimal numbers with radix point

### DIFF
--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -299,6 +299,13 @@ math.evaluate('0xffffffffi32')  //  -1
 math.evaluate('0xfffffffffi32') //  SyntaxError: String "0xfffffffff" is out of range
 ```
 
+Non decimal numbers can include a radix point:
+```js
+math.evaluate('0b1.1')         // 1.5
+math.evaluate('0o1.4')         // 1.5
+math.evaluate('0x1.8')         // 1.5
+```
+
 Numbers can be formatted as binary, octal, and hex strings using the `notation` option of the `format` function:
 
 ```js

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -332,11 +332,20 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
           state.token += currentCharacter(state)
           next(state)
         }
-        // check for word size suffix
-        const sign = currentCharacter(state)
-        if (sign === 'i') {
-          state.token += sign
+        if (currentCharacter(state) === '.') {
+          // this number has a radix point
+          state.token += '.'
           next(state)
+          // get the digits after the radix
+          while (parse.isHexDigit(currentCharacter(state))) {
+            state.token += currentCharacter(state)
+            next(state)
+          }
+        } else if (currentCharacter(state) === 'i') {
+          // this number has a word size suffix
+          state.token += 'i'
+          next(state)
+          // get the word size
           while (parse.isDigit(currentCharacter(state))) {
             state.token += currentCharacter(state)
             next(state)

--- a/src/type/bignumber/function/bignumber.js
+++ b/src/type/bignumber/function/bignumber.js
@@ -41,11 +41,11 @@ export const createBignumber = /* #__PURE__ */ factory(name, dependencies, ({ ty
     },
 
     string: function (x) {
-      const match = x.match(/(0[box][0-9a-fA-F]*)i([0-9]*)/)
-      if (match) {
+      const wordSizeSuffixMatch = x.match(/(0[box][0-9a-fA-F]*)i([0-9]*)/)
+      if (wordSizeSuffixMatch) {
         // x has a word size suffix
-        const size = match[2]
-        const n = BigNumber(match[1])
+        const size = wordSizeSuffixMatch[2]
+        const n = BigNumber(wordSizeSuffixMatch[1])
         const twoPowSize = new BigNumber(2).pow(Number(size))
         if (n.gt(twoPowSize.sub(1))) {
           throw new SyntaxError(`String "${x}" is out of range`)

--- a/src/type/number.js
+++ b/src/type/number.js
@@ -5,17 +5,17 @@ const name = 'number'
 const dependencies = ['typed']
 
 /**
- * Parse a non decimal number of the form 0BX.Y as a Number
- * @param {number} [base] the base in [2, 8, 16]
- * @param {string} [integerPart] the part before the radix
- * @param {string} [fractionalPart] the part after the radix
+ * Parse a non decimal number of the form 0RI.F as a Number
+ * @param {number} [radix] the radix in [2, 8, 16]
+ * @param {string} [integerPart] the part before the radix point
+ * @param {string} [fractionalPart] the part after the radix point
  */
-function parseNonDecimalWithRadix(base, integerPart, fractionalPart) {
-  const n = parseInt(integerPart, base)
+function parseNonDecimalWithRadixPoint(radix, integerPart, fractionalPart) {
+  const n = parseInt(integerPart, radix)
   let f = 0
   for (let i = 0; i < fractionalPart.length; i++) {
-    let digitValue = parseInt(fractionalPart[i], base)
-    f += digitValue / Math.pow(base, i + 1)
+    let digitValue = parseInt(fractionalPart[i], radix)
+    f += digitValue / Math.pow(radix, i + 1)
   }
   return n + f
 }
@@ -59,10 +59,10 @@ export const createNumber = /* #__PURE__ */ factory(name, dependencies, ({ typed
       if (x === 'NaN') return NaN
       const nonDecimalWithRadixMatch = x.match(/(0[box])([0-9a-fA-F]*)\.([0-9a-fA-F]*)/)
       if (nonDecimalWithRadixMatch) {
-        const base = ({'0b': 2, '0c':8, '0x':16})[nonDecimalWithRadixMatch[1]]
+        const radix = ({'0b': 2, '0o':8, '0x':16})[nonDecimalWithRadixMatch[1]]
         const integerPart = nonDecimalWithRadixMatch[2]
         const fractionalPart = nonDecimalWithRadixMatch[3]
-        return parseNonDecimalWithRadix(base, integerPart, fractionalPart)
+        return parseNonDecimalWithRadixPoint(radix, integerPart, fractionalPart)
       }
       let size = 0
       const wordSizeSuffixMatch = x.match(/(0[box][0-9a-fA-F]*)i([0-9]*)/)

--- a/src/type/number.js
+++ b/src/type/number.js
@@ -6,6 +6,9 @@ const dependencies = ['typed']
 
 /**
  * Parse a non decimal number of the form 0BX.Y as a Number
+ * @param {number} [base] the base in [2, 8, 16]
+ * @param {string} [integerPart] the part before the radix
+ * @param {string} [fractionalPart] the part after the radix
  */
 function parseNonDecimalWithRadix(base, integerPart, fractionalPart) {
   const n = parseInt(integerPart, base)

--- a/src/type/number.js
+++ b/src/type/number.js
@@ -10,11 +10,11 @@ const dependencies = ['typed']
  * @param {string} [integerPart] the part before the radix point
  * @param {string} [fractionalPart] the part after the radix point
  */
-function parseNonDecimalWithRadixPoint(radix, integerPart, fractionalPart) {
+function parseNonDecimalWithRadixPoint (radix, integerPart, fractionalPart) {
   const n = parseInt(integerPart, radix)
   let f = 0
   for (let i = 0; i < fractionalPart.length; i++) {
-    let digitValue = parseInt(fractionalPart[i], radix)
+    const digitValue = parseInt(fractionalPart[i], radix)
     f += digitValue / Math.pow(radix, i + 1)
   }
   return n + f
@@ -59,7 +59,7 @@ export const createNumber = /* #__PURE__ */ factory(name, dependencies, ({ typed
       if (x === 'NaN') return NaN
       const nonDecimalWithRadixMatch = x.match(/(0[box])([0-9a-fA-F]*)\.([0-9a-fA-F]*)/)
       if (nonDecimalWithRadixMatch) {
-        const radix = ({'0b': 2, '0o':8, '0x':16})[nonDecimalWithRadixMatch[1]]
+        const radix = ({ '0b': 2, '0o': 8, '0x': 16 })[nonDecimalWithRadixMatch[1]]
         const integerPart = nonDecimalWithRadixMatch[2]
         const fractionalPart = nonDecimalWithRadixMatch[3]
         return parseNonDecimalWithRadixPoint(radix, integerPart, fractionalPart)

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -269,6 +269,12 @@ describe('parse', function () {
       assert.strictEqual(parseAndEval('0o1.4'), 1.5)
       assert.strictEqual(parseAndEval('0x1.8'), 1.5)
       assert.strictEqual(parseAndEval('0x1.f'), 1.9375)
+      assert.strictEqual(parseAndEval('0b100.001'), 4.125)
+      assert.strictEqual(parseAndEval('0o100.001'), 64.001953125)
+      assert.strictEqual(parseAndEval('0x100.001'), 256.000244140625)
+      assert.strictEqual(parseAndEval('0b1.'), 1)
+      assert.strictEqual(parseAndEval('0o1.'), 1)
+      assert.strictEqual(parseAndEval('0x1.'), 1)
     })
 
     it('should parse a number followed by e', function () {
@@ -327,6 +333,12 @@ describe('parse', function () {
       assert.deepStrictEqual(bigmath.parse('0o1.4').compile().evaluate(), bigmath.bignumber(1.5))
       assert.deepStrictEqual(bigmath.parse('0x1.8').compile().evaluate(), bigmath.bignumber(1.5))
       assert.deepStrictEqual(bigmath.parse('0x1.f').compile().evaluate(), bigmath.bignumber(1.9375))
+      assert.deepStrictEqual(bigmath.parse('0b100.001').compile().evaluate(), bigmath.bignumber(4.125))
+      assert.deepStrictEqual(bigmath.parse('0o100.001').compile().evaluate(), bigmath.bignumber(64.001953125))
+      assert.deepStrictEqual(bigmath.parse('0x100.001').compile().evaluate(), bigmath.bignumber(256.000244140625))
+      assert.deepStrictEqual(bigmath.parse('0b1.').compile().evaluate(), bigmath.bignumber(1))
+      assert.deepStrictEqual(bigmath.parse('0o1.').compile().evaluate(), bigmath.bignumber(1))
+      assert.deepStrictEqual(bigmath.parse('0x1.').compile().evaluate(), bigmath.bignumber(1))
     })
   })
 

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -307,6 +307,10 @@ describe('parse', function () {
       assert.throws(function () { parseAndEval('0x12ii') })
       assert.throws(function () { parseAndEval('0x12u') })
       assert.throws(function () { parseAndEval('0x12i-8') })
+
+      assert.throws(function () { parseAndEval('0b123.45') }, /SyntaxError: String "0b123\.45" is no valid number/)
+      assert.throws(function () { parseAndEval('0o89.89') }, /SyntaxError: String "0o89\.89" is no valid number/)
+      assert.throws(function () { parseAndEval('0xghji.xyz') }, /SyntaxError: String "0x" is no valid number/)
     })
   })
 

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -265,6 +265,10 @@ describe('parse', function () {
       assert.strictEqual(parseAndEval('0x7fffffffi32'), 2 ** 31 - 1)
       assert.strictEqual(parseAndEval('0x1fffffffffffff'), 2 ** 53 - 1)
       assert.strictEqual(parseAndEval('0x1fffffffffffffi53'), -1)
+      assert.strictEqual(parseAndEval('0b1.1'), 1.5)
+      assert.strictEqual(parseAndEval('0o1.4'), 1.5)
+      assert.strictEqual(parseAndEval('0x1.8'), 1.5)
+      assert.strictEqual(parseAndEval('0x1.f'), 1.9375)
     })
 
     it('should parse a number followed by e', function () {
@@ -293,7 +297,6 @@ describe('parse', function () {
       assert.throws(function () { parseAndEval('0b2') }, SyntaxError)
       assert.throws(function () { parseAndEval('0o8') }, SyntaxError)
       assert.throws(function () { parseAndEval('0xg') }, SyntaxError)
-      assert.throws(function () { parseAndEval('0x12.3') }, SyntaxError)
 
       assert.throws(function () { parseAndEval('0x12ii') })
       assert.throws(function () { parseAndEval('0x12u') })
@@ -320,6 +323,10 @@ describe('parse', function () {
       assert.deepStrictEqual(bigmath.parse('0xffffffffi32').compile().evaluate(), bigmath.bignumber(-1))
       assert.deepStrictEqual(bigmath.parse('0xffffffffffffffffffffffffffffffffi128').compile().evaluate(), bigmath.bignumber(-1))
       assert.deepStrictEqual(bigmath.parse('0xffffffffffffffffffffffffffffffff').compile().evaluate(), bigmath.bignumber('0xffffffffffffffffffffffffffffffff'))
+      assert.deepStrictEqual(bigmath.parse('0b1.1').compile().evaluate(), bigmath.bignumber(1.5))
+      assert.deepStrictEqual(bigmath.parse('0o1.4').compile().evaluate(), bigmath.bignumber(1.5))
+      assert.deepStrictEqual(bigmath.parse('0x1.8').compile().evaluate(), bigmath.bignumber(1.5))
+      assert.deepStrictEqual(bigmath.parse('0x1.f').compile().evaluate(), bigmath.bignumber(1.9375))
     })
   })
 


### PR DESCRIPTION
I'm working on adding support for numbers with both a non decimal prefix (`0b`, `0o`, or `0x`) and a radix point (`.`) like `0b1.1`.

This should work for `number` and `BigNumber`.