### PR TITLE
fix(Unit): Avoid using unit offsets too much

### DIFF
--- a/src/function/arithmetic/sign.js
+++ b/src/function/arithmetic/sign.js
@@ -57,6 +57,9 @@ export const createSign = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     Unit: function (x) {
+      if (!x._isDerived() && x.units[0].unit.offset !== 0) {
+        throw new TypeError('sign is ambiguous for units with offset')
+      }
       return this(x.value)
     }
   })

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -504,6 +504,8 @@ describe('parse', function () {
         math.unit(68, 'fahrenheit').to('fahrenheit'))
       approx.deepEqual(parseAndEval('50 fahrenheit to celsius'),
         math.unit(10, 'celsius').to('celsius'))
+      approx.deepEqual(parseAndEval('degC to degF'),
+        math.unit(1.8, 'degF').to('degF'))
     })
 
     it('should create units and aliases', function () {

--- a/test/unit-tests/function/arithmetic/addScalar.test.js
+++ b/test/unit-tests/function/arithmetic/addScalar.test.js
@@ -123,6 +123,14 @@ describe('addScalar', function () {
     approx.deepEqual(add(math.unit(math.complex(-3, 2), 'g'), math.unit(math.complex(5, -6), 'g')).toString(), '(2 - 4i) g')
   })
 
+  it('should add units properly even when they have offsets', () => {
+    let t = math.unit(20, 'degC')
+    assert.deepStrictEqual(add(t, math.unit(1, 'degC')), math.unit(21, 'degC'))
+    t = math.unit(68, 'degF')
+    assert.deepStrictEqual(add(t, math.unit(2, 'degF')), math.unit(70, 'degF'))
+    approx.deepEqual(add(t, math.unit(1, 'degC')), math.unit(69.8, 'degF'))
+  })
+
   it('should throw an error for two measures of different units', function () {
     assert.throws(function () {
       add(math.unit(5, 'km'), math.unit(100, 'gram'))

--- a/test/unit-tests/function/arithmetic/multiply.test.js
+++ b/test/unit-tests/function/arithmetic/multiply.test.js
@@ -169,6 +169,11 @@ describe('multiply', function () {
       assert.strictEqual(multiply(unit(math.complex(3, -4), 'N'), unit(math.complex(7, -2), 'm')).toString(), '(13 - 34i) J')
     })
 
+    it('should evaluate a complicated unit multiplication', () => {
+      const v1 = math.evaluate('0.1 kg/s * 4.2 J/degC/g * 5 degC')
+      approx.equal(v1.value, 2100)
+    })
+
     it('should multiply valueless units correctly', function () {
       assert.strictEqual(multiply(unit('m'), unit('4 m')).toString(), '4 m^2')
       assert.strictEqual(multiply(unit('ft'), unit('4 ft')).format(5), '4 ft^2')

--- a/test/unit-tests/function/arithmetic/sign.test.js
+++ b/test/unit-tests/function/arithmetic/sign.test.js
@@ -41,9 +41,16 @@ describe('sign', function () {
     assert.strictEqual(math.sign(math.unit('5 cm')), 1)
     assert.strictEqual(math.sign(math.unit('-5 kg')), -1)
     assert.strictEqual(math.sign(math.unit('0 mol/s')), 0)
-    assert.strictEqual(math.sign(math.unit('-283.15 degC')), -1)
-    assert.strictEqual(math.sign(math.unit('-273.15 degC')), 0)
-    assert.strictEqual(math.sign(math.unit('-263.15 degC')), 1)
+
+    /* sign is ambiguous on units with offset, because you don't know if
+     * -3 degC is the difference between two temperatures, in which case
+     * it is definitely negative, or an actual temperature of something,
+     * in which case it is arguably positive. So actually mathjs should
+     * throw an error, which we will test below. Formerly:
+     assert.strictEqual(math.sign(math.unit('-283.15 degC')), -1)
+     assert.strictEqual(math.sign(math.unit('-273.15 degC')), 0)
+     assert.strictEqual(math.sign(math.unit('-263.15 degC')), 1)
+    */
 
     assert.deepStrictEqual(math.sign(math.unit(bignumber(5), 'cm')), bignumber(1))
     assert.deepStrictEqual(math.sign(math.unit(bignumber(-5), 'cm')), bignumber(-1))
@@ -51,6 +58,11 @@ describe('sign', function () {
     assert.deepStrictEqual(math.sign(math.unit(fraction(-5), 'cm')), fraction(-1))
 
     assert.deepStrictEqual(math.sign(math.unit(complex(3, 4), 'mi')), complex(0.6, 0.8))
+  })
+
+  it('should throw an error on a valueless unit or a unit with offset', () => {
+    assert.throws(() => math.sign(math.unit('ohm')), TypeError)
+    assert.throws(() => math.sign(math.unit('-3 degC')), /ambiguous/)
   })
 
   it('should throw an error when used with a string', function () {

--- a/test/unit-tests/function/arithmetic/subtract.test.js
+++ b/test/unit-tests/function/arithmetic/subtract.test.js
@@ -94,6 +94,14 @@ describe('subtract', function () {
     assert.deepStrictEqual(subtract(math.unit(math.complex(10, 10), 'K'), math.unit(3, 'K')), math.unit(math.complex(7, 10), 'K'))
   })
 
+  it('should subtract units even when they have offsets', () => {
+    let t = math.unit(20, 'degC')
+    assert.deepStrictEqual(subtract(t, math.unit(1, 'degC')), math.unit(19, 'degC'))
+    t = math.unit(68, 'degF')
+    approx.deepEqual(subtract(t, math.unit(2, 'degF')), math.unit(66, 'degF'))
+    approx.deepEqual(subtract(t, math.unit(1, 'degC')), math.unit(66.2, 'degF'))
+  })
+
   it('should throw an error if subtracting two quantities of different units', function () {
     assert.throws(function () {
       subtract(math.unit(5, 'km'), math.unit(100, 'gram'))

--- a/test/unit-tests/type/unit/Unit.test.js
+++ b/test/unit-tests/type/unit/Unit.test.js
@@ -1007,6 +1007,19 @@ describe('Unit', function () {
       const unitP = unit5.pow(math.bignumber(-3.5))
       assert(math.isBigNumber(unitP.value))
     })
+
+    it('should multiply/divide units with offsets correctly', () => {
+      const unit1 = new Unit(1, 'm')
+      const unit2 = new Unit(1, 'degC')
+      const unit3 = new Unit(1, 'm degC')
+      unit3.skipAutomaticSimplification = false
+      assert.deepStrictEqual(unit1.multiply(unit2), unit3)
+      const unit4 = new Unit(1, 'in')
+      const unit5 = new Unit(1, 'degF')
+      const unit6 = new Unit(1, 'in/degF')
+      unit6.skipAutomaticSimplification = false
+      assert.deepStrictEqual(unit4.divide(unit5), unit6)
+    })
   })
 
   describe('plurals', function () {
@@ -1129,7 +1142,9 @@ describe('Unit', function () {
 
     it('should create a custom unit from a configuration object', function () {
       Unit.createUnitSingle('wiggle', { definition: '4 rad^2/s', offset: 1, prefixes: 'long' })
-      assert.strictEqual(math.evaluate('8000 rad^2/s').toString(), '1 kilowiggle')
+      assert.strictEqual(math.evaluate('8000 rad^2/s').toString(), '2 kilowiggle')
+      Unit.createUnitSingle('wriggle', { definition: '4 rad^2/s', offset: 0, prefixes: 'long' })
+      assert.strictEqual(math.evaluate('2 wriggle to wiggle').toString(), '1 wiggle')
     })
 
     it('should return the new (value-less) unit', function () {


### PR DESCRIPTION
  Incorporating unit offsets into the internal "value" of the unit
  causes more problems than it solves. This commit ends that practice
  and instead only uses the offset when converting units or when
  computing the absolute value of a unit.
  Further, it makes it an error to compute the sign of a unit with an
  offset, since that is inherently ambiguous: there is no way to tell
  whether "-5 degC" is a temperature change, in which case it is definitely
  negative, or if it is a specific temperature of something, in which case
  it is "positive" in the sense of being above absolute zero.
  (Unclear how valuable this latter concept is anyway, given that there are
  no negative temperatures possible in that sense...)
  Adds several tests for the various problems the former practice caused,
  including all four basic arithmetic operations on units with offsets.

Resolves #2499.