### PR TITLE
fix(demo): Restore autocomplete to operation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -252,6 +252,7 @@ blockquote {
 .tips {
   color: #b4b4b4;
   margin: 10px 0;
+  font-size: 80%;
 }
 .tips ul {
   margin: 0;

--- a/history.md
+++ b/history.md
@@ -4,6 +4,12 @@ layout: default
 
 <h1 id="history">History <a href="#history" title="Permalink">#</a></h1>
 
+<h1 id="20220225-version-unpublished">2022-02-25, unpublished</h1>
+
+- Restore autocompletion functionality in demo on homepage
+  - Also allow cycling through all completions by repeating TAB
+  - Mention autocompletion in demo tips
+
 <h1 id="20220202-version-1011">2022-02-02, version 10.1.1 <a href="#20220202-version-1011" title="Permalink">#</a></h1>
 
 - Improvements and fixes in function `simplify`, thanks <a href="https://github.com/gwhitney">@gwhitney</a>:

--- a/index.md
+++ b/index.md
@@ -62,6 +62,7 @@ Math.js is an extensive math library for JavaScript and Node.js. It features a f
       <ul>
         <li>Press <b>S</b> to set focus to the input field</li>
         <li>Press <b>Ctrl+F11</b> to toggle full screen</li>
+        <li>Press <b>Tab</b> to autocomplete (repeat to cycle choices)</li>
         <li>Enter <b>"clear"</b> to clear history</li>
       </ul>
     </div>


### PR DESCRIPTION
  Adjust to the new location of Unit, as math.Unit not math.type.Unit.
  Also, use the new api for the parser's scope (getAll() to get all
  the identifiers) so that autocompletion of user-defined symbols will
  again work.
  Finally, when there are multiple matches, cycle through them with
  repeated TABs.

  Resolves #2434
