### PR TITLE
fix(parse): Allow (and ignore) comments wherever white space would be

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -259,17 +259,21 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
     state.token = ''
     state.comment = ''
 
-    // skip over whitespaces
-    // space, tab, and newline when inside parameters
-    while (parse.isWhitespace(currentCharacter(state), state.nestingLevel)) {
-      next(state)
-    }
-
-    // skip comment
-    if (currentCharacter(state) === '#') {
-      while (currentCharacter(state) !== '\n' && currentCharacter(state) !== '') {
-        state.comment += currentCharacter(state)
+    // skip over ignored characters:
+    while (true) {
+      // comments:
+      if (currentCharacter(state) === '#') {
+        while (currentCharacter(state) !== '\n' &&
+               currentCharacter(state) !== '') {
+          state.comment += currentCharacter(state)
+          next(state)
+        }
+      }
+      // whitespace: space, tab, and newline when inside parameters
+      if (parse.isWhitespace(currentCharacter(state), state.nestingLevel)) {
         next(state)
+      } else {
+        break
       }
     }
 

--- a/test/unit-tests/expression/function/parse.test.js
+++ b/test/unit-tests/expression/function/parse.test.js
@@ -3,6 +3,10 @@ import assert from 'assert'
 
 import math from '../../../../src/defaultInstance.js'
 const Node = math.Node
+const ArrayNode = math.ArrayNode
+const ObjectNode = math.ObjectNode
+const FunctionNode = math.FunctionNode
+const OperatorNode = math.OperatorNode
 
 describe('parse', function () {
   it('should parse an expression', function () {
@@ -20,6 +24,20 @@ describe('parse', function () {
     assert.ok(nodes[1] instanceof Node)
     assert.strictEqual(nodes[0].compile().evaluate(), 5)
     assert.strictEqual(nodes[1].compile().evaluate(), 9)
+  })
+
+  it('should parse expressions with internal newlines', () => {
+    assert.ok(math.parse('[1,\n2]') instanceof ArrayNode)
+    assert.ok(math.parse('{x:1,\n y:2}') instanceof ObjectNode)
+    assert.ok(math.parse('f(x,\n y)') instanceof FunctionNode)
+    assert.ok(math.parse('3+\n7') instanceof OperatorNode)
+  })
+
+  it('should parse expressions with internal newlines and comments', () => {
+    assert.ok(math.parse('[1, # One\n2]') instanceof ArrayNode)
+    assert.ok(math.parse('{x:1, # x-coordinate\n y:2}') instanceof ObjectNode)
+    assert.ok(math.parse('f(x, # first argument\n y)') instanceof FunctionNode)
+    assert.ok(math.parse('3+#ignored terms\n7') instanceof OperatorNode)
   })
 
   it('should LaTeX parse', function () {


### PR DESCRIPTION
  Resolves #2491.