### PR TITLE
Fix ArrayNode.toTex(): Remove the row delimiter on the last row

### DIFF
--- a/src/expression/node/ArrayNode.js
+++ b/src/expression/node/ArrayNode.js
@@ -155,24 +155,17 @@ export const createArrayNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    * @return {string} str
    */
   ArrayNode.prototype._toTex = function (options) {
-    let s = '\\begin{bmatrix}'
+    const itemsTex = this.items
+      .map(function (node) {
+        if (node.items) {
+          return node.items.map(item => item.toTex(options)).join('&')
+        } else {
+          return node.toTex(options)
+        }
+      })
+      .join('\\\\')
 
-    this.items.forEach(function (node, idx, items) {
-      if (node.items) {
-        s += node.items.map(function (childNode) {
-          return childNode.toTex(options)
-        }).join('&')
-      } else {
-        s += node.toTex(options)
-      }
-
-      // new line (include row delimiter on every low but the last)
-      if (idx < items.length - 1) {
-        s += '\\\\'
-      }
-    })
-    s += '\\end{bmatrix}'
-    return s
+    return '\\begin{bmatrix}' + itemsTex + '\\end{bmatrix}'
   }
 
   return ArrayNode

--- a/src/expression/node/ArrayNode.js
+++ b/src/expression/node/ArrayNode.js
@@ -157,7 +157,7 @@ export const createArrayNode = /* #__PURE__ */ factory(name, dependencies, ({ No
   ArrayNode.prototype._toTex = function (options) {
     let s = '\\begin{bmatrix}'
 
-    this.items.forEach(function (node) {
+    this.items.forEach(function (node, idx, items) {
       if (node.items) {
         s += node.items.map(function (childNode) {
           return childNode.toTex(options)
@@ -166,8 +166,10 @@ export const createArrayNode = /* #__PURE__ */ factory(name, dependencies, ({ No
         s += node.toTex(options)
       }
 
-      // new line
-      s += '\\\\'
+      // new line (include row delimiter on every low but the last)
+      if (idx < items.length - 1) {
+        s += '\\\\'
+      }
     })
     s += '\\end{bmatrix}'
     return s

--- a/src/expression/node/ArrayNode.js
+++ b/src/expression/node/ArrayNode.js
@@ -162,8 +162,7 @@ export const createArrayNode = /* #__PURE__ */ factory(name, dependencies, ({ No
       const itemsTex = items
         .map(function (node) {
           if (node.items) {
-            const nodeTex = itemsToTex(node.items, !nested)
-            return nodeTex
+            return itemsToTex(node.items, !nested)
           } else {
             return node.toTex(options)
           }

--- a/test/unit-tests/expression/node/ArrayNode.test.js
+++ b/test/unit-tests/expression/node/ArrayNode.test.js
@@ -300,7 +300,7 @@ describe('ArrayNode', function () {
     const v2 = new ArrayNode([c, d])
     const n = new ArrayNode([v1, v2])
 
-    assert.strictEqual(n.toTex(), '\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}')
+    assert.strictEqual(n.toTex(), '\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}')
   })
 
   it('should LaTeX an ArrayNode with custom toTex', function () {

--- a/test/unit-tests/expression/node/ArrayNode.test.js
+++ b/test/unit-tests/expression/node/ArrayNode.test.js
@@ -303,6 +303,35 @@ describe('ArrayNode', function () {
     assert.strictEqual(n.toTex(), '\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}')
   })
 
+  it('should LaTeX a nested ArrayNode', function () {
+    // [x, [y, [z]]]
+    const a = new ConstantNode(1)
+    const b = new ConstantNode(2)
+    const c = new ConstantNode(3)
+
+    const v1 = new ArrayNode([c])
+    const v2 = new ArrayNode([b, v1])
+    const n = new ArrayNode([a, v2])
+
+    assert.strictEqual(n.toTex(), '\\begin{bmatrix}1&\\begin{bmatrix}2&\\begin{bmatrix}3\\end{bmatrix}\\end{bmatrix}\\end{bmatrix}')
+  })
+
+  it('should LaTeX a nested ArrayNode', function () {
+    // [x; [y; [z]]]
+    const v = new ArrayNode([
+      new ArrayNode([new ConstantNode(1)]),
+      new ArrayNode([
+        new ArrayNode([
+          new ArrayNode([new ConstantNode(2)]),
+          new ArrayNode([
+            new ArrayNode([new ConstantNode(3)])
+          ])
+        ])
+      ])
+    ])
+    assert.strictEqual(v.toTex(), '\\begin{bmatrix}1\\\\\\begin{bmatrix}2\\\\\\begin{bmatrix}3\\end{bmatrix}\\end{bmatrix}\\end{bmatrix}')
+  })
+
   it('should LaTeX an ArrayNode with custom toTex', function () {
     // Also checks if the custom functions get passed on to the children
     const customFunction = function (node, options) {

--- a/test/unit-tests/function/arithmetic/dotDivide.test.js
+++ b/test/unit-tests/function/arithmetic/dotDivide.test.js
@@ -169,6 +169,6 @@ describe('dotDivide', function () {
 
   it('should LaTeX dotDivide', function () {
     const expression = math.parse('dotDivide([1,2],[3,4])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix}.:\\begin{bmatrix}3\\\\4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix}.:\\begin{bmatrix}3\\\\4\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/arithmetic/dotMultiply.test.js
+++ b/test/unit-tests/function/arithmetic/dotMultiply.test.js
@@ -177,6 +177,6 @@ describe('dotMultiply', function () {
 
   it('should LaTeX dotMultiply', function () {
     const expression = math.parse('dotMultiply([1,2],[3,4])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix}.\\cdot\\begin{bmatrix}3\\\\4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix}.\\cdot\\begin{bmatrix}3\\\\4\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/arithmetic/dotPow.test.js
+++ b/test/unit-tests/function/arithmetic/dotPow.test.js
@@ -167,6 +167,6 @@ describe('dotPow', function () {
 
   it('should LaTeX dotPow', function () {
     const expression = math.parse('dotPow([1,2],[3,4])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix}.^\\wedge\\begin{bmatrix}3\\\\4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix}.^\\wedge\\begin{bmatrix}3\\\\4\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/concat.test.js
+++ b/test/unit-tests/function/matrix/concat.test.js
@@ -104,6 +104,6 @@ describe('concat', function () {
 
   it('should LaTeX concat', function () {
     const expression = math.parse('concat([1],[2])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{concat}\\left(\\begin{bmatrix}1\\\\\\end{bmatrix},\\begin{bmatrix}2\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{concat}\\left(\\begin{bmatrix}1\\end{bmatrix},\\begin{bmatrix}2\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/cross.test.js
+++ b/test/unit-tests/function/matrix/cross.test.js
@@ -44,6 +44,6 @@ describe('cross', function () {
 
   it('should LaTeX cross', function () {
     const expression = math.parse('cross([1],[2])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\\\end{bmatrix}\\right)\\times\\left(\\begin{bmatrix}2\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\end{bmatrix}\\right)\\times\\left(\\begin{bmatrix}2\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/ctranspose.test.js
+++ b/test/unit-tests/function/matrix/ctranspose.test.js
@@ -157,6 +157,6 @@ describe('ctranspose', function () {
 
   it('should LaTeX transpose', function () {
     const expression = math.parse('ctranspose([[1+2i,3+4i],[5+6i,7+8i]])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1+2~ i&3+4~ i\\\\5+6~ i&7+8~ i\\\\\\end{bmatrix}\\right)^H')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1+2~ i&3+4~ i\\\\5+6~ i&7+8~ i\\end{bmatrix}\\right)^H')
   })
 })

--- a/test/unit-tests/function/matrix/det.test.js
+++ b/test/unit-tests/function/matrix/det.test.js
@@ -151,6 +151,6 @@ describe('det', function () {
 
   it('should LaTeX det', function () {
     const expression = math.parse('det([1])')
-    assert.strictEqual(expression.toTex(), '\\det\\left(\\begin{bmatrix}1\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\det\\left(\\begin{bmatrix}1\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/diag.test.js
+++ b/test/unit-tests/function/matrix/diag.test.js
@@ -120,7 +120,7 @@ describe('diag', function () {
     const expr1 = math.parse('diag([1,2,3])')
     const expr2 = math.parse('diag([1,2,3],1)')
 
-    assert.strictEqual(expr1.toTex(), '\\mathrm{diag}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix}\\right)')
-    assert.strictEqual(expr2.toTex(), '\\mathrm{diag}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix},1\\right)')
+    assert.strictEqual(expr1.toTex(), '\\mathrm{diag}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix}\\right)')
+    assert.strictEqual(expr2.toTex(), '\\mathrm{diag}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix},1\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/dot.test.js
+++ b/test/unit-tests/function/matrix/dot.test.js
@@ -80,7 +80,7 @@ describe('dot', function () {
 
   it('should LaTeX dot', function () {
     const expression = math.parse('dot([1,2],[3,4])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix}\\cdot\\begin{bmatrix}3\\\\4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix}\\cdot\\begin{bmatrix}3\\\\4\\end{bmatrix}\\right)')
   })
 
   it('should be antilinear in the first argument', function () {

--- a/test/unit-tests/function/matrix/expm.test.js
+++ b/test/unit-tests/function/matrix/expm.test.js
@@ -88,6 +88,6 @@ describe('expm', function () {
 
   it('should LaTeX transpose', function () {
     const expression = math.parse('expm([[1,2],[3,4]])')
-    assert.strictEqual(expression.toTex(), '\\exp\\left(\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\exp\\left(\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/flatten.test.js
+++ b/test/unit-tests/function/matrix/flatten.test.js
@@ -47,6 +47,6 @@ describe('flatten', function () {
 
   it('should LaTeX flatten', function () {
     const expression = math.parse('flatten([[1,2],[3,4]])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{flatten}\\left(\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{flatten}\\left(\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/forEach.test.js
+++ b/test/unit-tests/function/matrix/forEach.test.js
@@ -75,6 +75,6 @@ describe('forEach', function () {
 
   it('should LaTeX forEach', function () {
     const expression = math.parse('forEach([1,2,3],callback)')
-    assert.strictEqual(expression.toTex(), '\\mathrm{forEach}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix}, callback\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{forEach}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix}, callback\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/inv.test.js
+++ b/test/unit-tests/function/matrix/inv.test.js
@@ -121,6 +121,6 @@ describe('inv', function () {
 
   it('should  LaTeX inv', function () {
     const expression = math.parse('inv([[1,2],[3,4]])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}\\right)^{-1}')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}\\right)^{-1}')
   })
 })

--- a/test/unit-tests/function/matrix/map.test.js
+++ b/test/unit-tests/function/matrix/map.test.js
@@ -74,6 +74,6 @@ describe('map', function () {
 
   it('should LaTeX map', function () {
     const expression = math.parse('map([1,2,3],callback)')
-    assert.strictEqual(expression.toTex(), '\\mathrm{map}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix}, callback\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{map}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix}, callback\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/reshape.test.js
+++ b/test/unit-tests/function/matrix/reshape.test.js
@@ -60,7 +60,7 @@ describe('reshape', function () {
 
   it('should LaTeX reshape', function () {
     const expression = math.parse('reshape([1,2],1)')
-    assert.strictEqual(expression.toTex(), '\\mathrm{reshape}\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix},1\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{reshape}\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix},1\\right)')
   })
 
   it('should reshape a SparseMatrix', function () {

--- a/test/unit-tests/function/matrix/resize.test.js
+++ b/test/unit-tests/function/matrix/resize.test.js
@@ -120,6 +120,6 @@ describe('resize', function () {
 
   it('should LaTeX resize', function () {
     const expression = math.parse('resize([1,2],1)')
-    assert.strictEqual(expression.toTex(), '\\mathrm{resize}\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix},1\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{resize}\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix},1\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/rotate.test.js
+++ b/test/unit-tests/function/matrix/rotate.test.js
@@ -176,10 +176,10 @@ describe('rotate', function () {
 
   it('should LaTeX rotationMatrix', function () {
     const expression1 = math.parse('rotate([1, 2, 3], 1)')
-    assert.strictEqual(expression1.toTex(), '\\mathrm{rotate}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix},1\\right)')
+    assert.strictEqual(expression1.toTex(), '\\mathrm{rotate}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix},1\\right)')
 
     const expression2 = math.parse('rotate([1, 2, 3], 1, [4, 5, 6])')
-    assert.strictEqual(expression2.toTex(), '\\mathrm{rotate}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix},1,' +
-      '\\begin{bmatrix}4\\\\5\\\\6\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression2.toTex(), '\\mathrm{rotate}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix},1,' +
+      '\\begin{bmatrix}4\\\\5\\\\6\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/sort.test.js
+++ b/test/unit-tests/function/matrix/sort.test.js
@@ -54,6 +54,6 @@ describe('sort', function () {
 
   it('should LaTeX sort', function () {
     const expression = math.parse('sort([3,2,1])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{sort}\\left(\\begin{bmatrix}3\\\\2\\\\1\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{sort}\\left(\\begin{bmatrix}3\\\\2\\\\1\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/sqrtm.test.js
+++ b/test/unit-tests/function/matrix/sqrtm.test.js
@@ -61,7 +61,7 @@ describe('sqrtm', function () {
 
   it('should LaTeX sqrtm', function () {
     const expression = math.parse('sqrtm([[33, 24], [48, 57]])')
-    assert.strictEqual(expression.toTex(), '{\\begin{bmatrix}33&24\\\\48&57\\\\\\end{bmatrix}}^{\\frac{1}{2}}')
+    assert.strictEqual(expression.toTex(), '{\\begin{bmatrix}33&24\\\\48&57\\end{bmatrix}}^{\\frac{1}{2}}')
   })
 
   it('should return the result in the same format as the input', function () {

--- a/test/unit-tests/function/matrix/squeeze.test.js
+++ b/test/unit-tests/function/matrix/squeeze.test.js
@@ -33,6 +33,6 @@ describe('squeeze', function () {
 
   it('should LaTeX squeeze', function () {
     const expression = math.parse('squeeze([[0],[0]])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{squeeze}\\left(\\begin{bmatrix}0\\\\0\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{squeeze}\\left(\\begin{bmatrix}0\\\\0\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/subset.test.js
+++ b/test/unit-tests/function/matrix/subset.test.js
@@ -166,6 +166,6 @@ describe('subset', function () {
 
   it('should LaTeX subset', function () {
     const expression = math.parse('subset([1],index(0,0))')
-    assert.strictEqual(expression.toTex(), '\\mathrm{subset}\\left(\\begin{bmatrix}1\\\\\\end{bmatrix},\\mathrm{index}\\left(0,0\\right)\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{subset}\\left(\\begin{bmatrix}1\\end{bmatrix},\\mathrm{index}\\left(0,0\\right)\\right)')
   })
 })

--- a/test/unit-tests/function/matrix/trace.test.js
+++ b/test/unit-tests/function/matrix/trace.test.js
@@ -206,7 +206,7 @@ describe('trace', function () {
 
   it('should LaTeX trace', function () {
     const expression = math.parse('trace([[1,2],[3,4]])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{tr}\\left(\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{tr}\\left(\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}\\right)')
   })
 
   describe('DenseMatrix', function () {

--- a/test/unit-tests/function/matrix/transpose.test.js
+++ b/test/unit-tests/function/matrix/transpose.test.js
@@ -96,6 +96,6 @@ describe('transpose', function () {
 
   it('should LaTeX transpose', function () {
     const expression = math.parse('transpose([[1,2],[3,4]])')
-    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1&2\\\\3&4\\\\\\end{bmatrix}\\right)^\\top')
+    assert.strictEqual(expression.toTex(), '\\left(\\begin{bmatrix}1&2\\\\3&4\\end{bmatrix}\\right)^\\top')
   })
 })

--- a/test/unit-tests/function/probability/pickRandom.test.js
+++ b/test/unit-tests/function/probability/pickRandom.test.js
@@ -303,7 +303,7 @@ describe('pickRandom', function () {
 
   it('should LaTeX pickRandom', function () {
     const expression = math.parse('pickRandom([1,2,3])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{pickRandom}\\left(\\begin{bmatrix}1\\\\2\\\\3\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{pickRandom}\\left(\\begin{bmatrix}1\\\\2\\\\3\\end{bmatrix}\\right)')
   })
 })
 

--- a/test/unit-tests/function/relational/deepEqual.test.js
+++ b/test/unit-tests/function/relational/deepEqual.test.js
@@ -60,6 +60,6 @@ describe('deepEqual', function () {
 
   it('should LaTeX deepEqual', function () {
     const expression = math.parse('deepEqual([1,2],[1,3])')
-    assert.strictEqual(expression.toTex(), '\\mathrm{deepEqual}\\left(\\begin{bmatrix}1\\\\2\\\\\\end{bmatrix},\\begin{bmatrix}1\\\\3\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expression.toTex(), '\\mathrm{deepEqual}\\left(\\begin{bmatrix}1\\\\2\\end{bmatrix},\\begin{bmatrix}1\\\\3\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/type/matrix/function/matrix.test.js
+++ b/test/unit-tests/type/matrix/function/matrix.test.js
@@ -101,6 +101,6 @@ describe('matrix', function () {
     const expr2 = math.parse('matrix([1])')
 
     assert.strictEqual(expr1.toTex(), '\\begin{bmatrix}\\end{bmatrix}')
-    assert.strictEqual(expr2.toTex(), '\\left(\\begin{bmatrix}1\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expr2.toTex(), '\\left(\\begin{bmatrix}1\\end{bmatrix}\\right)')
   })
 })

--- a/test/unit-tests/type/matrix/function/sparse.test.js
+++ b/test/unit-tests/type/matrix/function/sparse.test.js
@@ -48,6 +48,6 @@ describe('sparse', function () {
     const expr2 = math.parse('sparse([1])')
 
     assert.strictEqual(expr1.toTex(), '\\begin{bsparse}\\end{bsparse}')
-    assert.strictEqual(expr2.toTex(), '\\left(\\begin{bmatrix}1\\\\\\end{bmatrix}\\right)')
+    assert.strictEqual(expr2.toTex(), '\\left(\\begin{bmatrix}1\\end{bmatrix}\\right)')
   })
 })


### PR DESCRIPTION
This issue was addressed in [this PR](https://github.com/josdejong/mathjs/pull/1542), but it was not merged because the PR included other features whose inclusion has not been finalized. This fix is minimal: just a two-line fix to ensure the row delimiter is added to every row but the last.

The relevant unit tests fail because the expected output includes the trailing `\\` .

Although in regular TeX the trailing `\\` does not change the output, other libraries such as [MathQuill](mathquill.com) (reasonably) interpret this as a blank row:

![image](https://user-images.githubusercontent.com/30242944/123897321-32923680-d931-11eb-986f-24751eb99de8.png)

instead of the expected:

![image](https://user-images.githubusercontent.com/30242944/123897456-65d4c580-d931-11eb-8a66-6a8d4149b286.png)

