### PR TITLE
Demo webworker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 _site
+.jekyll-cache
 coverage
 node_modules

--- a/css/commandline.css
+++ b/css/commandline.css
@@ -99,6 +99,12 @@
   color: #dc3912;
 }
 
+.cle .results .awaiting {
+  padding: 0;
+  margin: 0 0 5px 30px;
+  color: orange;
+}
+
 .cle .results .expr,
 .cle .results .res {
   background: none;

--- a/css/style.css
+++ b/css/style.css
@@ -252,6 +252,7 @@ blockquote {
 .tips {
   color: #b4b4b4;
   margin: 10px 0;
+  font-size: 80%;
 }
 .tips ul {
   margin: 0;

--- a/index.md
+++ b/index.md
@@ -62,6 +62,7 @@ Math.js is an extensive math library for JavaScript and Node.js. It features a f
       <ul>
         <li>Press <b>S</b> to set focus to the input field</li>
         <li>Press <b>Ctrl+F11</b> to toggle full screen</li>
+        <li>Press <b>Tab</b> to autocomplete (repeat to cycle choices)</li>
         <li>Enter <b>"clear"</b> to clear history</li>
       </ul>
     </div>


### PR DESCRIPTION
  This change prevents the home page from blocking if a long-running
  expression like `sum(pickRandom([0,1],10000000))` is entered. A
  message that the results are being awaited will be shown until the
  answer comes back, and it will be possible to enter additional
  expressions. (This implementation only creates one worker, so subsequent
  computations have to wait until all prior expressions resolve.)

  This is primarily meant as an example in response to issue #2426, but it does add functionality to the demo on the home page, so if you like the looks of it, I think it would be fully reasonable to merge this PR.