### PR TITLE
feat(simplifyCore): convert equivalent function calls into operators

### DIFF
--- a/docs/expressions/algebra.md
+++ b/docs/expressions/algebra.md
@@ -27,6 +27,12 @@ console.log(simplified.toString())       // '3 * x'
 console.log(simplified.evaluate({x: 4})) // 12
 ```
 
+Among its other actions, calling `simplify()` on an expression will convert
+any functions that have operator equivalents to their operator form:
+```js
+console.log(math.simplify('multiply(x,3)').toString)  // '3 * x'
+```
+
 Note that `simplify` has an optional argument `scope` that allows the definitions of variables in the expression (as numeric values, or as further expressions) to be specified and used in the simplification, e.g. continuing the previous example,
 
 ```js

--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -207,8 +207,8 @@ Operator Expression  | Equivalent Function Expression
 `a or b`             |`or(a,b)`
 `a xor b`            |`xor(a,b)`
 `a and b`            |`and(a,b)`
-`a | b`              |`bitOr(a,b)`
-`a ^| b`             |`bitXor(a,b)`
+`a \| b`             |`bitOr(a,b)`
+`a ^\| b`            |`bitXor(a,b)`
 `a & b`              |`bitAnd(a,b)`
 `a == b`             |`equal(a,b)`
 `a != b`             |`unequal(a,b)`

--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -43,7 +43,11 @@ math.evaluate('2 + 3 * 4')   // 14
 math.evaluate('(2 + 3) * 4') // 20
 ```
 
-The following operators are available:
+The following operators are available. Note that almost every operator listed
+also has a function form with identical meaning that can be used
+interchangeably. For example, `x+y` will always evaluate identically to
+`add(x,y)`. For a full list of the equivalences, see the section on
+Functions below.
 
 Operator    | Name                       | Syntax      | Associativity | Example               | Result
 ----------- | -------------------------- | ----------  | ------------- | --------------------- | ---------------
@@ -193,6 +197,46 @@ const parser = math.parser()
 parser.evaluate('f = typed({"number": f(x) = x ^ 2 - 5})')
 ```
 
+Finally, as mentioned above, there is a function form for nearly every one of
+the mathematical operator symbols. Moreover, for some associative operators,
+the corresponding function allows arbitrarily many arguments. The table below
+gives the full correspondence.
+
+Operator Expression  | Equivalent Function Expression
+---------------------|-------------------------------
+`a or b`             |`or(a,b)`
+`a xor b`            |`xor(a,b)`
+`a and b`            |`and(a,b)`
+`a | b`              |`bitOr(a,b)`
+`a ^| b`             |`bitXor(a,b)`
+`a & b`              |`bitAnd(a,b)`
+`a == b`             |`equal(a,b)`
+`a != b`             |`unequal(a,b)`
+`a < b`              |`smaller(a,b)`
+`a > b`              |`larger(a,b)`
+`a <= b`             |`smallerEq(a,b)`
+`a << 3`             |`leftShift(a,3)`
+`a >> 3`             |`rightArithShift(a,3)`
+`a >>> 3`            |`rightLogShift(a,3)`
+`u to cm`            |`to(u, cm)`
+`a + b + c + ...`    |`add(a,b,c,...)`
+`a - b`              |`subtract(a,b)`
+`a * b * c * ...`    |`multiply(a,b,c,...)`
+`A .* B`             |`dotMultiply(A,B)`
+`A ./ B`             |`dotDivide(A,B)`
+`a mod b`            |`mod(a,b)`
+`+a`                 |`unaryPlus(a)`
+`-a`                 |`unaryMinus(a)`
+`~a`                 |`bitNot(a)`
+`not a`              |`not(a)`
+`a^b`                |`pow(a,b)`
+`A .^ B`             |`dotPow(A,B)`
+`a!`                 |`factorial(a)`
+`A'`                 |`ctranspose(A)`
+
+Note that math.js embodies a preference for the operator forms, in that calling
+`simplify` (see [Algebra](./algebra.md)) converts any instances of the function
+form into the corresponding operator.
 
 ## Constants and variables
 

--- a/src/expression/operators.js
+++ b/src/expression/operators.js
@@ -92,7 +92,7 @@ export const properties = [
       associativeWith: []
     },
     'OperatorNode:larger': {
-      op: '<',
+      op: '>',
       associativity: 'left',
       associativeWith: []
     },

--- a/src/expression/operators.js
+++ b/src/expression/operators.js
@@ -34,6 +34,7 @@ export const properties = [
   },
   { // logical or
     'OperatorNode:or': {
+      op: 'or',
       associativity: 'left',
       associativeWith: []
     }
@@ -41,56 +42,67 @@ export const properties = [
   },
   { // logical xor
     'OperatorNode:xor': {
+      op: 'xor',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // logical and
     'OperatorNode:and': {
+      op: 'and',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // bitwise or
     'OperatorNode:bitOr': {
+      op: '|',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // bitwise xor
     'OperatorNode:bitXor': {
+      op: '^|',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // bitwise and
     'OperatorNode:bitAnd': {
+      op: '&',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // relational operators
     'OperatorNode:equal': {
+      op: '==',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:unequal': {
+      op: '!=',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:smaller': {
+      op: '<',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:larger': {
+      op: '<',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:smallerEq': {
+      op: '<=',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:largerEq': {
+      op: '>=',
       associativity: 'left',
       associativeWith: []
     },
@@ -101,20 +113,24 @@ export const properties = [
   },
   { // bitshift operators
     'OperatorNode:leftShift': {
+      op: '<<',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:rightArithShift': {
+      op: '>>',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:rightLogShift': {
+      op: '>>>',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // unit conversion
     'OperatorNode:to': {
+      op: 'to',
       associativity: 'left',
       associativeWith: []
     }
@@ -124,16 +140,19 @@ export const properties = [
   },
   { // addition, subtraction
     'OperatorNode:add': {
+      op: '+',
       associativity: 'left',
       associativeWith: ['OperatorNode:add', 'OperatorNode:subtract']
     },
     'OperatorNode:subtract': {
+      op: '-',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // multiply, divide, modulus
     'OperatorNode:multiply': {
+      op: '*',
       associativity: 'left',
       associativeWith: [
         'OperatorNode:multiply',
@@ -143,6 +162,7 @@ export const properties = [
       ]
     },
     'OperatorNode:divide': {
+      op: '/',
       associativity: 'left',
       associativeWith: [],
       latexLeftParens: false,
@@ -153,6 +173,7 @@ export const properties = [
       // in LaTeX
     },
     'OperatorNode:dotMultiply': {
+      op: '.*',
       associativity: 'left',
       associativeWith: [
         'OperatorNode:multiply',
@@ -162,30 +183,37 @@ export const properties = [
       ]
     },
     'OperatorNode:dotDivide': {
+      op: './',
       associativity: 'left',
       associativeWith: []
     },
     'OperatorNode:mod': {
+      op: 'mod',
       associativity: 'left',
       associativeWith: []
     }
   },
   { // unary prefix operators
     'OperatorNode:unaryPlus': {
+      op: '+',
       associativity: 'right'
     },
     'OperatorNode:unaryMinus': {
+      op: '-',
       associativity: 'right'
     },
     'OperatorNode:bitNot': {
+      op: '~',
       associativity: 'right'
     },
     'OperatorNode:not': {
+      op: 'not',
       associativity: 'right'
     }
   },
   { // exponentiation
     'OperatorNode:pow': {
+      op: '^',
       associativity: 'right',
       associativeWith: [],
       latexRightParens: false
@@ -194,17 +222,20 @@ export const properties = [
       // (it's on top)
     },
     'OperatorNode:dotPow': {
+      op: '.^',
       associativity: 'right',
       associativeWith: []
     }
   },
   { // factorial
     'OperatorNode:factorial': {
+      op: '!',
       associativity: 'left'
     }
   },
   { // matrix transpose
-    'OperatorNode:transpose': {
+    'OperatorNode:ctranspose': {
+      op: "'",
       associativity: 'left'
     }
   }
@@ -307,5 +338,24 @@ export function isAssociativeWith (nodeA, nodeB, parenthesis) {
   }
 
   // associativeWith is not defined
+  return null
+}
+
+/**
+ * Get the operator associated with a function name.
+ * Returns a string with the operator symbol, or null if the
+ * input is not the name of a function associated with an
+ * operator.
+ *
+ * @param {string} Function name
+ * @return {string | null} Associated operator symbol, if any
+ */
+export function getOperator (fn) {
+  const identifier = 'OperatorNode:' + fn
+  for (const group of properties) {
+    if (identifier in group) {
+      return group[identifier].op
+    }
+  }
   return null
 }

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -111,7 +111,10 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
    * - 'v' - matches any Node that is not a ConstantNode
    *
    * The default list of rules is exposed on the function as `simplify.rules`
-   * and can be used as a basis to built a set of custom rules.
+   * and can be used as a basis to built a set of custom rules. Note that since
+   * the `simplifyCore` function is in the default list of rules, by default
+   * simplify will convert any function calls in the expression that have
+   * operator equivalents to their operator forms.
    *
    * To specify a rule as a string, separate the left and right pattern by '->'
    * When specifying a rule as an object, the following keys are meaningful:

--- a/src/function/algebra/simplifyCore.js
+++ b/src/function/algebra/simplifyCore.js
@@ -1,9 +1,12 @@
 import { isAccessorNode, isArrayNode, isConstantNode, isFunctionNode, isIndexNode, isObjectNode, isOperatorNode } from '../../utils/is.js'
+import { getOperator } from '../../expression/operators.js'
 import { createUtil } from './simplify/util.js'
 import { factory } from '../../utils/factory.js'
 
 const name = 'simplifyCore'
 const dependencies = [
+  'typed',
+  'parse',
   'equal',
   'isZero',
   'add',
@@ -23,6 +26,8 @@ const dependencies = [
 ]
 
 export const createSimplifyCore = /* #__PURE__ */ factory(name, dependencies, ({
+  typed,
+  parse,
   equal,
   isZero,
   add,
@@ -71,164 +76,199 @@ export const createSimplifyCore = /* #__PURE__ */ factory(name, dependencies, ({
    *     Simplification options, as per simplify()
    * @return {Node} Returns expression with basic simplifications applied
    */
-  function simplifyCore (node, options) {
-    const context = options ? options.context : undefined
-    if (hasProperty(node, 'trivial', context)) {
-      // This node does nothing if it has only one argument, so if so,
-      // return that argument simplified
-      if (isFunctionNode(node) && node.args.length === 1) {
-        return simplifyCore(node.args[0], options)
-      }
-      // For other node types, we try the generic methods
-      let simpChild = false
-      let childCount = 0
-      node.forEach(c => {
-        ++childCount
+  const simplifyCore = typed('simplifyCore', {
+    string: function (expr) {
+      return this(parse(expr), {})
+    },
+
+    'string, Object': function (expr, options) {
+      return this(parse(expr), options)
+    },
+
+    Node: function (node) {
+      return this(node, {})
+    },
+
+    'Node, Object': function (nodeToSimplify, options) {
+      const context = options ? options.context : undefined
+      if (hasProperty(nodeToSimplify, 'trivial', context)) {
+        // This node does nothing if it has only one argument, so if so,
+        // return that argument simplified
+        if (isFunctionNode(nodeToSimplify) && nodeToSimplify.args.length === 1) {
+          return simplifyCore(nodeToSimplify.args[0], options)
+        }
+        // For other node types, we try the generic methods
+        let simpChild = false
+        let childCount = 0
+        nodeToSimplify.forEach(c => {
+          ++childCount
+          if (childCount === 1) {
+            simpChild = simplifyCore(c, options)
+          }
+        })
         if (childCount === 1) {
-          simpChild = simplifyCore(c, options)
+          return simpChild
         }
-      })
-      if (childCount === 1) {
-        return simpChild
       }
-    }
-    if (isOperatorNode(node) && node.isUnary()) {
-      const a0 = simplifyCore(node.args[0], options)
-
-      if (node.op === '-') { // unary minus
-        if (isOperatorNode(a0)) {
-          if (a0.isUnary() && a0.op === '-') {
-            return a0.args[0]
-          } else if (a0.isBinary() && a0.fn === 'subtract') {
-            return new OperatorNode('-', 'subtract', [a0.args[1], a0.args[0]])
+      let node = nodeToSimplify
+      if (isFunctionNode(node)) {
+        const op = getOperator(node.name)
+        if (op) {
+          // Replace FunctionNode with a new OperatorNode
+          if (node.args.length > 2 && hasProperty(node, 'associative', context)) {
+            // unflatten into binary operations since that's what simplifyCore handles
+            while (node.args.length > 2) {
+              const last = node.args.pop()
+              const seclast = node.args.pop()
+              node.args.push(new OperatorNode(op, node.name, [last, seclast]))
+            }
           }
+          node = new OperatorNode(op, node.name, node.args)
+        } else {
+          return new FunctionNode(
+            simplifyCore(node.fn), node.args.map(n => simplifyCore(n, options)))
         }
-        return new OperatorNode(node.op, node.fn, [a0])
       }
-    } else if (isOperatorNode(node) && node.isBinary()) {
-      const a0 = simplifyCore(node.args[0], options)
-      const a1 = simplifyCore(node.args[1], options)
+      if (isOperatorNode(node) && node.isUnary()) {
+        const a0 = simplifyCore(node.args[0], options)
 
-      if (node.op === '+') {
-        if (isConstantNode(a0)) {
-          if (isZero(a0.value)) {
-            return a1
-          } else if (isConstantNode(a1)) {
-            return new ConstantNode(add(a0.value, a1.value))
+        if (node.op === '-') { // unary minus
+          if (isOperatorNode(a0)) {
+            if (a0.isUnary() && a0.op === '-') {
+              return a0.args[0]
+            } else if (a0.isBinary() && a0.fn === 'subtract') {
+              return new OperatorNode('-', 'subtract', [a0.args[1], a0.args[0]])
+            }
           }
+          return new OperatorNode(node.op, node.fn, [a0])
         }
-        if (isConstantNode(a1) && isZero(a1.value)) {
-          return a0
-        }
-        if (isOperatorNode(a1) && a1.isUnary() && a1.op === '-') {
-          return new OperatorNode('-', 'subtract', [a0, a1.args[0]])
-        }
-        return new OperatorNode(node.op, node.fn, a1 ? [a0, a1] : [a0])
-      } else if (node.op === '-') {
-        if (isConstantNode(a0) && a1) {
-          if (isConstantNode(a1)) {
-            return new ConstantNode(subtract(a0.value, a1.value))
-          } else if (isZero(a0.value)) {
-            return new OperatorNode('-', 'unaryMinus', [a1])
+      } else if (isOperatorNode(node) && node.isBinary()) {
+        const a0 = simplifyCore(node.args[0], options)
+        const a1 = simplifyCore(node.args[1], options)
+
+        if (node.op === '+') {
+          if (isConstantNode(a0)) {
+            if (isZero(a0.value)) {
+              return a1
+            } else if (isConstantNode(a1)) {
+              return new ConstantNode(add(a0.value, a1.value))
+            }
           }
-        }
-        // if (node.fn === "subtract" && node.args.length === 2) {
-        if (node.fn === 'subtract') {
           if (isConstantNode(a1) && isZero(a1.value)) {
             return a0
           }
           if (isOperatorNode(a1) && a1.isUnary() && a1.op === '-') {
-            return simplifyCore(
-              new OperatorNode('+', 'add', [a0, a1.args[0]]), options)
+            return new OperatorNode('-', 'subtract', [a0, a1.args[0]])
           }
-          return new OperatorNode(node.op, node.fn, [a0, a1])
-        }
-      } else if (node.op === '*') {
-        if (isConstantNode(a0)) {
-          if (isZero(a0.value)) {
-            return node0
-          } else if (equal(a0.value, 1)) {
-            return a1
-          } else if (isConstantNode(a1)) {
-            return new ConstantNode(multiply(a0.value, a1.value))
-          }
-        }
-        if (isConstantNode(a1)) {
-          if (isZero(a1.value)) {
-            return node0
-          } else if (equal(a1.value, 1)) {
-            return a0
-          } else if (isOperatorNode(a0) && a0.isBinary() &&
-                     a0.op === node.op && isCommutative(node, context)) {
-            const a00 = a0.args[0]
-            if (isConstantNode(a00)) {
-              const a00a1 = new ConstantNode(multiply(a00.value, a1.value))
-              return new OperatorNode(node.op, node.fn, [a00a1, a0.args[1]], node.implicit) // constants on left
+          return new OperatorNode(node.op, node.fn, a1 ? [a0, a1] : [a0])
+        } else if (node.op === '-') {
+          if (isConstantNode(a0) && a1) {
+            if (isConstantNode(a1)) {
+              return new ConstantNode(subtract(a0.value, a1.value))
+            } else if (isZero(a0.value)) {
+              return new OperatorNode('-', 'unaryMinus', [a1])
             }
           }
-          if (isCommutative(node, context)) {
-            return new OperatorNode(node.op, node.fn, [a1, a0], node.implicit) // constants on left
-          } else {
-            return new OperatorNode(node.op, node.fn, [a0, a1], node.implicit)
+          // if (node.fn === "subtract" && node.args.length === 2) {
+          if (node.fn === 'subtract') {
+            if (isConstantNode(a1) && isZero(a1.value)) {
+              return a0
+            }
+            if (isOperatorNode(a1) && a1.isUnary() && a1.op === '-') {
+              return simplifyCore(
+                new OperatorNode('+', 'add', [a0, a1.args[0]]), options)
+            }
+            return new OperatorNode(node.op, node.fn, [a0, a1])
           }
-        }
-        return new OperatorNode(node.op, node.fn, [a0, a1], node.implicit)
-      } else if (node.op === '/') {
-        if (isConstantNode(a0)) {
-          if (isZero(a0.value)) {
-            return node0
-          } else if (isConstantNode(a1) &&
-                      (equal(a1.value, 1) || equal(a1.value, 2) || equal(a1.value, 4))) {
-            return new ConstantNode(divide(a0.value, a1.value))
+        } else if (node.op === '*') {
+          if (isConstantNode(a0)) {
+            if (isZero(a0.value)) {
+              return node0
+            } else if (equal(a0.value, 1)) {
+              return a1
+            } else if (isConstantNode(a1)) {
+              return new ConstantNode(multiply(a0.value, a1.value))
+            }
           }
-        }
-        return new OperatorNode(node.op, node.fn, [a0, a1])
-      } else if (node.op === '^') {
-        if (isConstantNode(a1)) {
-          if (isZero(a1.value)) {
-            return node1
-          } else if (equal(a1.value, 1)) {
-            return a0
-          } else {
-            if (isConstantNode(a0)) {
-              // fold constant
-              return new ConstantNode(pow(a0.value, a1.value))
-            } else if (isOperatorNode(a0) && a0.isBinary() && a0.op === '^') {
-              const a01 = a0.args[1]
-              if (isConstantNode(a01)) {
-                return new OperatorNode(node.op, node.fn, [
-                  a0.args[0],
-                  new ConstantNode(multiply(a01.value, a1.value))
-                ])
+          if (isConstantNode(a1)) {
+            if (isZero(a1.value)) {
+              return node0
+            } else if (equal(a1.value, 1)) {
+              return a0
+            } else if (isOperatorNode(a0) && a0.isBinary() &&
+                       a0.op === node.op && isCommutative(node, context)) {
+              const a00 = a0.args[0]
+              if (isConstantNode(a00)) {
+                const a00a1 = new ConstantNode(multiply(a00.value, a1.value))
+                return new OperatorNode(node.op, node.fn, [a00a1, a0.args[1]], node.implicit) // constants on left
+              }
+            }
+            if (isCommutative(node, context)) {
+              return new OperatorNode(node.op, node.fn, [a1, a0], node.implicit) // constants on left
+            } else {
+              return new OperatorNode(node.op, node.fn, [a0, a1], node.implicit)
+            }
+          }
+          return new OperatorNode(node.op, node.fn, [a0, a1], node.implicit)
+        } else if (node.op === '/') {
+          if (isConstantNode(a0)) {
+            if (isZero(a0.value)) {
+              return node0
+            } else if (isConstantNode(a1) &&
+                       (equal(a1.value, 1) || equal(a1.value, 2) || equal(a1.value, 4))) {
+              return new ConstantNode(divide(a0.value, a1.value))
+            }
+          }
+          return new OperatorNode(node.op, node.fn, [a0, a1])
+        } else if (node.op === '^') {
+          if (isConstantNode(a1)) {
+            if (isZero(a1.value)) {
+              return node1
+            } else if (equal(a1.value, 1)) {
+              return a0
+            } else {
+              if (isConstantNode(a0)) {
+                // fold constant
+                return new ConstantNode(pow(a0.value, a1.value))
+              } else if (isOperatorNode(a0) && a0.isBinary() && a0.op === '^') {
+                const a01 = a0.args[1]
+                if (isConstantNode(a01)) {
+                  return new OperatorNode(node.op, node.fn, [
+                    a0.args[0],
+                    new ConstantNode(multiply(a01.value, a1.value))
+                  ])
+                }
               }
             }
           }
         }
+        return new OperatorNode(node.op, node.fn, [a0, a1])
+      } else if (isOperatorNode(node)) {
+        return new OperatorNode(node.op, node.fn,
+          node.args.map(a => simplifyCore(a, options)))
       }
-      return new OperatorNode(node.op, node.fn, [a0, a1])
-    } else if (isFunctionNode(node)) {
-      return new FunctionNode(
-        simplifyCore(node.fn), node.args.map(n => simplifyCore(n, options)))
-    } else if (isArrayNode(node)) {
-      return new ArrayNode(
-        node.items.map(n => simplifyCore(n, options)))
-    } else if (isAccessorNode(node)) {
-      return new AccessorNode(
-        simplifyCore(node.object, options), simplifyCore(node.index, options))
-    } else if (isIndexNode(node)) {
-      return new IndexNode(
-        node.dimensions.map(n => simplifyCore(n, options)))
-    } else if (isObjectNode(node)) {
-      const newProps = {}
-      for (const prop in node.properties) {
-        newProps[prop] = simplifyCore(node.properties[prop], options)
+      if (isArrayNode(node)) {
+        return new ArrayNode(node.items.map(n => simplifyCore(n, options)))
       }
-      return new ObjectNode(newProps)
-    } else {
+      if (isAccessorNode(node)) {
+        return new AccessorNode(
+          simplifyCore(node.object, options), simplifyCore(node.index, options))
+      }
+      if (isIndexNode(node)) {
+        return new IndexNode(
+          node.dimensions.map(n => simplifyCore(n, options)))
+      }
+      if (isObjectNode(node)) {
+        const newProps = {}
+        for (const prop in node.properties) {
+          newProps[prop] = simplifyCore(node.properties[prop], options)
+        }
+        return new ObjectNode(newProps)
+      }
       // cannot simplify
+      return node
     }
-    return node
-  }
+  })
 
   return simplifyCore
 })

--- a/src/function/algebra/simplifyCore.js
+++ b/src/function/algebra/simplifyCore.js
@@ -56,15 +56,31 @@ export const createSimplifyCore = /* #__PURE__ */ factory(name, dependencies, ({
    * extends simplifyCore() with additional passes to provide deeper
    * simplification.
    *
+   * Specifically, simplifyCore:
+   *
+   * * Converts all function calls with operator equivalents to their
+   *   operator forms.
+   * * Removes operators or function calls that are guaranteed to have no
+   *   effect (such as unary '+').
+   * * Removes double unary '-'
+   * * Eliminates addition/subtraction of 0 and multiplication/division/powers
+   *   by 1 or 0.
+   * * Converts addition of a negation into subtraction.
+   * * Puts constants on the left of a product, if multiplication is
+   *   considered commutative by the options (which is the default)
+   * * Replaces subexpressions that consist of basic arithmetic operations on
+   *   constants with their values.
+   *
    * Syntax:
    *
    *     simplifyCore(expr)
+   *     simplifyCore(expr, options)
    *
    * Examples:
    *
    *     const f = math.parse('2 * 1 * x ^ (2 - 1)')
-   *     math.simpifyCore(f)                          // Node {2 * x}
-   *     math.simplify('2 * 1 * x ^ (2 - 1)', [math.simplifyCore]) // Node {2 * x}
+   *     math.simplifyCore(f)                          // Node "2 * x"
+   *     math.simplify('2 * 1 * x ^ (2 - 1)', [math.simplifyCore]) // Node "2 * x"
    *
    * See also:
    *

--- a/test/node-tests/doc.test.js
+++ b/test/node-tests/doc.test.js
@@ -92,7 +92,7 @@ const knownProblems = new Set([
   'mod', 'invmod', 'floor', 'fix', 'expm1', 'exp', 'dotPow', 'dotMultiply',
   'dotDivide', 'divide', 'ceil', 'cbrt', 'add', 'usolveAll', 'usolve', 'slu',
   'rationalize', 'qr', 'lusolve', 'lup', 'lsolveAll', 'lsolve', 'derivative',
-  'simplifyCore', 'symbolicEqual', 'map', 'resolve'
+  'symbolicEqual', 'map', 'resolve'
 ])
 
 function maybeCheckExpectation (name, expected, expectedFrom, got, gotFrom) {

--- a/test/unit-tests/expression/operators.test.js
+++ b/test/unit-tests/expression/operators.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import math from '../../../src/defaultInstance.js'
-import { getAssociativity, getPrecedence, isAssociativeWith } from '../../../src/expression/operators.js'
+import { getAssociativity, getPrecedence, isAssociativeWith, getOperator } from '../../../src/expression/operators.js'
 const OperatorNode = math.OperatorNode
 const AssignmentNode = math.AssignmentNode
 const SymbolNode = math.SymbolNode
@@ -15,9 +15,11 @@ describe('operators', function () {
 
     const n1 = new AssignmentNode(new SymbolNode('a'), a)
     const n2 = new OperatorNode('or', 'or', [a, b])
+    const n3 = math.parse("M'")
 
     assert.strictEqual(getPrecedence(n1, 'keep'), 0)
     assert.strictEqual(getPrecedence(n2, 'keep'), 2)
+    assert.strictEqual(getPrecedence(n3, 'keep'), 17)
   })
 
   it('should return null if precedence is not defined for a node', function () {
@@ -45,11 +47,13 @@ describe('operators', function () {
     const n2 = new OperatorNode('^', 'pow', [a, a])
     const n3 = new OperatorNode('-', 'unaryMinus', [a])
     const n4 = new OperatorNode('!', 'factorial', [a])
+    const n5 = math.parse("M'")
 
     assert.strictEqual(getAssociativity(n1, 'keep'), 'left')
     assert.strictEqual(getAssociativity(n2, 'keep'), 'right')
     assert.strictEqual(getAssociativity(n3, 'keep'), 'right')
     assert.strictEqual(getAssociativity(n4, 'keep'), 'left')
+    assert.strictEqual(getAssociativity(n5, 'keep'), 'left')
   })
 
   it('should return the associativity of a ParenthesisNode', function () {
@@ -109,5 +113,12 @@ describe('operators', function () {
     assert.strictEqual(isAssociativeWith(p, sub, 'all'), true)
     assert.strictEqual(isAssociativeWith(p, sub, 'auto'), true)
     assert.strictEqual(isAssociativeWith(p, sub, 'keep'), null)
+  })
+
+  it('should get the operator of a function name', () => {
+    assert.strictEqual(getOperator('multiply'), '*')
+    assert.strictEqual(getOperator('ctranspose'), "'")
+    assert.strictEqual(getOperator('mod'), 'mod')
+    assert.strictEqual(getOperator('square'), null)
   })
 })

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -233,6 +233,19 @@ describe('simplify', function () {
     simplifyAndCompare('x^2*y^3*z - y*z*x^2*y', 'x^2*z*(y^3-y^2)')
   })
 
+  it('can simplify with functions as well as operators', () => {
+    simplifyAndCompare('add(x,x)', '2*x')
+    simplifyAndCompare('multiply(x,2)+x', '3*x')
+    simplifyAndCompare('add(2*add(x,1), x+1)', '3*(x + 1)')
+    simplifyAndCompare('multiply(2, x+1) + add(x,1)', '3*(x + 1)')
+    simplifyAndCompare('add(y*pow(x,2), multiply(2,x^2))', 'x^2*(y+2)')
+    simplifyAndCompare('add(x*y, multiply(y,x))', '2*x*y')
+    simplifyAndCompare('subtract(multiply(x,y), multiply(y,x))', '0')
+    simplifyAndCompare('pow(x,2)*multiply(y^3, z) - multiply(y,z,y,x^2,y)', '0')
+    simplifyAndCompare('subtract(multiply(x^2, pow(y,3))*z, y*multiply(z,x^2)*y)',
+      'x^2*z*(y^3-y^2)')
+  })
+
   it('should collect separated like terms', function () {
     simplifyAndCompare('x+1+x', '2*x+1')
     simplifyAndCompare('x^2+x+3+x^2', '2*x^2+x+3')

--- a/test/unit-tests/function/algebra/simplifyCore.test.js
+++ b/test/unit-tests/function/algebra/simplifyCore.test.js
@@ -4,8 +4,10 @@ import assert from 'assert'
 import math from '../../../../src/defaultInstance.js'
 
 describe('simplifyCore', function () {
-  const testSimplifyCore = function (expr, expected, opts = {}) {
-    const actual = math.simplifyCore(math.parse(expr)).toString(opts)
+  const testSimplifyCore = function (expr, expected, opts = {}, simpOpts = {}) {
+    let actual = math.simplifyCore(math.parse(expr), simpOpts).toString(opts)
+    assert.strictEqual(actual, expected)
+    actual = math.simplifyCore(expr, simpOpts).toString(opts)
     assert.strictEqual(actual, expected)
   }
 
@@ -31,6 +33,14 @@ describe('simplifyCore', function () {
     testSimplifyCore('[x+0,1*y,z*0]', '[x, y, 0]')
     testSimplifyCore('(a+b+0)[n*0+1,-(n)]', '(a + b)[1, -n]')
     testSimplifyCore('{a:x*1, b:y-0}', '{"a": x, "b": y}')
+  })
+
+  it('should not alter order of multiplication when noncommutative', function () {
+    testSimplifyCore('5*x*3', '5 * x * 3', {}, { context: { multiply: { commutative: false } } })
+  })
+
+  it('should remove any trivial function', function () {
+    testSimplifyCore('foo(y)', 'y', {}, { context: { foo: { trivial: true } } })
   })
 
   it('strips ParenthesisNodes (implicit in tree)', function () {
@@ -61,5 +71,18 @@ describe('simplifyCore', function () {
   it('should recurse through arbitrary binary operators', () => {
     testSimplifyCore('x+0==5', 'x == 5')
     testSimplifyCore('(x*1) % (y^1)', 'x % y')
+  })
+
+  it('converts functions to their corresponding infix operators', () => {
+    testSimplifyCore('add(x, y)', 'x + y')
+    testSimplifyCore('mod(x, 5)', 'x mod 5')
+    testSimplifyCore('to(5 cm, in)', '5 cm to in')
+    testSimplifyCore('ctranspose(M)', "M'")
+  })
+
+  it('continues to simplify after function -> operator conversion', () => {
+    testSimplifyCore('add(multiply(x, 0), y)', 'y')
+    testSimplifyCore('and(multiply(1, x), true)', 'x and true')
+    testSimplifyCore('add(x, 0 ,y)', 'x + y')
   })
 })


### PR DESCRIPTION
  Resolves #2415.

  Also fixes a (unreported) typo that prevented getPrecedence of `M'` from returning the correct value.