### PR TITLE
Fix syntax error on example.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
   (#2455). Thanks @NattapongSiri.
 - Fix #1633: implement a `cumsum` function generating cumulative sums of a list
   of values or a matrix. (#1870). Thanks @hjonasson.
+- Fix typo in documentation example for `format`. (#2468) Thanks @abranhe.
 
 # 2021-03-02, version 10.3.0
 

--- a/src/function/string/format.js
+++ b/src/function/string/format.js
@@ -110,7 +110,7 @@ export const createFormat = /* #__PURE__ */ factory(name, dependencies, ({ typed
    *      // you could also use math.format inside the callback:
    *      // return '$' + math.format(value, {notation: 'fixed', precision: 2})
    *    }
-   *    math.format([2.1, 3, 0.016], formatCurrency}            // returns '[$2.10, $3.00, $0.02]'
+   *    math.format([2.1, 3, 0.016], formatCurrency)            // returns '[$2.10, $3.00, $0.02]'
    *
    * See also:
    *


### PR DESCRIPTION
Found this syntax error on the docs, I am here just to fix it.

https://mathjs.org/docs/reference/functions/format.html