### PR TITLE
Fix the `simplifyCore` fix

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -712,6 +712,8 @@ declare namespace math {
      */
     simplify: Simplify;
 
+    simplifyCore(expr: MathNode): MathNode;
+
     /**
      * Calculate the Sparse Matrix LU decomposition with full pivoting.
      * Sparse Matrix A is decomposed in two matrices (L, U) and two
@@ -3746,7 +3748,7 @@ declare namespace math {
      */
     simplify(rules?: SimplifyRule[], scope?: object): MathJsChain;
 
-    simplifyCore(expr: MathNode): MathNode;
+    simplifyCore(expr: MathNode): MathJsChain;
 
     /**
      * Calculate the Sparse Matrix LU decomposition with full pivoting.


### PR DESCRIPTION
In #2456 I failed to introduce `simplifyCore` typing to `MathJsStatic` (it was only added to `MathJsChain`). This PR fixes that omission. It also changes the return type of the `MathJsChain` form of `simplifyCore` to be `MathJsChain` which is the convention in that environment.