### PR TITLE
Jhugman math with transform using maps

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -111,11 +111,9 @@ function completer (text) {
 
     // math functions and constants
     const ignore = ['expr', 'type']
-    for (const func in math.expression.mathWithTransform) {
-      if (hasOwnProperty(math.expression.mathWithTransform, func)) {
-        if (func.indexOf(keyword) === 0 && ignore.indexOf(func) === -1) {
-          matches.push(func)
-        }
+    for (const key of math.expression.mathWithTransform.keys()) {
+      if (key.indexOf(keyword) === 0 && ignore.indexOf(key) === -1) {
+        matches.push(key)
       }
     }
 

--- a/src/core/create.js
+++ b/src/core/create.js
@@ -1,4 +1,5 @@
 import './../utils/polyfills.js'
+import { LazyMap } from '../utils/map.js'
 import { deepFlatten, isLegacyFactory, values } from '../utils/object.js'
 import * as emitter from './../utils/emitter.js'
 import { importFactory } from './function/import.js'
@@ -145,11 +146,12 @@ export function create (factories, config) {
   // load config function and apply provided config
   math.config = configFactory(configInternal, math.emit)
 
+  const mathWithTransform = new LazyMap()
+  mathWithTransform.set('config', math.config)
+
   math.expression = {
     transform: {},
-    mathWithTransform: {
-      config: math.config
-    }
+    mathWithTransform
   }
 
   // cached factories and instances used by function load

--- a/src/core/function/import.js
+++ b/src/core/function/import.js
@@ -183,13 +183,13 @@ export function importFactory (typed, load, math, importedFactories) {
     if (value && typeof value.transform === 'function') {
       math.expression.transform[name] = value.transform
       if (allowedInExpressions(name)) {
-        math.expression.mathWithTransform[name] = value.transform
+        math.expression.mathWithTransform.set(name, value.transform)
       }
     } else {
       // remove existing transform
       delete math.expression.transform[name]
       if (allowedInExpressions(name)) {
-        math.expression.mathWithTransform[name] = value
+        math.expression.mathWithTransform.set(name, value)
       }
     }
   }
@@ -197,9 +197,9 @@ export function importFactory (typed, load, math, importedFactories) {
   function _deleteTransform (name) {
     delete math.expression.transform[name]
     if (allowedInExpressions(name)) {
-      math.expression.mathWithTransform[name] = math[name]
+      math.expression.mathWithTransform.set(name, math[name])
     } else {
-      delete math.expression.mathWithTransform[name]
+      math.expression.mathWithTransform.delete(name)
     }
   }
 
@@ -302,7 +302,7 @@ export function importFactory (typed, load, math, importedFactories) {
         _deleteTransform(name)
       } else {
         if (isTransformFunctionFactory(factory) || factoryAllowedInExpressions(factory)) {
-          lazy(math.expression.mathWithTransform, name, () => namespace[name])
+          math.expression.mathWithTransform.setLazy(name, () => namespace[name])
         }
       }
     } else {
@@ -313,7 +313,7 @@ export function importFactory (typed, load, math, importedFactories) {
         _deleteTransform(name)
       } else {
         if (isTransformFunctionFactory(factory) || factoryAllowedInExpressions(factory)) {
-          lazy(math.expression.mathWithTransform, name, () => namespace[name])
+          math.expression.mathWithTransform.setLazy(name, () => namespace[name])
         }
       }
     }

--- a/src/expression/function/help.js
+++ b/src/expression/function/help.js
@@ -1,7 +1,6 @@
-import { factory } from '../../utils/factory.js'
 import { getSafeProperty } from '../../utils/customs.js'
+import { factory } from '../../utils/factory.js'
 import { embeddedDocs } from '../embeddedDocs/embeddedDocs.js'
-import { hasOwnProperty } from '../../utils/object.js'
 
 const name = 'help'
 const dependencies = ['typed', 'mathWithTransform', 'Help']
@@ -27,13 +26,12 @@ export const createHelp = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
    */
   return typed(name, {
     any: function (search) {
-      let prop
       let searchName = search
 
       if (typeof search !== 'string') {
-        for (prop in mathWithTransform) {
+        for (const prop of mathWithTransform.keys()) {
           // search in functions and constants
-          if (hasOwnProperty(mathWithTransform, prop) && (search === mathWithTransform[prop])) {
+          if (search === mathWithTransform.get(prop)) {
             searchName = prop
             break
           }

--- a/src/expression/node/AccessorNode.js
+++ b/src/expression/node/AccessorNode.js
@@ -73,7 +73,7 @@ export const createAccessorNode = /* #__PURE__ */ factory(name, dependencies, ({
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/ArrayNode.js
+++ b/src/expression/node/ArrayNode.js
@@ -51,9 +51,9 @@ export const createArrayNode = /* #__PURE__ */ factory(name, dependencies, ({ No
       return item._compile(math, argNames)
     })
 
-    const asMatrix = (math.config.matrix !== 'Array')
+    const asMatrix = (math.get('config').matrix !== 'Array')
     if (asMatrix) {
-      const matrix = math.matrix
+      const matrix = math.get('matrix')
       return function evalArrayNode (scope, args, context) {
         return matrix(map(evalItems, function (evalItem) {
           return evalItem(scope, args, context)

--- a/src/expression/node/ArrayNode.js
+++ b/src/expression/node/ArrayNode.js
@@ -37,7 +37,7 @@ export const createArrayNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/BlockNode.js
+++ b/src/expression/node/BlockNode.js
@@ -49,7 +49,7 @@ export const createBlockNode = /* #__PURE__ */ factory(name, dependencies, ({ Re
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/ConditionalNode.js
+++ b/src/expression/node/ConditionalNode.js
@@ -41,7 +41,7 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/ConstantNode.js
+++ b/src/expression/node/ConstantNode.js
@@ -39,7 +39,7 @@ export const createConstantNode = /* #__PURE__ */ factory(name, dependencies, ({
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/FunctionAssignmentNode.js
+++ b/src/expression/node/FunctionAssignmentNode.js
@@ -57,7 +57,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/FunctionNode.js
+++ b/src/expression/node/FunctionNode.js
@@ -61,7 +61,7 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/FunctionNode.js
+++ b/src/expression/node/FunctionNode.js
@@ -1,7 +1,7 @@
 import { isAccessorNode, isFunctionAssignmentNode, isIndexNode, isNode, isSymbolNode } from '../../utils/is.js'
 import { escape } from '../../utils/string.js'
 import { hasOwnProperty } from '../../utils/object.js'
-import { getSafeProperty, validateSafeMethod } from '../../utils/customs.js'
+import { validateSafeMethod } from '../../utils/customs.js'
 import { createSubScope } from '../../utils/scope.js'
 import { factory } from '../../utils/factory.js'
 import { defaultTemplate, latexFunctions } from '../../utils/latex.js'
@@ -81,15 +81,15 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
     if (isSymbolNode(this.fn)) {
       // we can statically determine whether the function has an rawArgs property
       const name = this.fn.name
-      const fn = name in math ? getSafeProperty(math, name) : undefined
+      const fn = math.has(name) ? math.get(name) : undefined
       const isRaw = typeof fn === 'function' && fn.rawArgs === true
 
       const resolveFn = (scope) => {
         if (scope.has(name)) {
           return scope.get(name)
         }
-        if (name in math) {
-          return getSafeProperty(math, name)
+        if (math.has(name)) {
+          return math.get(name)
         }
         return FunctionNode.onUndefinedFunction(name)
       }

--- a/src/expression/node/IndexNode.js
+++ b/src/expression/node/IndexNode.js
@@ -53,7 +53,7 @@ export const createIndexNode = /* #__PURE__ */ factory(name, dependencies, ({ Ra
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/IndexNode.js
+++ b/src/expression/node/IndexNode.js
@@ -2,7 +2,6 @@ import { isBigNumber, isConstantNode, isNode, isRangeNode, isSymbolNode } from '
 import { map } from '../../utils/array.js'
 import { escape } from '../../utils/string.js'
 import { factory } from '../../utils/factory.js'
-import { getSafeProperty } from '../../utils/customs.js'
 
 const name = 'IndexNode'
 const dependencies = [
@@ -134,7 +133,7 @@ export const createIndexNode = /* #__PURE__ */ factory(name, dependencies, ({ Ra
       }
     })
 
-    const index = getSafeProperty(math, 'index')
+    const index = math.get('index')
 
     return function evalIndexNode (scope, args, context) {
       const dimensions = map(evalDimensions, function (evalDimension) {

--- a/src/expression/node/Node.js
+++ b/src/expression/node/Node.js
@@ -33,19 +33,16 @@ export const createNode = /* #__PURE__ */ factory(name, dependencies, ({ mathWit
 
   Node.prototype.comment = ''
 
-  // Wrap the mathWithTransform object in a map
-  const math = createMap(mathWithTransform)
-
   /**
-   * Compile the node into an optimized, evauatable JavaScript function
-   * @return {{evaluate: function([Object])}} object
+   * Compile the node into an optimized, evaluable JavaScript function
+   * @return {{evaluate: function(Object?)}} object
    *                Returns an object with a function 'evaluate',
    *                which can be invoked as expr.evaluate([scope: Object]),
    *                where scope is an optional object with
    *                variables.
    */
   Node.prototype.compile = function () {
-    const expr = this._compile(math, {})
+    const expr = this._compile(mathWithTransform, {})
     const args = {}
     const context = null
 
@@ -64,7 +61,7 @@ export const createNode = /* #__PURE__ */ factory(name, dependencies, ({ mathWit
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/Node.js
+++ b/src/expression/node/Node.js
@@ -33,6 +33,9 @@ export const createNode = /* #__PURE__ */ factory(name, dependencies, ({ mathWit
 
   Node.prototype.comment = ''
 
+  // Wrap the mathWithTransform object in a map
+  const math = createMap(mathWithTransform)
+
   /**
    * Compile the node into an optimized, evauatable JavaScript function
    * @return {{evaluate: function([Object])}} object
@@ -42,7 +45,7 @@ export const createNode = /* #__PURE__ */ factory(name, dependencies, ({ mathWit
    *                variables.
    */
   Node.prototype.compile = function () {
-    const expr = this._compile(mathWithTransform, {})
+    const expr = this._compile(math, {})
     const args = {}
     const context = null
 

--- a/src/expression/node/ObjectNode.js
+++ b/src/expression/node/ObjectNode.js
@@ -43,7 +43,7 @@ export const createObjectNode = /* #__PURE__ */ factory(name, dependencies, ({ N
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/OperatorNode.js
+++ b/src/expression/node/OperatorNode.js
@@ -1,7 +1,7 @@
 import { isNode } from '../../utils/is.js'
 import { map } from '../../utils/array.js'
 import { escape } from '../../utils/string.js'
-import { getSafeProperty, isSafeMethod } from '../../utils/customs.js'
+import { isSafeMethod } from '../../utils/customs.js'
 import { getAssociativity, getPrecedence, isAssociativeWith, properties } from '../operators.js'
 import { latexOperators } from '../../utils/latex.js'
 import { factory } from '../../utils/factory.js'
@@ -65,15 +65,14 @@ export const createOperatorNode = /* #__PURE__ */ factory(name, dependencies, ({
    */
   OperatorNode.prototype._compile = function (math, argNames) {
     // validate fn
-    if (typeof this.fn !== 'string' || !isSafeMethod(math, this.fn)) {
-      if (!math[this.fn]) {
-        throw new Error('Function ' + this.fn + ' missing in provided namespace "math"')
-      } else {
-        throw new Error('No access to function "' + this.fn + '"')
-      }
+    if (typeof this.fn !== 'string' || isSafeMethod(this.fn)) {
+      throw new Error('No access to function "' + this.fn + '"')
+    }
+    if (!math.has(this.fn)) {
+      throw new Error('Function ' + this.fn + ' missing in provided namespace "math"')
     }
 
-    const fn = getSafeProperty(math, this.fn)
+    const fn = math.get(this.fn)
     const evalArgs = map(this.args, function (arg) {
       return arg._compile(math, argNames)
     })

--- a/src/expression/node/OperatorNode.js
+++ b/src/expression/node/OperatorNode.js
@@ -54,7 +54,7 @@ export const createOperatorNode = /* #__PURE__ */ factory(name, dependencies, ({
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/ParenthesisNode.js
+++ b/src/expression/node/ParenthesisNode.js
@@ -37,7 +37,7 @@ export const createParenthesisNode = /* #__PURE__ */ factory(name, dependencies,
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/RangeNode.js
+++ b/src/expression/node/RangeNode.js
@@ -56,7 +56,7 @@ export const createRangeNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/RangeNode.js
+++ b/src/expression/node/RangeNode.js
@@ -66,7 +66,7 @@ export const createRangeNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    *                        evalNode(scope: Object, args: Object, context: *)
    */
   RangeNode.prototype._compile = function (math, argNames) {
-    const range = math.range
+    const range = math.get('range')
     const evalStart = this.start._compile(math, argNames)
     const evalEnd = this.end._compile(math, argNames)
 

--- a/src/expression/node/RelationalNode.js
+++ b/src/expression/node/RelationalNode.js
@@ -1,6 +1,5 @@
 import { getPrecedence } from '../operators.js'
 import { escape } from '../../utils/string.js'
-import { getSafeProperty } from '../../utils/customs.js'
 import { latexOperators } from '../../utils/latex.js'
 import { factory } from '../../utils/factory.js'
 
@@ -62,7 +61,7 @@ export const createRelationalNode = /* #__PURE__ */ factory(name, dependencies, 
       for (let i = 0; i < self.conditionals.length; i++) {
         evalLhs = evalRhs
         evalRhs = compiled[i + 1](scope, args, context)
-        const condFn = getSafeProperty(math, self.conditionals[i])
+        const condFn = math.get(self.conditionals[i])
         if (!condFn(evalLhs, evalRhs)) {
           return false
         }

--- a/src/expression/node/RelationalNode.js
+++ b/src/expression/node/RelationalNode.js
@@ -40,7 +40,7 @@ export const createRelationalNode = /* #__PURE__ */ factory(name, dependencies, 
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/SymbolNode.js
+++ b/src/expression/node/SymbolNode.js
@@ -47,7 +47,7 @@ export const createSymbolNode = /* #__PURE__ */ factory(name, dependencies, ({ m
    * Compile a node into a JavaScript function.
    * This basically pre-calculates as much as possible and only leaves open
    * calculations which depend on a dynamic scope with variables.
-   * @param {Object} math     Math.js namespace with functions and constants.
+   * @param {Map} math        Math.js namespace with functions and constants.
    * @param {Object} argNames An object with argument names as key and `true`
    *                          as value. Used in the SymbolNode to optimize
    *                          for arguments from user assigned functions

--- a/src/expression/node/SymbolNode.js
+++ b/src/expression/node/SymbolNode.js
@@ -1,5 +1,4 @@
 import { escape } from '../../utils/string.js'
-import { getSafeProperty } from '../../utils/customs.js'
 import { factory } from '../../utils/factory.js'
 import { toSymbol } from '../../utils/latex.js'
 
@@ -66,11 +65,11 @@ export const createSymbolNode = /* #__PURE__ */ factory(name, dependencies, ({ m
       return function (scope, args, context) {
         return args[name]
       }
-    } else if (name in math) {
+    } else if (math.has(name)) {
       return function (scope, args, context) {
         return scope.has(name)
           ? scope.get(name)
-          : getSafeProperty(math, name)
+          : math.get(name)
       }
     } else {
       const isUnit = isValuelessUnit(name)

--- a/src/expression/transform/utils/compileInlineExpression.js
+++ b/src/expression/transform/utils/compileInlineExpression.js
@@ -13,8 +13,8 @@ export function compileInlineExpression (expression, math, scope) {
   // find an undefined symbol
   const symbol = expression.filter(function (node) {
     return isSymbolNode(node) &&
-        !(node.name in math) &&
-        !(scope.has(node.name))
+        !math.has(node.name) &&
+        !scope.has(node.name)
   })[0]
 
   if (!symbol) {

--- a/src/function/algebra/simplify/simplifyConstant.js
+++ b/src/function/algebra/simplify/simplifyConstant.js
@@ -38,7 +38,7 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
 
   function _eval (fnname, args, options) {
     try {
-      return _toNumber(mathWithTransform[fnname].apply(null, args), options)
+      return _toNumber(mathWithTransform.get(fnname).apply(null, args), options)
     } catch (ignore) {
       // sometimes the implicit type conversion causes the evaluation to fail, so we'll try again after removing Fractions
       args = args.map(function (x) {
@@ -47,7 +47,7 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
         }
         return x
       })
-      return _toNumber(mathWithTransform[fnname].apply(null, args), options)
+      return _toNumber(mathWithTransform.get(fnname).apply(null, args), options)
     }
   }
 
@@ -181,7 +181,7 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
         }
         return node
       case 'FunctionNode':
-        if (mathWithTransform[node.name] && mathWithTransform[node.name].rawArgs) {
+        if (mathWithTransform.has(node.name) && mathWithTransform.get(node.name).rawArgs) {
           return node
         }
         {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,4 +1,5 @@
 import { isBigNumber } from './is.js'
+import { LazyMap } from './map.js'
 
 /**
  * Clone an object
@@ -204,32 +205,36 @@ export function canDefineProperty () {
  * Attach a lazy loading property to a constant.
  * The given function `fn` is called once when the property is first requested.
  *
- * @param {Object} object         Object where to add the property
- * @param {string} prop           Property name
- * @param {Function} valueResolver Function returning the property value. Called
- *                                without arguments.
+ * @param {Object | LazyMap} object Object where to add the property
+ * @param {string} prop             Property name
+ * @param {Function} valueResolver  Function returning the property value. Called
+ *                                  without arguments.
  */
 export function lazy (object, prop, valueResolver) {
-  let _uninitialized = true
-  let _value
+  if (object instanceof LazyMap) {
+    object.setLazy(prop, valueResolver)
+  } else {
+    let _uninitialized = true
+    let _value
 
-  Object.defineProperty(object, prop, {
-    get: function () {
-      if (_uninitialized) {
-        _value = valueResolver()
+    Object.defineProperty(object, prop, {
+      get: function () {
+        if (_uninitialized) {
+          _value = valueResolver()
+          _uninitialized = false
+        }
+        return _value
+      },
+
+      set: function (value) {
+        _value = value
         _uninitialized = false
-      }
-      return _value
-    },
+      },
 
-    set: function (value) {
-      _value = value
-      _uninitialized = false
-    },
-
-    configurable: true,
-    enumerable: true
-  })
+      configurable: true,
+      enumerable: true
+    })
+  }
 }
 
 /**

--- a/src/utils/snapshot.js
+++ b/src/utils/snapshot.js
@@ -8,6 +8,7 @@
 import assert from 'assert'
 import * as allIsFunctions from './is.js'
 import { create } from '../core/create.js'
+import { isMap } from './map.js'
 import { endsWith } from './string.js'
 
 export function validateBundle (expectedBundleStructure, bundle) {
@@ -287,7 +288,11 @@ function get (object, path) {
 
   for (let i = 0; i < path.length; i++) {
     const key = path[i]
-    child = child ? child[key] : undefined
+    child = isMap(child)
+      ? child.get(key)
+      : child
+        ? child[key]
+        : undefined
   }
 
   return child

--- a/test/node-tests/browser.test.js
+++ b/test/node-tests/browser.test.js
@@ -47,7 +47,7 @@ describe('lib/browser', function () {
 
     // test whether all functions are documented
     const missing = []
-    Object.keys(math.expression.mathWithTransform).forEach(function (prop) {
+    Array.from(math.expression.mathWithTransform.keys()).forEach(function (prop) {
       const obj = math[prop]
       if (math.typeOf(obj) !== 'Object') {
         try {

--- a/test/unit-tests/core/import.test.js
+++ b/test/unit-tests/core/import.test.js
@@ -94,6 +94,8 @@ describe('import', function () {
 
   it('should parse the user defined members', function () {
     if (math.parser) {
+      math.import({ myvalue: 10 }, { override: true })
+
       const parser = math.parser()
       math.add(math.myvalue, 10)
       parser.evaluate('myvalue + 10') // 52
@@ -256,7 +258,7 @@ describe('import', function () {
     assert(hasOwnProperty(math, 'mean'))
     assert.strictEqual(math.mean, mean)
     assert.strictEqual(math.expression.transform.mean, undefined)
-    assert.strictEqual(math.expression.mathWithTransform.mean, mean)
+    assert.strictEqual(math.expression.mathWithTransform.get('mean'), mean)
   })
 
   describe('factory', () => {

--- a/test/unit-tests/expression/node/FunctionNode.test.js
+++ b/test/unit-tests/expression/node/FunctionNode.test.js
@@ -115,7 +115,7 @@ describe('FunctionNode', function () {
       return 'myFunction(' + args.join(', ') + ')'
     }
     myFunction.rawArgs = true
-    mymath.import({ myFunction: myFunction })
+    mymath.import({ myFunction })
 
     const s = new SymbolNode('myFunction')
     const a = new mymath.ConstantNode(4)


### PR DESCRIPTION
Followup of #2264: changing `mathWithTransform` into a `LazyMap`

This is a work in progress. 

- [ ] Test whether the lazy loading actually works as in functions are loaded only when first used
- [ ] Think through whether there are unforeseen edge cases
- [ ] This is a breaking change in the API of `rawFunction`: there, `math` is now changed from `Object` into a `Map`