### PR TITLE
Changed "square" to "curly"

### DIFF
--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -547,7 +547,7 @@ parser.evaluate('c[end - 1 : -1 : 2]')    // Matrix, [8, 7, 6]
 ## Objects
 
 Objects in math.js work the same as in languages like JavaScript and Python.
-An object is enclosed by square brackets `{`, `}`, and contains a set of
+An object is enclosed by curly brackets `{`, `}`, and contains a set of
 comma separated key/value pairs. Keys and values are separated by a colon `:`.
 Keys can be a symbol like `prop` or a string like `"prop"`.
 


### PR DESCRIPTION
It says:
An object is enclosed by **square** brackets `{`, `}`,
But they are not square`[`,`]`, they are **curly** `{`, `}`.
The proposal is:
An object is enclosed by curly brackets `{`, `}`,