### PR TITLE
`Unit` Typescript type update

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
   errors for larger values, see #2414. Thanks @gwhitney.
 - Fix #2385: function `rotate` missing in TypeScript definitions. 
   Thanks @DIVYA-19.
+- Fix #2450: Add BigNumber to parameter type in `math.unit` and add TypeScript
+  types for `Unit.simplify` and `Unit.units` (#2353).
 
 
 # 2022-02-02, version 10.1.1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@
 - Fix #2385: function `rotate` missing in TypeScript definitions. 
   Thanks @DIVYA-19.
 - Fix #2450: Add BigNumber to parameter type in `math.unit` and add TypeScript
-  types for `Unit.simplify` and `Unit.units` (#2353).
+  types for `Unit.simplify` and `Unit.units` (#2353). Thanks @joshhansen.
 
 
 # 2022-02-02, version 10.1.1

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -575,7 +575,7 @@ declare namespace math {
      * @param unit The unit to be created
      * @returns The created unit
      */
-    unit(value: number | MathArray | Matrix, unit: string): Unit;
+    unit(value: number | MathArray | Matrix | BigNumber, unit: string): Unit;
 
     /*************************************************************************
      * Expression functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3134,6 +3134,28 @@ declare namespace math {
     fixPrefix?: boolean;
   }
 
+  interface UnitComponent {
+    power: number;
+    prefix: string;
+    unit: {
+      name: string;
+      base: {
+        dimensions: number[];
+        key: string;
+      };
+      prefixes: Record<string, UnitPrefix>;
+      value: number;
+      offset: number;
+      dimensions: number[];
+    };
+  }
+
+  interface UnitPrefix {
+    name: string;
+    value: number;
+    scientific: boolean;
+  }
+
   interface Unit {
     valueOf(): string;
     clone(): Unit;
@@ -3152,7 +3174,14 @@ declare namespace math {
     toJSON(): MathJSON;
     formatUnits(): string;
     format(options: FormatOptions): string;
+    simplify(): Unit;
     splitUnit(parts: ReadonlyArray<string | Unit>): Unit[];
+
+    units: UnitComponent[];
+    dimensions: number[];
+    value: number;
+    fixPrefix: boolean;
+    skipAutomaticSimplification: true;
   }
 
   interface CreateUnitOptions {


### PR DESCRIPTION
This PR updates the type of `math.unit`'s parameter to allow `BigNumber`, and adds types for `Unit.simplify` and `Unit.units`, resolving #2353 