### PR TITLE
fix(OperatorNode): Correct parenthesization in some cases of .toString()

### DIFF
--- a/src/expression/node/OperatorNode.js
+++ b/src/expression/node/OperatorNode.js
@@ -340,10 +340,22 @@ export const createOperatorNode = /* #__PURE__ */ factory(name, dependencies, ({
         break
     }
 
-    // handles an edge case of 'auto' parentheses with implicit multiplication of ConstantNode
-    // In that case print parentheses for ParenthesisNodes even though they normally wouldn't be
-    // printed.
+    // The following block handles edge cases of 'auto' parentheses with
+    // implicit multiplication:
+    // A) Parenthesized ConstantNodes must be placed in parentheses even
+    //    though they normally wouldn't be, to preserve implicit
+    //    multiplication
+    // B) Fractions with unary operators for either operand must be
+    //    parenthesized, because of parsing rules for implicit multiplication
+    //    by fractions (e.g. 1/2 a is interpreted as (1/2)a and -1/2a is
+    //    interpreted as -1/(2a) by contrast).
     if ((args.length >= 2) && (root.getIdentifier() === 'OperatorNode:multiply') && root.implicit && (parenthesis === 'auto') && (implicit === 'hide')) {
+      // First check case (B) above
+      if (args[0].getIdentifier() === 'OperatorNode:divide' &&
+          args[0].args.some(n => n.type === 'OperatorNode' && n.isUnary())) {
+        result[0] = true
+      }
+      // Then handle case (A)
       result = args.map(function (arg, index) {
         const isParenthesisNode = (arg.getIdentifier() === 'ParenthesisNode')
         if (result[index] || isParenthesisNode) { // put in parenthesis?

--- a/test/unit-tests/expression/node/OperatorNode.test.js
+++ b/test/unit-tests/expression/node/OperatorNode.test.js
@@ -801,6 +801,29 @@ describe('OperatorNode', function () {
     assert.strictEqual(c.toString({ implicit: 'hide', parenthesis: 'auto' }), '4 (4 (4))')
   })
 
+  it('should stringify implicit multiplications of a fraction with unary operators to preserve its value', function () {
+    const one = new ConstantNode(1)
+    const two = new ConstantNode(2)
+    const m1 = new OperatorNode('-', 'unaryMinus', [one])
+    const m2 = new OperatorNode('-', 'unaryMinus', [two])
+    const p1 = new OperatorNode('+', 'unaryPlus', [one])
+    const p2 = new OperatorNode('+', 'unaryPlus', [two])
+    const m1two = new OperatorNode('/', 'divide', [m1, two])
+    const p1two = new OperatorNode('/', 'divide', [p1, two])
+    const onem2 = new OperatorNode('/', 'divide', [one, m2])
+    const onep2 = new OperatorNode('/', 'divide', [one, p2])
+    const avar = new SymbolNode('a')
+    const ascope = { a: 2 }
+    for (const coeff of [m1two, p1two, onem2, onep2]) {
+      let expr = new math.OperatorNode('*', 'multiply', [coeff, avar], true)
+      let estring = expr.toString({ parenthesis: 'auto', implicit: 'hide' })
+      assert.strictEqual(math.evaluate(estring, ascope), expr.evaluate(ascope))
+      expr = new math.OperatorNode('*', 'multiply', [coeff, two], true)
+      estring = expr.toString({ parenthesis: 'auto', implicit: 'hide' })
+      assert.strictEqual(math.evaluate(estring, {}), expr.evaluate(ascope))
+    }
+  })
+
   it('should LaTeX implicit multiplications between ConstantNodes with parentheses', function () {
     const a = math.parse('(4)(4)(4)(4)')
     const b = math.parse('4b*4(4)')


### PR DESCRIPTION
  If the first operand of an implicit multiplication is a fraction in
  which either the numerator or denominator has a unary operator, that
  operand must be parenthesized, because of the rules for interpreting
  implicit multiplication in the parser. This commit checks for that
  condition and inserts the parentheses.

  Resolves #1431.