### PR TITLE
fix: Allow base argument to `log` in number-only module

### DIFF
--- a/src/factoriesNumber.js
+++ b/src/factoriesNumber.js
@@ -123,7 +123,8 @@ export const createXgcd = /* #__PURE__ */ createNumberFactory('xgcd', xgcdNumber
 export const createDivideScalar = /* #__PURE__ */ createNumberFactory('divideScalar', divideNumber)
 export const createPow = /* #__PURE__ */ createNumberFactory('pow', powNumber)
 export { createRoundNumber as createRound } from './function/arithmetic/round.js'
-export const createLog = /* #__PURE__ */ createNumberFactory('log', logNumber)
+export const createLog = /* #__PURE__ */
+  createNumberOptionalSecondArgFactory('log', logNumber)
 export const createLog1p = /* #__PURE__ */ createNumberFactory('log1p', log1pNumber)
 export const createAdd = /* #__PURE__ */ createNumberFactory('add', addNumber)
 export { createHypot } from './function/arithmetic/hypot.js'
@@ -322,7 +323,11 @@ export { createNumeric } from './function/utils/numeric.js'
 export { createReviver } from './json/reviver.js'
 export { createReplacer } from './json/replacer.js'
 
-// helper function to create a factory function for a function which only needs typed-function
+// helper functions to create a factory function for a function which only needs typed-function
 function createNumberFactory (name, fn) {
   return factory(name, ['typed'], ({ typed }) => typed(fn))
+}
+function createNumberOptionalSecondArgFactory (name, fn) {
+  return factory(
+    name, ['typed'], ({ typed }) => typed({ number: fn, 'number,number': fn }))
 }

--- a/src/plain/number/arithmetic.js
+++ b/src/plain/number/arithmetic.js
@@ -124,14 +124,15 @@ export function lcmNumber (a, b) {
 lcmNumber.signature = n2
 
 /**
- * Calculate the logarithm of a value.
+ * Calculate the logarithm of a value, optionally to a given base.
  * @param {number} x
+ * @param {number | null | undefined} base
  * @return {number}
  */
-export function logNumber (x) {
+export function logNumber (x, y) {
+  if (y) { return Math.log(x) / Math.log(y) }
   return Math.log(x)
 }
-logNumber.signature = n1
 
 /**
  * Calculate the 10-base logarithm of a number

--- a/test/node-tests/commonjs.test.js
+++ b/test/node-tests/commonjs.test.js
@@ -16,7 +16,7 @@ describe('lib/cjs', function () {
     const filename = path.join(__dirname, 'commonjsAppNumberOnly.cjs')
     cp.exec('node ' + filename, function (error, result) {
       assert.strictEqual(error, null)
-      assert.strictEqual(result, '2\nNaN\n')
+      assert.strictEqual(result, '2\nNaN\n2\n4\n')
       done()
     })
   })

--- a/test/node-tests/commonjsAppNumberOnly.cjs
+++ b/test/node-tests/commonjsAppNumberOnly.cjs
@@ -1,4 +1,6 @@
-const { sqrt, format } = require('../../lib/cjs/number.js')
+const { e, sqrt, format, log } = require('../../lib/cjs/number.js')
 
 console.log(format(sqrt(4)))
 console.log(format(sqrt(-4)))
+console.log(format(log(e * e)))
+console.log(format(log(625, 5)))

--- a/test/node-tests/esm.test.js
+++ b/test/node-tests/esm.test.js
@@ -17,7 +17,7 @@ describe('lib/esm', function () {
     const filename = path.join(__dirname, 'esmAppNumberOnly.mjs')
     cp.exec('node ' + filename, function (error, result) {
       assert.strictEqual(error, null)
-      assert.strictEqual(result, '2\nNaN\n')
+      assert.strictEqual(result, '2\nNaN\n2\n4\n')
       done()
     })
   })

--- a/test/node-tests/esmAppNumberOnly.mjs
+++ b/test/node-tests/esmAppNumberOnly.mjs
@@ -1,5 +1,7 @@
 // TODO: would be nice to call '../../' so we know for sure ESM is correctly exported
-import { sqrt, format } from '../../lib/esm/number.js'
+import { e, sqrt, format, log } from '../../lib/esm/number.js'
 
 console.log(format(sqrt(4)))
 console.log(format(sqrt(-4)))
+console.log(format(log(e * e)))
+console.log(format(log(625, 5)))


### PR DESCRIPTION
  Provides a number-only factory for `log` with both signatures 'number'
  and 'number,number'.

  Resolves #2514.