### PR TITLE
chore: Bump complex.js to version 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
-        "complex.js": "^2.0.15",
+        "complex.js": "^2.1.0",
         "decimal.js": "^10.3.1",
         "escape-latex": "^1.2.0",
         "fraction.js": "^4.2.0",
@@ -4425,9 +4425,9 @@
       "dev": true
     },
     "node_modules/complex.js": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.15.tgz",
-      "integrity": "sha512-gDBvQU8IG139ZBQTSo2qvDFP+lANMGluM779csXOr6ny1NUtA3wkUnCFjlDNH/moAVfXtvClYt6G0zarFbtz5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.0.tgz",
+      "integrity": "sha512-RdcrDz7YynXp/YXGwXIZ4MtmxXXniT5WmLFRX93cuXUX+0geWAqB8l1BoLXF+3BkzviVzHlpw27P9ow7MvlcmA==",
       "engines": {
         "node": "*"
       },
@@ -20206,9 +20206,9 @@
       "dev": true
     },
     "complex.js": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.15.tgz",
-      "integrity": "sha512-gDBvQU8IG139ZBQTSo2qvDFP+lANMGluM779csXOr6ny1NUtA3wkUnCFjlDNH/moAVfXtvClYt6G0zarFbtz5w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.0.tgz",
+      "integrity": "sha512-RdcrDz7YynXp/YXGwXIZ4MtmxXXniT5WmLFRX93cuXUX+0geWAqB8l1BoLXF+3BkzviVzHlpw27P9ow7MvlcmA=="
     },
     "component-emitter": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.17.8",
-    "complex.js": "^2.0.15",
+    "complex.js": "^2.1.0",
     "decimal.js": "^10.3.1",
     "escape-latex": "^1.2.0",
     "fraction.js": "^4.2.0",

--- a/test/unit-tests/function/arithmetic/log.test.js
+++ b/test/unit-tests/function/arithmetic/log.test.js
@@ -93,6 +93,17 @@ describe('log', function () {
     approx.deepEqual(log(complex(1, 0)), complex(0, 0))
   })
 
+  it('should handle complex number with large imaginary part', function () {
+    const tau4 = math.tau / 4
+    const real = [0, -1, 1]
+    const imaginary = [1e15, 1e17, 1e20, 1e30]
+    for (const r of real) {
+      for (const im of imaginary) {
+        approx.deepEqual(log(complex(r, im)), complex(Math.log(im), tau4))
+      }
+    }
+  })
+
   it('should throw an error when used on a unit', function () {
     assert.throws(function () { log(unit('5cm')) })
   })


### PR DESCRIPTION
  Also adds tests for math.log() of complex numbers in which the imaginary
  part is much larger in absolute value than the real part.
  Resolves #2503.