### PR TITLE
Fix/mocha reporter

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,5 @@
 {
+  "reporter": "dot",
   "timeout": 60000,
   "forbid-only": true,
   "recursive": true

--- a/test/unit-tests/expression/Parser.test.js
+++ b/test/unit-tests/expression/Parser.test.js
@@ -33,7 +33,6 @@ describe('parser', function () {
     const parser = new Parser()
 
     const result = parser.evaluate(['a = 2', 'a + 3'])
-    console.log('result', result, math.typeOf(result))
     assert.deepStrictEqual(result, [2, 5])
   })
 


### PR DESCRIPTION
When running the almost ~5000 or so unit tests, a log line is outputted for every unit test. This gives huge log files, where you cannot see any "real" outputs because they're lost in the noise. 

This PR changes the reporter of Mocha to `dot`, outputting only a dot for every executed test.

Does that make sense to you @gwhitney ?