### PR TITLE
Add the simplify utils as `math.simplify.utils`

### DIFF
--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -82,8 +82,9 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     ParenthesisNode
   })
 
-  const { isCommutative, isAssociative, flatten, unflattenr, unflattenl, createMakeNodeFunction } =
-    createUtil({ FunctionNode, OperatorNode, SymbolNode })
+  const utils = createUtil({ FunctionNode, OperatorNode, SymbolNode })
+  const { isCommutative, isAssociative, flatten, unflattenr, unflattenl, createMakeNodeFunction } = utils;
+    
 
   /**
    * Simplify an expression tree.
@@ -739,6 +740,8 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
 
     return true
   }
+
+  simplify.utils = utils;
 
   return simplify
 })


### PR DESCRIPTION
This exports the utility functions in `math.simplify` as `math.simplify.utils`.

I have found specific use for `isCommutative`, `isAssociative`, and `flatten` and would rather not implement them myself. The others seem like they might also be useful to people, except maybe not `createMakeNodeFunction`, but for now it's along for the ride.

I can get some Typescript annotations for you as well if you think this is a worthwhile endeavor.