### PR TITLE
refactor: Remove the automatic conversion from number to string.

### DIFF
--- a/src/core/function/typed.js
+++ b/src/core/function/typed.js
@@ -180,12 +180,6 @@ export const createTyped = /* #__PURE__ */ factory('typed', dependencies, functi
         return new Complex(x, 0)
       }
     }, {
-      from: 'number',
-      to: 'string',
-      convert: function (x) {
-        return x + ''
-      }
-    }, {
       from: 'BigNumber',
       to: 'Complex',
       convert: function (x) {

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -82,13 +82,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       this.units = u.units
       this.dimensions = u.dimensions
     } else {
-      this.units = [
-        {
-          unit: UNIT_NONE,
-          prefix: PREFIXES.NONE, // link to a list with supported prefixes
-          power: 0
-        }
-      ]
+      this.units = []
       this.dimensions = []
       for (let i = 0; i < BASE_DIMENSIONS.length; i++) {
         this.dimensions[i] = 0

--- a/src/type/unit/function/unit.js
+++ b/src/type/unit/function/unit.js
@@ -47,6 +47,11 @@ export const createUnitFunction = /* #__PURE__ */ factory(name, dependencies, ({
       return new Unit(value, unit)
     },
 
+    'number | BigNumber | Fraction': function (value) {
+      // dimensionless
+      return new Unit(value)
+    },
+
     'Array | Matrix': function (x) {
       return deepMap(x, this)
     }

--- a/test/unit-tests/function/algebra/derivative.test.js
+++ b/test/unit-tests/function/algebra/derivative.test.js
@@ -254,7 +254,7 @@ describe('derivative', function () {
   it('should throw error for incorrect argument types', function () {
     assert.throws(function () {
       derivative('42', '42')
-    }, /TypeError: Unexpected type of argument in function derivative \(expected: string or SymbolNode or number or boolean, actual: ConstantNode, index: 1\)/)
+    }, /TypeError: Unexpected type of argument in function derivative \(expected: string or SymbolNode or boolean, actual: ConstantNode, index: 1\)/)
 
     assert.throws(function () {
       derivative('[1, 2; 3, 4]', 'x')
@@ -268,7 +268,7 @@ describe('derivative', function () {
   it('should throw error if incorrect number of arguments', function () {
     assert.throws(function () {
       derivative('x + 2')
-    }, /TypeError: Too few arguments in function derivative \(expected: string or SymbolNode or number or boolean, index: 1\)/)
+    }, /TypeError: Too few arguments in function derivative \(expected: string or SymbolNode or boolean, index: 1\)/)
 
     assert.throws(function () {
       derivative('x + 2', 'x', {}, true, 42)

--- a/test/unit-tests/function/matrix/count.test.js
+++ b/test/unit-tests/function/matrix/count.test.js
@@ -31,7 +31,7 @@ describe('count', function () {
 
   it('should throw an error if called with an invalid number of arguments', function () {
     assert.throws(function () { count() }, /TypeError: Too few arguments/)
-    assert.throws(function () { count(1, 2) }, /TypeError: Too many arguments/)
+    assert.throws(function () { count([1], 2) }, /TypeError: Too many arguments/)
   })
 
   it('should throw an error if called with invalid type of arguments', function () {

--- a/test/unit-tests/function/matrix/diag.test.js
+++ b/test/unit-tests/function/matrix/diag.test.js
@@ -108,7 +108,7 @@ describe('diag', function () {
 
   it('should throw an error in case of wrong number of arguments', function () {
     assert.throws(function () { math.diag() }, /TypeError: Too few arguments/)
-    assert.throws(function () { math.diag([], 2, 3, 4) }, /TypeError: Too many arguments/)
+    assert.throws(function () { math.diag([], 2, 'dense', 4) }, /TypeError: Too many arguments/)
   })
 
   it('should throw an error in case of invalid type of arguments', function () {

--- a/test/unit-tests/function/unit/to.test.js
+++ b/test/unit-tests/function/unit/to.test.js
@@ -70,7 +70,7 @@ describe('to', function () {
 
   it('should throw an error if called with a number', function () {
     assert.throws(function () { math.to(5, unit('m')) }, TypeError)
-    assert.throws(function () { math.to(unit('5cm'), 2) }, /SyntaxError: "2" contains no units/)
+    assert.throws(function () { math.to(unit('5cm'), 2) }, TypeError)
   })
 
   it('should throw an error if called with a string', function () {

--- a/test/unit-tests/type/matrix/function/matrix.test.js
+++ b/test/unit-tests/type/matrix/function/matrix.test.js
@@ -85,11 +85,11 @@ describe('matrix', function () {
   })
 
   it('should throw an error if called with too many arguments', function () {
-    assert.throws(function () { matrix([], 3, 3, 7) }, /TypeError: Too many arguments/)
+    assert.throws(function () { matrix([], 'dense', 'number', 7) }, /TypeError: Too many arguments/)
   })
 
   it('should throw an error when called with an invalid storage format', function () {
-    assert.throws(function () { math.matrix([], 1) }, /TypeError: Unknown matrix type "1"/)
+    assert.throws(function () { math.matrix([], '1') }, /TypeError: Unknown matrix type "1"/)
   })
 
   it('should throw an error when called with an unknown storage format', function () {

--- a/test/unit-tests/type/matrix/function/sparse.test.js
+++ b/test/unit-tests/type/matrix/function/sparse.test.js
@@ -40,7 +40,7 @@ describe('sparse', function () {
   })
 
   it('should throw an error if called with too many arguments', function () {
-    assert.throws(function () { sparse([], 3, 3) }, /TypeError: Too many arguments/)
+    assert.throws(function () { sparse([], 'number', 3) }, /TypeError: Too many arguments/)
   })
 
   it('should LaTeX matrix', function () {


### PR DESCRIPTION
  This is a breaking change. However, nothing in the unit tests or examples
  actually depended on such a conversion, and it's difficult to construct
  situations in which it's necessary. The best such example is e.g.
  `count(57)` which formerly gave the number of digits in its numeric
  argument. Of course, after this commit, that behavior can still be
  obtained by the just slightly longer expression `count(string(57))`

  The change is proposed in preparation for an addition of new facilities/
  handlers to allow symbolic computation in a couple of different ways
  (see #2475 and #2470).