### PR TITLE
fix(simplifyCore): make sure simplifyCore recurses over all binary nodes

### DIFF
--- a/src/function/algebra/simplifyCore.js
+++ b/src/function/algebra/simplifyCore.js
@@ -204,8 +204,8 @@ export const createSimplifyCore = /* #__PURE__ */ factory(name, dependencies, ({
             }
           }
         }
-        return new OperatorNode(node.op, node.fn, [a0, a1])
       }
+      return new OperatorNode(node.op, node.fn, [a0, a1])
     } else if (isFunctionNode(node)) {
       return new FunctionNode(
         simplifyCore(node.fn), node.args.map(n => simplifyCore(n, options)))

--- a/test/unit-tests/function/algebra/simplifyCore.test.js
+++ b/test/unit-tests/function/algebra/simplifyCore.test.js
@@ -57,4 +57,9 @@ describe('simplifyCore', function () {
     ).toString()
     assert.strictEqual(result, 'x + y - 1')
   })
+
+  it('should recurse through arbitrary binary operators', () => {
+    testSimplifyCore('x+0==5', 'x == 5')
+    testSimplifyCore('(x*1) % (y^1)', 'x % y')
+  })
 })


### PR DESCRIPTION
  Moves the catchall for an arbitrary binary operator node up one level in the
  code so that it doesn't let any cases slip through.
  Resolves #2461.