### PR TITLE
fix(combinatorics): Improve precision of stirlingS2

### DIFF
--- a/src/function/combinatorics/stirlingS2.js
+++ b/src/function/combinatorics/stirlingS2.js
@@ -1,4 +1,5 @@
 import { factory } from '../../utils/factory.js'
+import { isNumber } from '../../utils/is.js'
 
 const name = 'stirlingS2'
 const dependencies = [
@@ -12,6 +13,8 @@ const dependencies = [
   'combinations',
   'isNegative',
   'isInteger',
+  'number',
+  '?bignumber',
   'larger'
 ]
 
@@ -27,16 +30,24 @@ export const createStirlingS2 = /* #__PURE__ */ factory(name, dependencies, (
     combinations,
     isNegative,
     isInteger,
+    number,
+    bignumber,
     larger
   }
 ) => {
+  const smallCache = []
+  const bigCache = []
   /**
    * The Stirling numbers of the second kind, counts the number of ways to partition
    * a set of n labelled objects into k nonempty unlabelled subsets.
    * stirlingS2 only takes integer arguments.
    * The following condition must be enforced: k <= n.
    *
-   *  If n = k or k = 1, then s(n,k) = 1
+   *  If n = k or k = 1 <= n, then s(n,k) = 1
+   *  If k = 0 < n, then s(n,k) = 0
+   *
+   * Note that if either n or k is supplied as a BigNumber, the result will be
+   * as well.
    *
    * Syntax:
    *
@@ -62,18 +73,32 @@ export const createStirlingS2 = /* #__PURE__ */ factory(name, dependencies, (
         throw new TypeError('k must be less than or equal to n in function stirlingS2')
       }
 
-      // 1/k! Sum(i=0 -> k) [(-1)^(k-i)*C(k,j)* i^n]
-      const kFactorial = factorial(k)
-      let result = 0
-      for (let i = 0; i <= k; i++) {
-        const negativeOne = pow(-1, subtract(k, i))
-        const kChooseI = combinations(k, i)
-        const iPower = pow(i, n)
-
-        result = addScalar(result, multiplyScalar(multiplyScalar(kChooseI, iPower), negativeOne))
+      let big = !(isNumber(n) && isNumber(k))
+      const cache = big ? bigCache : smallCache
+      const make = big ? bignumber : number
+      const nn = number(n)
+      const nk = number(k)
+      /* See if we already have the value: */
+      if (cache[nn] && cache[nn].length > nk) {
+        return cache[nn][nk]
       }
-
-      return divideScalar(result, kFactorial)
+      /* Fill the cache */
+      for (let m = 0; m <= nn; ++m) {
+        if (!cache[m]) {
+          cache[m] = [ m === 0 ? make(1) : make(0) ]
+        }
+        if (m === 0) continue
+        const row = cache[m]
+        const prev = cache[m-1]
+        for (let i = row.length; i <= m && i <= nk; ++i) {
+          if (i == m) {
+            row[i] = 1
+          } else {
+            row[i] = addScalar(multiplyScalar(make(i), prev[i]), prev[i-1])
+          }
+        }
+      }
+      return cache[nn][nk]
     }
   })
 })

--- a/test/unit-tests/function/combinatorics/bellNumbers.test.js
+++ b/test/unit-tests/function/combinatorics/bellNumbers.test.js
@@ -7,11 +7,21 @@ describe('bellNumbers', function () {
     assert.strictEqual(bellNumbers(3), 5)
     assert.strictEqual(bellNumbers(0), 1)
     assert.strictEqual(bellNumbers(8), 4140)
+    assert.strictEqual(bellNumbers(17), 82864869804)
+    assert.strictEqual(bellNumbers(22), 4506715738447323)
+    // That's as large as we can go with number representation
   })
 
   it('should calculate the bellNumbers of n items with BigNumbers', function () {
-    assert.deepStrictEqual(bellNumbers(math.bignumber(2)), math.bignumber(2))
-    assert.deepStrictEqual(bellNumbers(math.bignumber(3)), math.bignumber(5))
+    const bn = math.bignumber
+    assert.deepStrictEqual(bellNumbers(bn(2)), bn(2))
+    assert.deepStrictEqual(bellNumbers(bn(3)), bn(5))
+    assert.deepStrictEqual(bellNumbers(bn(17)), bn(82864869804))
+    assert.deepStrictEqual(bellNumbers(bn(22)), bn(4506715738447323))
+    // and now we can go farther
+    assert.deepStrictEqual(bellNumbers(bn(26)), bn('49631246523618756274'))
+    assert.deepStrictEqual(bellNumbers(bn(50)),
+      bn('185724268771078270438257767181908917499221852770'))
   })
 
   it('should not work with non-integer and negative input', function () {

--- a/test/unit-tests/function/combinatorics/stirlingS2.test.js
+++ b/test/unit-tests/function/combinatorics/stirlingS2.test.js
@@ -7,11 +7,25 @@ describe('stirlingS2', function () {
     assert.strictEqual(stirlingS2(5, 3), 25)
     assert.strictEqual(stirlingS2(0, 0), 1)
     assert.strictEqual(stirlingS2(8, 7), 28)
+    assert.strictEqual(stirlingS2(14, 13), 91)
+    assert.strictEqual(stirlingS2(10, 5), 42525)
+    assert.strictEqual(stirlingS2(15, 6), 420693273)
+    assert.strictEqual(stirlingS2(22, 9), 1241963303533920)
+    // and that's about as big as we can go with the number type
   })
 
   it('should calculate the stirlingS2 of n items taken k at a time with BigNumbers', function () {
-    assert.deepStrictEqual(stirlingS2(math.bignumber(7), math.bignumber(5)), math.bignumber(140))
-    assert.deepStrictEqual(stirlingS2(math.bignumber(8), math.bignumber(6)), math.bignumber(266))
+    const bn = math.bignumber
+    assert.deepStrictEqual(stirlingS2(bn(7), bn(5)), bn(140))
+    assert.deepStrictEqual(stirlingS2(bn(8), bn(6)), bn(266))
+    assert.deepStrictEqual(stirlingS2(bn(14), 13), bn(91))
+    assert.deepStrictEqual(stirlingS2(10, bn(5)), bn(42525))
+    assert.deepStrictEqual(stirlingS2(bn(15), bn(6)), bn(420693273))
+    assert.deepStrictEqual(stirlingS2(bn(22), 9), bn(1241963303533920))
+    // And now we can go bigger:
+    assert.deepStrictEqual(stirlingS2(bn(23), 9), bn('12320068811796900'))
+    assert.deepStrictEqual(stirlingS2(bn(50), 14),
+      bn('16132809270066494376125322988035691981158490930'))
   })
 
   it('should not work with non-integer and negative input', function () {


### PR DESCRIPTION
  Previously the computation of stirlingS2 used the closed form, which
  suffers numerically by dividing a sum of very large terms by a large
  factorial, causing roundoff errors for unnecessarily small inputs.

  This commit switches to using the recurrence relation for the stirling
  numbers of the second kind, and caching the partial results for future
  calls. This has the advantage that all intermediate results are smaller
  than the final value.

  Also adds tests for much larger values of the stirlingS2 function and of
  bellNumbers, whose computation depends on stirlingS2.

  Resolves #2508.