### PR TITLE
add `isRelationalNode` to `MathNode` in types/index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2987,6 +2987,7 @@ declare namespace math {
     isOperatorNode?: boolean;
     isParenthesisNode?: boolean;
     isRangeNode?: boolean;
+    isRelationalNode?: boolean;
     isSymbolNode?: boolean;
     isUpdateNode?: boolean;
     comment?: string;


### PR DESCRIPTION
At runtime, `math.parse('a == b == c').isRelationalNode` is true. Types should reflect this.