### PR TITLE
Fix “AIAO-MIMO” of my previous PRs

### DIFF
--- a/src/function/arithmetic/norm.js
+++ b/src/function/arithmetic/norm.js
@@ -239,7 +239,7 @@ export const createNorm = /* #__PURE__ */ factory(
       }
       const tx = ctranspose(x)
       const squaredX = multiply(tx, x)
-      const eigenVals = eigs(squaredX).values
+      const eigenVals = eigs(squaredX).values.toArray()
       const rho = eigenVals[eigenVals.length - 1]
       return abs(sqrt(rho))
     }

--- a/src/function/matrix/eigs.js
+++ b/src/function/matrix/eigs.js
@@ -7,10 +7,10 @@ import { typeOf, isNumber, isBigNumber, isComplex, isFraction } from '../../util
 const name = 'eigs'
 
 // The absolute state of math.js's dependency system:
-const dependencies = ['config', 'typed', 'matrix', 'addScalar', 'equal', 'subtract', 'abs', 'atan', 'cos', 'sin', 'multiplyScalar', 'divideScalar', 'inv', 'bignumber', 'multiply', 'add', 'larger', 'column', 'flatten', 'number', 'complex', 'sqrt', 'diag', 'qr', 'usolveAll', 'im', 're', 'smaller', 'round', 'log10', 'transpose']
-export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config, typed, matrix, addScalar, subtract, equal, abs, atan, cos, sin, multiplyScalar, divideScalar, inv, bignumber, multiply, add, larger, column, flatten, number, complex, sqrt, diag, qr, usolveAll, im, re, smaller, round, log10, transpose }) => {
+const dependencies = ['config', 'typed', 'matrix', 'addScalar', 'equal', 'subtract', 'abs', 'atan', 'cos', 'sin', 'multiplyScalar', 'divideScalar', 'inv', 'bignumber', 'multiply', 'add', 'larger', 'column', 'flatten', 'number', 'complex', 'sqrt', 'diag', 'qr', 'usolveAll', 'im', 're', 'smaller', 'round', 'log10', 'transpose', 'matrixFromColumns']
+export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config, typed, matrix, addScalar, subtract, equal, abs, atan, cos, sin, multiplyScalar, divideScalar, inv, bignumber, multiply, add, larger, column, flatten, number, complex, sqrt, diag, qr, usolveAll, im, re, smaller, round, log10, transpose, matrixFromColumns }) => {
   const doRealSymetric = createRealSymmetric({ config, addScalar, subtract, column, flatten, equal, abs, atan, cos, sin, multiplyScalar, inv, bignumber, complex, multiply, add })
-  const doComplexEigs = createComplexEigs({ config, addScalar, subtract, multiply, multiplyScalar, flatten, divideScalar, sqrt, abs, bignumber, diag, qr, inv, usolveAll, equal, complex, larger, smaller, round, log10, transpose })
+  const doComplexEigs = createComplexEigs({ config, addScalar, subtract, multiply, multiplyScalar, flatten, divideScalar, sqrt, abs, bignumber, diag, qr, inv, usolveAll, equal, complex, larger, smaller, round, log10, transpose, matrixFromColumns })
 
   /**
    * Compute eigenvalues and eigenvectors of a matrix. The eigenvalues are sorted by their absolute value, ascending.
@@ -41,7 +41,7 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
    * @param {Array | Matrix} x  Matrix to be diagonalized
    *
    * @param {number | BigNumber} [prec] Precision, default value: 1e-15
-   * @return {{values: Array, vectors: Matrix}} Object containing an array of eigenvalues and a matrix with eigenvectors as columns.
+   * @return {{values: Array|Matrix, vectors: Array|Matrix}} Object containing an array of eigenvalues and a matrix with eigenvectors as columns.
    *
    */
   return typed('eigs', {
@@ -57,11 +57,19 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
     },
 
     Matrix: function (mat) {
-      return computeValuesAndVectors(mat)
+      const { values, vectors } = computeValuesAndVectors(mat)
+      return {
+        values: matrix(values),
+        vectors: matrix(vectors)
+      }
     },
 
     'Matrix, number|BigNumber': function (mat, prec) {
-      return computeValuesAndVectors(mat, prec)
+      const { values, vectors } = computeValuesAndVectors(mat, prec)
+      return {
+        values: matrix(values),
+        vectors: matrix(vectors)
+      }
     }
   })
 

--- a/src/function/matrix/eigs/complexEigs.js
+++ b/src/function/matrix/eigs/complexEigs.js
@@ -1,12 +1,14 @@
 import { clone } from '../../../utils/object.js'
 
-export function createComplexEigs ({ addScalar, subtract, flatten, multiply, multiplyScalar, divideScalar, sqrt, abs, bignumber, diag, inv, qr, usolveAll, equal, complex, larger, smaller, round, log10, transpose }) {
+export function createComplexEigs ({ addScalar, subtract, flatten, multiply, multiplyScalar, divideScalar, sqrt, abs, bignumber, diag, inv, qr, usolveAll, equal, complex, larger, smaller, round, log10, transpose, matrixFromColumns }) {
   /**
    * @param {number[][]} arr the matrix to find eigenvalues of
    * @param {number} N size of the matrix
    * @param {number|BigNumber} prec precision, anything lower will be considered zero
    * @param {'number'|'BigNumber'|'Complex'} type
    * @param {boolean} findVectors should we find eigenvectors?
+   *
+   * @returns {{ values: number[], vectors: number[][] }}
    */
   function complexEigs (arr, N, prec, type, findVectors) {
     if (findVectors === undefined) {
@@ -45,7 +47,7 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
 
     if (findVectors) {
       vectors = findEigenvectors(arr, N, C, values, prec)
-      vectors = transpose((vectors)) // vectors are columns of a matrix
+      vectors = matrixFromColumns(...vectors)
     }
 
     return { values, vectors }
@@ -388,7 +390,7 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
    * @param {number} N size of A
    * @param {Matrix} C column transformation matrix that turns A into upper triangular
    * @param {number[]} values array of eigenvalues of A
-   * @returns {Matrix[]} eigenvalues
+   * @returns {number[][]} eigenvalues
    */
   function findEigenvectors (A, N, C, values, prec) {
     const Cinv = inv(C)

--- a/src/function/matrix/matrixFromFunction.js
+++ b/src/function/matrix/matrixFromFunction.js
@@ -6,6 +6,8 @@ const dependencies = ['typed', 'matrix', 'isZero']
 export const createMatrixFromFunction = /* #__PURE__ */ factory(name, dependencies, ({ typed, matrix, isZero }) => {
   /**
    * Create a matrix by evaluating a generating function at each index.
+   * The simplest overload returns a multi-dimensional array as long as `size` is an array.
+   * Passing `size` as a Matrix or specifying a `format` will result in returning a Matrix.
    *
    * Syntax:
    *
@@ -27,9 +29,9 @@ export const createMatrixFromFunction = /* #__PURE__ */ factory(name, dependenci
    *
    * @param {Array | Matrix} size   The size of the matrix to be created
    * @param {function} fn           Callback function invoked for every entry in the matrix
-   * @param {string} [format]       The Matrix storage format, either `'dense'` or `'sparse'
+   * @param {string} [format]       The Matrix storage format, either `'dense'` or `'sparse'`
    * @param {string} [datatype]     Type of the values
-   * @return {Matrix} Returns the created matrix
+   * @return {Array | Matrix} Returns the created matrix
    */
   return typed(name, {
     'Array | Matrix, function, string, string': function (size, fn, format, datatype) {
@@ -38,8 +40,11 @@ export const createMatrixFromFunction = /* #__PURE__ */ factory(name, dependenci
     'Array | Matrix, function, string': function (size, fn, format) {
       return _create(size, fn, format)
     },
-    'Array | Matrix, function': function (size, fn) {
+    'Matrix, function': function (size, fn) {
       return _create(size, fn, 'dense')
+    },
+    'Array, function': function (size, fn) {
+      return _create(size, fn, 'dense').toArray()
     },
     'Array | Matrix, string, function': function (size, format, fn) {
       return _create(size, fn, format)

--- a/test/unit-tests/function/matrix/eigs.test.js
+++ b/test/unit-tests/function/matrix/eigs.test.js
@@ -1,8 +1,7 @@
 import assert from 'assert'
 import math from '../../../../src/defaultInstance.js'
 import approx from '../../../../tools/approx.js'
-const eigs = math.eigs
-const complex = math.complex
+const { eigs, complex, matrix, size, bignumber: bignum, Matrix, Complex } = math
 
 describe('eigs', function () {
   it('only accepts a square matrix', function () {
@@ -12,6 +11,28 @@ describe('eigs', function () {
     assert.throws(function () { eigs([4, 5, 6]) }, /Matrix must be square/)
     assert.throws(function () { eigs(1.0) }, /TypeError: Unexpected type of argument/)
     assert.throws(function () { eigs('random') }, /TypeError: Unexpected type of argument/)
+  })
+
+  it('follows aiao-mimo', function () {
+    const realSymArray = eigs([[1, 0], [0, 1]])
+    assert(Array.isArray(realSymArray.values) && typeof realSymArray.values[0] === 'number')
+    assert(Array.isArray(realSymArray.vectors) && typeof realSymArray.vectors[0][0] === 'number')
+
+    const genericArray = eigs([[0, 1], [-1, 0]])
+    assert(Array.isArray(genericArray.values) && genericArray.values[0] instanceof Complex)
+    assert(Array.isArray(genericArray.vectors) && genericArray.vectors[0][0] instanceof Complex)
+
+    const realSymMatrix = eigs(matrix([[1, 0], [0, 1]]))
+    assert(realSymMatrix.values instanceof Matrix)
+    assert.deepStrictEqual(size(realSymMatrix.values), matrix([2]))
+    assert(realSymMatrix.vectors instanceof Matrix)
+    assert.deepStrictEqual(size(realSymMatrix.vectors), matrix([2, 2]))
+
+    const genericMatrix = eigs(matrix([[0, 1], [-1, 0]]))
+    assert(genericMatrix.values instanceof Matrix)
+    assert.deepStrictEqual(size(genericMatrix.values), matrix([2]))
+    assert(genericMatrix.vectors instanceof Matrix)
+    assert.deepStrictEqual(size(genericMatrix.vectors), matrix([2, 2]))
   })
 
   it('only accepts a matrix with valid element type', function () {
@@ -37,7 +58,7 @@ describe('eigs', function () {
       [[1, 0.1], [0.1, 1]]).values, [0.9, 1.1]
     )
     approx.deepEqual(eigs(
-      math.matrix([[1, 0.1], [0.1, 1]])).values, [0.9, 1.1]
+      matrix([[1, 0.1], [0.1, 1]])).values, matrix([0.9, 1.1])
     )
     approx.deepEqual(eigs(
       [[5, 2.3], [2.3, 1]]).values, [-0.04795013082563382, 6.047950130825635]
@@ -90,13 +111,13 @@ describe('eigs', function () {
   })
 
   it('diagonalizes matrix with bigNumber', function () {
-    const x = [[math.bignumber(1), math.bignumber(0)], [math.bignumber(0), math.bignumber(1)]]
-    approx.deepEqual(eigs(x).values, [math.bignumber(1), math.bignumber(1)])
-    const y = [[math.bignumber(1), math.bignumber(1.0)], [math.bignumber(1.0), math.bignumber(1)]]
+    const x = [[bignum(1), bignum(0)], [bignum(0), bignum(1)]]
+    approx.deepEqual(eigs(x).values, [bignum(1), bignum(1)])
+    const y = [[bignum(1), bignum(1.0)], [bignum(1.0), bignum(1)]]
     const E1 = eigs(y).values
     approx.equal(E1[0].toNumber(), 0.0)
     approx.equal(E1[1].toNumber(), 2.0)
-    const H = math.bignumber([[-4.78, -1.0, -2.59, -3.26, 4.24, 4.14],
+    const H = bignum([[-4.78, -1.0, -2.59, -3.26, 4.24, 4.14],
       [-1.0, -2.45, -0.92, -2.33, -4.68, 4.27],
       [-2.59, -0.92, -2.45, 4.17, -3.33, 3.05],
       [-3.26, -2.33, 4.17, 2.51, 1.67, 2.24],
@@ -108,13 +129,13 @@ describe('eigs', function () {
     const VtHV = math.multiply(math.transpose(V), H, V)
     const Ei = Array(H.length)
     for (let i = 0; i < H.length; i++) {
-      Ei[i] = math.bignumber(VtHV[i][i])
+      Ei[i] = bignum(VtHV[i][i])
     }
     approx.deepEqual(Ei, E)
   })
 
   it('actually calculates BigNumbers input with BigNumber precision', function () {
-    const B = math.bignumber([
+    const B = bignum([
       [0, 1],
       [1, 0]
     ])

--- a/test/unit-tests/function/matrix/matrixFrom.test.js
+++ b/test/unit-tests/function/matrix/matrixFrom.test.js
@@ -8,9 +8,14 @@ describe('matrixFrom...', function () {
   it('...Function', function () {
     let expected, actual
 
-    // an antisymmetric matrix
-    expected = matrix([[0, -1, -2], [1, 0, -1], [2, 1, 0]])
+    // an antisymmetric matrix (array)
+    expected = [[0, -1, -2], [1, 0, -1], [2, 1, 0]]
     actual = math.matrixFromFunction([3, 3], i => i[0] - i[1])
+    assert.deepStrictEqual(actual, expected)
+
+    // an antisymmetric matrix (an actual Matrix)
+    expected = matrix([[0, -1, -2], [1, 0, -1], [2, 1, 0]])
+    actual = math.matrixFromFunction(matrix([3, 3]), i => i[0] - i[1])
     assert.deepStrictEqual(actual, expected)
 
     // a sparse subdiagonal matrix
@@ -19,7 +24,7 @@ describe('matrixFrom...', function () {
     assert.deepStrictEqual(actual, expected)
 
     // a random vector
-    actual = math.matrixFromFunction([5], i => math.random())
+    actual = math.matrixFromFunction([5], 'dense', i => math.random())
     assert.deepStrictEqual(actual.size(), [5])
     let counter = 0
     for (const { value } of actual) {


### PR DESCRIPTION
The PRs #1743 and #2155 didn't adhere the _“Array in—Array out, Matrix in—Matrix out”_ principle.
See: [#2155 (comment)](https://github.com/josdejong/mathjs/pull/2155#issuecomment-835750079) and [`e163032` (comment)](https://github.com/josdejong/mathjs/commit/e163032ad2051ee26c617a43d653bb66812b4bd8#commitcomment-50579604)

This PR fixes the problem, the current function annotations are:
```typescript
function eigs(m: number[][]): { values: number[], vectors: number[][] }
function eigs(m: Matrix): { values: Matrix, vectors: Matrix }

function matrixFromFunction(size: number[], fn: Function): Array
function matrixFromFunction(size: Matrix, fn: Function): Matrix
function matrixFromFunction(size: Matrix | number[], format: 'dense' | 'sparse', fn): Matrix
function matrixFromFunction(size: Matrix | number[], format: 'dense' | 'sparse', datatype, fn): Matrix
function matrixFromFunction(size: Matrix | number[], fn, format: 'dense' | 'sparse', datatype?): Matrix
```

Note that to get a `Matrix` from `matrixFromFunction`, you can either pass `size` as a `Matrix`, or specify `format`.
