### PR TITLE
feat: Improve `approx.deepEqual`, to support epsilon

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,9 @@
 - Fix #2493: unclear error message when an entity that is not a function
   is being called as a function (#2494). Thanks @gwhitney.
 - Some fixes in the docs on units (#2498). Thanks @dvd101x.
-
+- Correct approx.deepEqual() to accept an epsilon argument giving the
+  comparison tolerance. It was already being called this way, but was
+  silently ignoring the tolerance. Thanks @yifanwww.
 
 # 2022-03-23, version 10.4.1
 

--- a/test/unit-tests/approx.test.js
+++ b/test/unit-tests/approx.test.js
@@ -10,6 +10,11 @@ describe('approx', function () {
     approx.equal(2, 1.999999)
     assert.throws(function () { approx.equal(2, 2.001) }, assert.AssertionError)
     assert.throws(function () { approx.equal(2, 1.999) }, assert.AssertionError)
+
+    approx.equal(2, 2.0000000001, 1e-10)
+    approx.equal(2, 1.9999999999, 1e-10)
+    assert.throws(() => approx.equal(2, 2.0000000001, 1e-11), assert.AssertionError)
+    assert.throws(() => approx.equal(2, 1.9999999999, 1e-11), assert.AssertionError)
   })
 
   it('should test equality of negative values', function () {
@@ -17,6 +22,11 @@ describe('approx', function () {
     approx.equal(-2, -1.999999)
     assert.throws(function () { approx.equal(-2, -2.001) }, assert.AssertionError)
     assert.throws(function () { approx.equal(-2, -1.999) }, assert.AssertionError)
+
+    approx.equal(-2, -2.0000000001, 1e-10)
+    approx.equal(-2, -1.9999999999, 1e-10)
+    assert.throws(() => approx.equal(-2, -2.0000000001, 1e-11), assert.AssertionError)
+    assert.throws(() => approx.equal(-2, -1.9999999999, 1e-11), assert.AssertionError)
   })
 
   it('should test equality of very large values', function () {
@@ -24,6 +34,11 @@ describe('approx', function () {
     approx.equal(2e100, 1.999999e100)
     assert.throws(function () { approx.equal(2e100, 2.001e100) }, assert.AssertionError)
     assert.throws(function () { approx.equal(2e100, 1.999e100) }, assert.AssertionError)
+
+    approx.equal(2e100, 2.0000000001e100, 1e-10)
+    approx.equal(2e100, 1.9999999999e100, 1e-10)
+    assert.throws(() => approx.equal(2e100, 2.0000000001e100, 1e-11), assert.AssertionError)
+    assert.throws(() => approx.equal(2e100, 1.9999999999e100, 1e-11), assert.AssertionError)
   })
 
   it('should test equality of very small values', function () {
@@ -31,6 +46,11 @@ describe('approx', function () {
     approx.equal(2e-100, 1.999999e-100)
     assert.throws(function () { approx.equal(2e-100, 2.001e-100) }, assert.AssertionError)
     assert.throws(function () { approx.equal(2e-100, 1.999e-100) }, assert.AssertionError)
+
+    approx.equal(2e-100, 2.0000000001e-100, 1e-10)
+    approx.equal(2e-100, 1.9999999999e-100, 1e-10)
+    assert.throws(() => approx.equal(2e-100, 2.0000000001e-100, 1e-11), assert.AssertionError)
+    assert.throws(() => approx.equal(2e-100, 1.9999999999e-100, 1e-11), assert.AssertionError)
   })
 
   it('should test equality of NaN numbers', function () {
@@ -47,6 +67,9 @@ describe('approx', function () {
     approx.equal(0, 1e-15)
     approx.equal(1e-15, 0)
     assert.throws(function () { approx.equal(0, 0.001) }, assert.AssertionError)
+
+    approx.equal(0, 0.00000000009, 1e-10)
+    assert.throws(() => approx.equal(0, 0.00000000009, 1e-11), assert.AssertionError)
   })
 
   // TODO: test approx.equal for (mixed) numbers, BigNumbers, Fractions, Complex numbers
@@ -78,6 +101,31 @@ describe('approx', function () {
         a: [1.001, 1.99999999, 3.000005],
         b: [{ c: 3, d: 5.0000023 }]
       })
+    }, assert.AssertionError)
+
+    approx.deepEqual(
+      {
+        a: [1, 2, 3],
+        b: [{ c: 4.123456789123, d: 5.987654321987 }]
+      },
+      {
+        a: [1.00000000001, 1.9999999999, 3.0000000002],
+        b: [{ c: 4.12345678913, d: 5.98765432197 }]
+      },
+      1e-10
+    )
+    assert.throws(() => {
+      approx.deepEqual(
+        {
+          a: [1, 2, 3],
+          b: [{ c: 4.123456789123, d: 5.987654321987 }]
+        },
+        {
+          a: [1.00000000001, 1.9999999999, 3.0000000002],
+          b: [{ c: 4.12345678913, d: 5.98765432197 }]
+        },
+        1e-11
+      )
     }, assert.AssertionError)
   })
 })

--- a/test/unit-tests/function/trigonometry/sinh.test.js
+++ b/test/unit-tests/function/trigonometry/sinh.test.js
@@ -73,7 +73,7 @@ describe('sinh', function () {
   it('should return the sinh of a complex number', function () {
     approx.deepEqual(sinh(complex('1')), complex(1.1752011936438014, 0), EPSILON)
     approx.deepEqual(sinh(complex('i')), complex(0, 0.8414709848079), EPSILON)
-    approx.deepEqual(sinh(complex('2 + i')), complex(1.9596010414216, 3.1657785132162), 1e-13)
+    approx.deepEqual(sinh(complex('2 + i')), complex(1.95960104142160589707, 3.16577851321616814674), EPSILON)
   })
 
   it('should return the sinh of an angle', function () {
@@ -83,7 +83,7 @@ describe('sinh', function () {
     assert(math.isBigNumber(sinh(unit(math.bignumber(90), 'deg'))))
     approx.equal(sinh(unit(math.bignumber(90), 'deg')).toNumber(), 2.3012989023073, EPSILON)
 
-    approx.deepEqual(sinh(unit(complex('2 + i'), 'rad')), complex(1.9596010414216, 3.1657785132162), 1e-13)
+    approx.deepEqual(sinh(unit(complex('2 + i'), 'rad')), complex(1.95960104142160589707, 3.16577851321616814674), EPSILON)
   })
 
   it('should throw an error if called with an invalid unit', function () {

--- a/test/unit-tests/function/trigonometry/sinh.test.js
+++ b/test/unit-tests/function/trigonometry/sinh.test.js
@@ -73,7 +73,7 @@ describe('sinh', function () {
   it('should return the sinh of a complex number', function () {
     approx.deepEqual(sinh(complex('1')), complex(1.1752011936438014, 0), EPSILON)
     approx.deepEqual(sinh(complex('i')), complex(0, 0.8414709848079), EPSILON)
-    approx.deepEqual(sinh(complex('2 + i')), complex(1.9596010414216, 3.1657785132162), EPSILON)
+    approx.deepEqual(sinh(complex('2 + i')), complex(1.9596010414216, 3.1657785132162), 1e-13)
   })
 
   it('should return the sinh of an angle', function () {
@@ -83,7 +83,7 @@ describe('sinh', function () {
     assert(math.isBigNumber(sinh(unit(math.bignumber(90), 'deg'))))
     approx.equal(sinh(unit(math.bignumber(90), 'deg')).toNumber(), 2.3012989023073, EPSILON)
 
-    approx.deepEqual(sinh(unit(complex('2 + i'), 'rad')), complex(1.9596010414216, 3.1657785132162), EPSILON)
+    approx.deepEqual(sinh(unit(complex('2 + i'), 'rad')), complex(1.9596010414216, 3.1657785132162), 1e-13)
   })
 
   it('should throw an error if called with an invalid unit', function () {

--- a/tools/approx.js
+++ b/tools/approx.js
@@ -65,29 +65,29 @@ exports.equal = function equal (a, b, epsilon) {
  * @param {*} a
  * @param {*} b
  */
-exports.deepEqual = function deepEqual (a, b) {
+exports.deepEqual = function deepEqual (a, b, epsilon) {
   let prop, i, len
 
   if (Array.isArray(a) && Array.isArray(b)) {
     assert.strictEqual(a.length, b.length, a + ' ~= ' + b)
     for (i = 0, len = a.length; i < len; i++) {
-      deepEqual(a[i], b[i])
+      deepEqual(a[i], b[i], epsilon)
     }
   } else if (a instanceof Object && b instanceof Object) {
     for (prop in a) {
       if (hasOwnProperty(a, prop)) {
         assert.ok(hasOwnProperty(b, prop), a[prop] + ' ~= ' + b[prop])
-        deepEqual(a[prop], b[prop])
+        deepEqual(a[prop], b[prop], epsilon)
       }
     }
 
     for (prop in b) {
       if (hasOwnProperty(b, prop)) {
         assert.ok(hasOwnProperty(a, prop), a[prop] + ' ~= ' + b[prop])
-        deepEqual(a[prop], b[prop])
+        deepEqual(a[prop], b[prop], epsilon)
       }
     }
   } else {
-    exports.equal(a, b)
+    exports.equal(a, b, epsilon)
   }
 }


### PR DESCRIPTION
Just let `approx.deepEqual` support `epsilon` so that I can test the precision of lgamma for complex numbers in PR #2417 