### PR TITLE
fix(parse): Implement amended "Rule 2"

### DIFF
--- a/src/expression/node/AssignmentNode.js
+++ b/src/expression/node/AssignmentNode.js
@@ -215,15 +215,16 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
    * Is parenthesis needed?
    * @param {node} node
    * @param {string} [parenthesis='keep']
+   * @param {string} implicit
    * @private
    */
-  function needParenthesis (node, parenthesis) {
+  function needParenthesis (node, parenthesis, implicit) {
     if (!parenthesis) {
       parenthesis = 'keep'
     }
 
-    const precedence = getPrecedence(node, parenthesis)
-    const exprPrecedence = getPrecedence(node.value, parenthesis)
+    const precedence = getPrecedence(node, parenthesis, implicit)
+    const exprPrecedence = getPrecedence(node.value, parenthesis, implicit)
     return (parenthesis === 'all') ||
       ((exprPrecedence !== null) && (exprPrecedence <= precedence))
   }
@@ -237,7 +238,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
     const object = this.object.toString(options)
     const index = this.index ? this.index.toString(options) : ''
     let value = this.value.toString(options)
-    if (needParenthesis(this, options && options.parenthesis)) {
+    if (needParenthesis(this, options && options.parenthesis, options && options.implicit)) {
       value = '(' + value + ')'
     }
 
@@ -277,7 +278,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
     const object = this.object.toHTML(options)
     const index = this.index ? this.index.toHTML(options) : ''
     let value = this.value.toHTML(options)
-    if (needParenthesis(this, options && options.parenthesis)) {
+    if (needParenthesis(this, options && options.parenthesis, options && options.implicit)) {
       value = '<span class="math-paranthesis math-round-parenthesis">(</span>' + value + '<span class="math-paranthesis math-round-parenthesis">)</span>'
     }
 
@@ -293,7 +294,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
     const object = this.object.toTex(options)
     const index = this.index ? this.index.toTex(options) : ''
     let value = this.value.toTex(options)
-    if (needParenthesis(this, options && options.parenthesis)) {
+    if (needParenthesis(this, options && options.parenthesis, options && options.implicit)) {
       value = `\\left(${value}\\right)`
     }
 

--- a/src/expression/node/ConditionalNode.js
+++ b/src/expression/node/ConditionalNode.js
@@ -101,14 +101,14 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
    */
   ConditionalNode.prototype._toString = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const precedence = getPrecedence(this, parenthesis)
+    const precedence = getPrecedence(this, parenthesis, options && options.implicit)
 
     // Enclose Arguments in parentheses if they are an OperatorNode
     // or have lower or equal precedence
     // NOTE: enclosing all OperatorNodes in parentheses is a decision
     // purely based on aesthetics and readability
     let condition = this.condition.toString(options)
-    const conditionPrecedence = getPrecedence(this.condition, parenthesis)
+    const conditionPrecedence = getPrecedence(this.condition, parenthesis, options && options.implicit)
     if ((parenthesis === 'all') ||
         (this.condition.type === 'OperatorNode') ||
         ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
@@ -116,7 +116,7 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
     }
 
     let trueExpr = this.trueExpr.toString(options)
-    const truePrecedence = getPrecedence(this.trueExpr, parenthesis)
+    const truePrecedence = getPrecedence(this.trueExpr, parenthesis, options && options.implicit)
     if ((parenthesis === 'all') ||
         (this.trueExpr.type === 'OperatorNode') ||
         ((truePrecedence !== null) && (truePrecedence <= precedence))) {
@@ -124,7 +124,7 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
     }
 
     let falseExpr = this.falseExpr.toString(options)
-    const falsePrecedence = getPrecedence(this.falseExpr, parenthesis)
+    const falsePrecedence = getPrecedence(this.falseExpr, parenthesis, options && options.implicit)
     if ((parenthesis === 'all') ||
         (this.falseExpr.type === 'OperatorNode') ||
         ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {
@@ -164,14 +164,14 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
    */
   ConditionalNode.prototype.toHTML = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const precedence = getPrecedence(this, parenthesis)
+    const precedence = getPrecedence(this, parenthesis, options && options.implicit)
 
     // Enclose Arguments in parentheses if they are an OperatorNode
     // or have lower or equal precedence
     // NOTE: enclosing all OperatorNodes in parentheses is a decision
     // purely based on aesthetics and readability
     let condition = this.condition.toHTML(options)
-    const conditionPrecedence = getPrecedence(this.condition, parenthesis)
+    const conditionPrecedence = getPrecedence(this.condition, parenthesis, options && options.implicit)
     if ((parenthesis === 'all') ||
         (this.condition.type === 'OperatorNode') ||
         ((conditionPrecedence !== null) && (conditionPrecedence <= precedence))) {
@@ -179,7 +179,7 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
     }
 
     let trueExpr = this.trueExpr.toHTML(options)
-    const truePrecedence = getPrecedence(this.trueExpr, parenthesis)
+    const truePrecedence = getPrecedence(this.trueExpr, parenthesis, options && options.implicit)
     if ((parenthesis === 'all') ||
         (this.trueExpr.type === 'OperatorNode') ||
         ((truePrecedence !== null) && (truePrecedence <= precedence))) {
@@ -187,7 +187,7 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
     }
 
     let falseExpr = this.falseExpr.toHTML(options)
-    const falsePrecedence = getPrecedence(this.falseExpr, parenthesis)
+    const falsePrecedence = getPrecedence(this.falseExpr, parenthesis, options && options.implicit)
     if ((parenthesis === 'all') ||
         (this.falseExpr.type === 'OperatorNode') ||
         ((falsePrecedence !== null) && (falsePrecedence <= precedence))) {

--- a/src/expression/node/FunctionAssignmentNode.js
+++ b/src/expression/node/FunctionAssignmentNode.js
@@ -131,11 +131,12 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
    * Is parenthesis needed?
    * @param {Node} node
    * @param {Object} parenthesis
+   * @param {string} implicit
    * @private
    */
-  function needParenthesis (node, parenthesis) {
-    const precedence = getPrecedence(node, parenthesis)
-    const exprPrecedence = getPrecedence(node.expr, parenthesis)
+  function needParenthesis (node, parenthesis, implicit) {
+    const precedence = getPrecedence(node, parenthesis, implicit)
+    const exprPrecedence = getPrecedence(node.expr, parenthesis, implicit)
 
     return (parenthesis === 'all') ||
       ((exprPrecedence !== null) && (exprPrecedence <= precedence))
@@ -149,7 +150,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
   FunctionAssignmentNode.prototype._toString = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
     let expr = this.expr.toString(options)
-    if (needParenthesis(this, parenthesis)) {
+    if (needParenthesis(this, parenthesis, options && options.implicit)) {
       expr = '(' + expr + ')'
     }
     return this.name + '(' + this.params.join(', ') + ') = ' + expr
@@ -198,7 +199,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
       params.push('<span class="math-symbol math-parameter">' + escape(this.params[i]) + '</span>')
     }
     let expr = this.expr.toHTML(options)
-    if (needParenthesis(this, parenthesis)) {
+    if (needParenthesis(this, parenthesis, options && options.implicit)) {
       expr = '<span class="math-parenthesis math-round-parenthesis">(</span>' + expr + '<span class="math-parenthesis math-round-parenthesis">)</span>'
     }
     return '<span class="math-function">' + escape(this.name) + '</span>' + '<span class="math-parenthesis math-round-parenthesis">(</span>' + params.join('<span class="math-separator">,</span>') + '<span class="math-parenthesis math-round-parenthesis">)</span><span class="math-operator math-assignment-operator math-variable-assignment-operator math-binary-operator">=</span>' + expr
@@ -212,7 +213,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
   FunctionAssignmentNode.prototype._toTex = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
     let expr = this.expr.toTex(options)
-    if (needParenthesis(this, parenthesis)) {
+    if (needParenthesis(this, parenthesis, options && options.implicit)) {
       expr = `\\left(${expr}\\right)`
     }
 

--- a/src/expression/node/RangeNode.js
+++ b/src/expression/node/RangeNode.js
@@ -128,24 +128,25 @@ export const createRangeNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    * Calculate the necessary parentheses
    * @param {Node} node
    * @param {string} parenthesis
+   * @param {string} implicit
    * @return {Object} parentheses
    * @private
    */
-  function calculateNecessaryParentheses (node, parenthesis) {
-    const precedence = getPrecedence(node, parenthesis)
+  function calculateNecessaryParentheses (node, parenthesis, implicit) {
+    const precedence = getPrecedence(node, parenthesis, implicit)
     const parens = {}
 
-    const startPrecedence = getPrecedence(node.start, parenthesis)
+    const startPrecedence = getPrecedence(node.start, parenthesis, implicit)
     parens.start = ((startPrecedence !== null) && (startPrecedence <= precedence)) ||
       (parenthesis === 'all')
 
     if (node.step) {
-      const stepPrecedence = getPrecedence(node.step, parenthesis)
+      const stepPrecedence = getPrecedence(node.step, parenthesis, implicit)
       parens.step = ((stepPrecedence !== null) && (stepPrecedence <= precedence)) ||
         (parenthesis === 'all')
     }
 
-    const endPrecedence = getPrecedence(node.end, parenthesis)
+    const endPrecedence = getPrecedence(node.end, parenthesis, implicit)
     parens.end = ((endPrecedence !== null) && (endPrecedence <= precedence)) ||
       (parenthesis === 'all')
 
@@ -159,7 +160,7 @@ export const createRangeNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    */
   RangeNode.prototype._toString = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const parens = calculateNecessaryParentheses(this, parenthesis)
+    const parens = calculateNecessaryParentheses(this, parenthesis, options && options.implicit)
 
     // format string as start:step:stop
     let str
@@ -218,7 +219,7 @@ export const createRangeNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    */
   RangeNode.prototype.toHTML = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const parens = calculateNecessaryParentheses(this, parenthesis)
+    const parens = calculateNecessaryParentheses(this, parenthesis, options && options.implicit)
 
     // format string as start:step:stop
     let str
@@ -253,7 +254,7 @@ export const createRangeNode = /* #__PURE__ */ factory(name, dependencies, ({ No
    */
   RangeNode.prototype._toTex = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const parens = calculateNecessaryParentheses(this, parenthesis)
+    const parens = calculateNecessaryParentheses(this, parenthesis, options && options.implicit)
 
     let str = this.start.toTex(options)
     if (parens.start) {

--- a/src/expression/node/RelationalNode.js
+++ b/src/expression/node/RelationalNode.js
@@ -104,10 +104,10 @@ export const createRelationalNode = /* #__PURE__ */ factory(name, dependencies, 
    */
   RelationalNode.prototype._toString = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const precedence = getPrecedence(this, parenthesis)
+    const precedence = getPrecedence(this, parenthesis, options && options.implicit)
 
     const paramStrings = this.params.map(function (p, index) {
-      const paramPrecedence = getPrecedence(p, parenthesis)
+      const paramPrecedence = getPrecedence(p, parenthesis, options && options.implicit)
       return (parenthesis === 'all' || (paramPrecedence !== null && paramPrecedence <= precedence))
         ? '(' + p.toString(options) + ')'
         : p.toString(options)
@@ -160,10 +160,10 @@ export const createRelationalNode = /* #__PURE__ */ factory(name, dependencies, 
    */
   RelationalNode.prototype.toHTML = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const precedence = getPrecedence(this, parenthesis)
+    const precedence = getPrecedence(this, parenthesis, options && options.implicit)
 
     const paramStrings = this.params.map(function (p, index) {
-      const paramPrecedence = getPrecedence(p, parenthesis)
+      const paramPrecedence = getPrecedence(p, parenthesis, options && options.implicit)
       return (parenthesis === 'all' || (paramPrecedence !== null && paramPrecedence <= precedence))
         ? '<span class="math-parenthesis math-round-parenthesis">(</span>' + p.toHTML(options) + '<span class="math-parenthesis math-round-parenthesis">)</span>'
         : p.toHTML(options)
@@ -193,10 +193,10 @@ export const createRelationalNode = /* #__PURE__ */ factory(name, dependencies, 
    */
   RelationalNode.prototype._toTex = function (options) {
     const parenthesis = (options && options.parenthesis) ? options.parenthesis : 'keep'
-    const precedence = getPrecedence(this, parenthesis)
+    const precedence = getPrecedence(this, parenthesis, options && options.implicit)
 
     const paramStrings = this.params.map(function (p, index) {
-      const paramPrecedence = getPrecedence(p, parenthesis)
+      const paramPrecedence = getPrecedence(p, parenthesis, options && options.implicit)
       return (parenthesis === 'all' || (paramPrecedence !== null && paramPrecedence <= precedence))
         ? '\\left(' + p.toTex(options) + '\right)'
         : p.toTex(options)

--- a/src/expression/operators.js
+++ b/src/expression/operators.js
@@ -17,6 +17,7 @@
 //                  in parentheses
 // latexRightParens: the same for the right argument
 import { hasOwnProperty } from '../utils/object.js'
+import { isConstantNode, isParenthesisNode, rule2Node } from '../utils/is.js'
 
 export const properties = [
   { // assignment
@@ -170,6 +171,17 @@ export const properties = [
       associativeWith: []
     }
   },
+  { // Repeat multiplication for implicit multiplication
+    'OperatorNode:multiply': {
+      associativity: 'left',
+      associativeWith: [
+        'OperatorNode:multiply',
+        'OperatorNode:divide',
+        'Operator:dotMultiply',
+        'Operator:dotDivide'
+      ]
+    }
+  },
   { // unary prefix operators
     'OperatorNode:unaryPlus': {
       associativity: 'right'
@@ -211,27 +223,60 @@ export const properties = [
 ]
 
 /**
+ * Returns the first non-parenthesis internal node, but only
+ * when the 'parenthesis' option is unset or auto.
+ * @param {Node} _node
+ * @param {string} parenthesis
+ * @return {Node}
+ */
+function unwrapParen (_node, parenthesis) {
+  if (!parenthesis || parenthesis !== 'auto') return _node
+  let node = _node
+  while (isParenthesisNode(node)) node = node.content
+  return node
+}
+
+/**
  * Get the precedence of a Node.
  * Higher number for higher precedence, starting with 0.
  * Returns null if the precedence is undefined.
  *
  * @param {Node} _node
  * @param {string} parenthesis
+ * @param {string} implicit
+ * @param {Node} parent (for determining context for implicit multiplication)
  * @return {number | null}
  */
-export function getPrecedence (_node, parenthesis) {
+export function getPrecedence (_node, parenthesis, implicit, parent) {
   let node = _node
   if (parenthesis !== 'keep') {
     // ParenthesisNodes are only ignored when not in 'keep' mode
     node = _node.getContent()
   }
   const identifier = node.getIdentifier()
+  let precedence = null
   for (let i = 0; i < properties.length; i++) {
     if (identifier in properties[i]) {
-      return i
+      precedence = i
+      break
     }
   }
-  return null
+  // Bump up precedence of implicit multiplication, except when preceded
+  // by a "Rule 2" fraction ( [unaryOp]constant / constant )
+  if (identifier === 'OperatorNode:multiply' && node.implicit &&
+      implicit !== 'show') {
+    const leftArg = unwrapParen(node.args[0], parenthesis)
+    if (!(isConstantNode(leftArg) && parent &&
+          parent.getIdentifier() === 'OperatorNode:divide' &&
+          rule2Node(unwrapParen(parent.args[0], parenthesis))) &&
+        !(leftArg.getIdentifier() === 'OperatorNode:divide' &&
+          rule2Node(unwrapParen(leftArg.args[0], parenthesis)) &&
+          isConstantNode(unwrapParen(leftArg.args[1])))
+    ) {
+      precedence += 1
+    }
+  }
+  return precedence
 }
 
 /**

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1,5 +1,5 @@
 import { factory } from '../utils/factory.js'
-import { isAccessorNode, isConstantNode, isFunctionNode, isOperatorNode, isSymbolNode } from '../utils/is.js'
+import { isAccessorNode, isConstantNode, isFunctionNode, isOperatorNode, isSymbolNode, rule2Node } from '../utils/is.js'
 import { deepMap } from '../utils/collection.js'
 import { hasOwnProperty } from '../utils/object.js'
 
@@ -1075,13 +1075,6 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
     return node
   }
 
-  function isRule2Node (node) {
-    return isConstantNode(node) ||
-      (isOperatorNode(node) &&
-       node.args.length === 1 &&
-       isConstantNode(node.args[0]) &&
-       '-+~'.includes(node.op))
-  }
   /**
    * Infamous "rule 2" as described in https://github.com/josdejong/mathjs/issues/792#issuecomment-361065370
    * And as amended in https://github.com/josdejong/mathjs/issues/2370#issuecomment-1054052164
@@ -1098,7 +1091,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
     while (true) {
       // Match the "number /" part of the pattern "number / number symbol"
-      if (state.token === '/' && isRule2Node(last)) {
+      if (state.token === '/' && rule2Node(last)) {
         // Look ahead to see if the next token is a number
         tokenStates.push(Object.assign({}, state))
         getTokenSkipNewline(state)

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1075,10 +1075,19 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
     return node
   }
 
+  function isRule2Node (node) {
+    return isConstantNode(node) ||
+      (isOperatorNode(node) &&
+       node.args.length === 1 &&
+       isConstantNode(node.args[0]) &&
+       '-+~'.includes(node.op))
+  }
   /**
    * Infamous "rule 2" as described in https://github.com/josdejong/mathjs/issues/792#issuecomment-361065370
+   * And as amended in https://github.com/josdejong/mathjs/issues/2370#issuecomment-1054052164
    * Explicit division gets higher precedence than implicit multiplication
-   * when the division matches this pattern: [number] / [number] [symbol]
+   * when the division matches this pattern:
+   *   [unaryPrefixOp]?[number] / [number] [symbol]
    * @return {Node} node
    * @private
    */
@@ -1089,7 +1098,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
     while (true) {
       // Match the "number /" part of the pattern "number / number symbol"
-      if (state.token === '/' && isConstantNode(last)) {
+      if (state.token === '/' && isRule2Node(last)) {
         // Look ahead to see if the next token is a number
         tokenStates.push(Object.assign({}, state))
         getTokenSkipNewline(state)

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -153,6 +153,24 @@ export function isConstantNode (x) {
   return (x && x.isConstantNode === true && x.constructor.prototype.isNode === true) || false
 }
 
+/* Very specialized: returns true for those nodes which in the numerator of
+   a fraction means that the division in that fraction has precedence over implicit
+   multiplication, e.g. -2/3 x parses as (-2/3) x and 3/4 x parses as (3/4) x but
+   6!/8 x parses as 6! / (8x). It is located here because it is shared between
+   parse.js and OperatorNode.js (for parsing and printing, respectively).
+
+   This should *not* be exported from mathjs, unlike most of the tests here.
+   Its name does not start with 'is' to prevent utils/snapshot.js from thinking
+   it should be exported.
+*/
+export function rule2Node (node) {
+  return isConstantNode(node) ||
+    (isOperatorNode(node) &&
+     node.args.length === 1 &&
+     isConstantNode(node.args[0]) &&
+     '-+~'.includes(node.op))
+}
+
 export function isFunctionAssignmentNode (x) {
   return (x && x.isFunctionAssignmentNode === true && x.constructor.prototype.isNode === true) || false
 }

--- a/test/unit-tests/expression/node/OperatorNode.test.js
+++ b/test/unit-tests/expression/node/OperatorNode.test.js
@@ -529,6 +529,8 @@ describe('OperatorNode', function () {
     exhs({ i: '(2+3)a', s: ['(2 + 3) a', '(2 + 3) * a'], l: ['\\left(2+3\\right)~ a', '\\left(2+3\\right)\\cdot a'] })
     exhs({ i: '(2+3)2', s: ['(2 + 3) 2', '(2 + 3) * 2'], l: ['\\left(2+3\\right)~2', '\\left(2+3\\right)\\cdot2'] })
     exhs({ i: '2(3+4)', s: ['2 (3 + 4)', '2 * (3 + 4)'], l: ['2~\\left(3+4\\right)', '2\\cdot\\left(3+4\\right)'] })
+    exhs({ i: 'a / b c', s: ['a / b c', 'a / (b * c)'], l: ['\\frac{ a}{\\mathrm{b}~ c}', '\\frac{ a}{\\mathrm{b}\\cdot c}'] })
+    exhs({ i: 'a / b c d', s: ['a / b c d', 'a / (b * c * d)'], l: ['\\frac{ a}{\\mathrm{b}~ c~ d}', '\\frac{ a}{\\mathrm{b}\\cdot c\\cdot d}'] })
     exhs({ i: '1/2 a', s: ['1 / 2 a', '1 / 2 * a'], l: ['\\frac{1}{2}~ a', '\\frac{1}{2}\\cdot a'] })
     exhs({ i: '-2/3 a', s: ['-2 / 3 a', '-2 / 3 * a'], l: ['\\frac{-2}{3}~ a', '\\frac{-2}{3}\\cdot a'] })
     exhs({ i: '2!/3 a', s: ['2! / 3 a', '2! / (3 * a)'], l: ['\\frac{2!}{3~ a}', '\\frac{2!}{3\\cdot a}'] })
@@ -540,8 +542,10 @@ describe('OperatorNode', function () {
     exhs({ i: '-2/(3+4)x', s: ['-2 / (3 + 4) x', '-2 / ((3 + 4) * x)'], l: ['\\frac{-2}{\\left(3+4\\right)~ x}', '\\frac{-2}{\\left(3+4\\right)\\cdot x}'] })
     exhs({
       i: '(2)/3x',
-      s: ['(2) / 3 x', '(2) / (3 * x)'],
-      l: ['\\frac{\\left(2\\right)}{3~ x}', '\\frac{\\left(2\\right)}{3\\cdot x}']
+      skeep: ['(2) / 3 x', '(2) / (3 * x)'],
+      sauto: ['2 / (3 x)', '2 / (3 * x)'],
+      lkeep: ['\\frac{\\left(2\\right)}{3~ x}', '\\frac{\\left(2\\right)}{3\\cdot x}'],
+      lauto: ['\\frac{2}{3~ x}', '\\frac{2}{3\\cdot x}']
     })
     exhs({
       i: '2/(3)x',

--- a/test/unit-tests/expression/node/OperatorNode.test.js
+++ b/test/unit-tests/expression/node/OperatorNode.test.js
@@ -791,6 +791,38 @@ describe('OperatorNode', function () {
     )
   })
 
+  it('should stringify implicit multiplications in a recoverable way', function () {
+    let coeff = new OperatorNode('/', 'divide',
+      [new ConstantNode(1), new ConstantNode(2)])
+    const variable = new SymbolNode('a')
+    let start = new OperatorNode('*', 'multiply', [coeff, variable], true)
+    let startString = start.toString()
+    let finish = math.parse(startString)
+    assert.strictEqual(
+      finish.toString({ parenthesis: 'all' }),
+      start.toString({ parenthesis: 'all' }))
+    coeff = new OperatorNode('/', 'divide', [
+      new OperatorNode('-', 'unaryMinus', [new ConstantNode(1)]),
+      new ConstantNode(2)])
+    start = new OperatorNode('*', 'multiply', [coeff, variable], true)
+    startString = start.toString()
+    finish = math.parse(startString)
+    assert.strictEqual(
+      finish.toString({ parenthesis: 'all' }),
+      start.toString({ parenthesis: 'all' }))
+    coeff = new OperatorNode('/', 'divide', [
+      new ConstantNode(1),
+      new OperatorNode('-', 'unaryMinus', [new ConstantNode(2)])])
+    start = new OperatorNode('*', 'multiply', [coeff, variable], true)
+    startString = start.toString()
+    finish = math.parse(startString)
+    /* FIXME: this test currently fails, related to #1431:
+    assert.strictEqual(
+      finish.toString({ parenthesis: 'all' }),
+      start.toString({ parenthesis: 'all' }))
+    */
+  })
+
   it('should stringify implicit multiplications between ConstantNodes with parentheses', function () {
     const a = math.parse('(4)(4)(4)(4)')
     const b = math.parse('4b*4(4)')

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -1337,6 +1337,13 @@ describe('parse', function () {
     it('should follow precedence rules for implicit multiplication and division', function () {
       assert.strictEqual(parseAndStringifyWithParens('2 / 3 x'), '(2 / 3) x')
       assert.strictEqual(parseAndStringifyWithParens('-2/3x'), '((-2) / 3) x')
+      assert.strictEqual(parseAndStringifyWithParens('+2/3x'), '((+2) / 3) x')
+      assert.strictEqual(parseAndStringifyWithParens('2!/3x'), '(2!) / (3 x)')
+      assert.strictEqual(parseAndStringifyWithParens('(2)/3x'), '2 / (3 x)')
+      assert.strictEqual(parseAndStringifyWithParens('2/3!x'), '2 / ((3!) x)')
+      assert.strictEqual(parseAndStringifyWithParens('2/(3)x'), '2 / (3 x)')
+      assert.strictEqual(parseAndStringifyWithParens('(2+4)/3x'), '(2 + 4) / (3 x)')
+      assert.strictEqual(parseAndStringifyWithParens('2/(3+4)x'), '2 / ((3 + 4) x)')
       assert.strictEqual(parseAndStringifyWithParens('2.5 / 5 kg'), '(2.5 / 5) kg')
       assert.strictEqual(parseAndStringifyWithParens('2.5 / 5 x y'), '((2.5 / 5) x) y')
       assert.strictEqual(parseAndStringifyWithParens('2 x / 5 y'), '(2 x) / (5 y)')

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -1336,11 +1336,16 @@ describe('parse', function () {
 
     it('should follow precedence rules for implicit multiplication and division', function () {
       assert.strictEqual(parseAndStringifyWithParens('2 / 3 x'), '(2 / 3) x')
+      assert.strictEqual(parseAndStringifyWithParens('-2/3x'), '((-2) / 3) x')
       assert.strictEqual(parseAndStringifyWithParens('2.5 / 5 kg'), '(2.5 / 5) kg')
       assert.strictEqual(parseAndStringifyWithParens('2.5 / 5 x y'), '((2.5 / 5) x) y')
       assert.strictEqual(parseAndStringifyWithParens('2 x / 5 y'), '(2 x) / (5 y)')
       assert.strictEqual(parseAndStringifyWithParens('17 h / 1 h'), '(17 h) / (1 h)')
       assert.strictEqual(parseAndStringifyWithParens('1 / 2 x'), '(1 / 2) x')
+      assert.strictEqual(parseAndStringifyWithParens('+1/2x'), '((+1) / 2) x')
+      assert.strictEqual(parseAndStringifyWithParens('~1/2x'), '((~1) / 2) x')
+      assert.strictEqual(parseAndStringifyWithParens('1 / -2 x'), '1 / ((-2) x)')
+      assert.strictEqual(parseAndStringifyWithParens('-1 / -2 x'), '(-1) / ((-2) x)')
       assert.strictEqual(parseAndStringifyWithParens('1 / 2 * x'), '(1 / 2) * x')
       assert.strictEqual(parseAndStringifyWithParens('1 / 2 x y'), '((1 / 2) x) y')
       assert.strictEqual(parseAndStringifyWithParens('1 / 2 (x y)'), '(1 / 2) (x y)')

--- a/test/unit-tests/function/algebra/derivative.test.js
+++ b/test/unit-tests/function/algebra/derivative.test.js
@@ -159,7 +159,7 @@ describe('derivative', function () {
     compareString(derivativeWithoutSimplify('asech((2x))', 'x'), '-(2 * 1) / ((2 x) * sqrt(1 - (2 x) ^ 2))')
     compareString(derivativeWithoutSimplify('acsch((2x))', 'x'), '-(2 * 1) / (abs((2 x)) * sqrt((2 x) ^ 2 + 1))')
     compareString(derivativeWithoutSimplify('acoth((2x))', 'x'), '-(2 * 1) / (1 - (2 x) ^ 2)')
-    compareString(derivativeWithoutSimplify('abs(2x)', 'x'), '2 * 1 * abs(2 x) / (2 x)')
+    compareString(derivativeWithoutSimplify('abs(2x)', 'x'), '2 * 1 * abs(2 x) / 2 x')
 
     // See power operator tests above
     compareString(derivativeWithoutSimplify('pow(0, 2^x + x^3 + 2)', 'x'), '0')


### PR DESCRIPTION
  As per the discussion in #2370, the amended "Rule 2" is
  "when having a division followed by an implicit multiplication, the
   division gets higher precedence over the implicit multiplication when
   (a) the numerator is a constant with optionally a
       prefix operator (-, +, ~), and
   (b) the denominator is a constant."
  This commit implements that behavior and adds tests for it.
  Resolves #2370.