### PR TITLE
Test lgamma on IE11 with less precision

### DIFF
--- a/test/unit-tests/function/probability/lgamma.test.js
+++ b/test/unit-tests/function/probability/lgamma.test.js
@@ -5,7 +5,14 @@ import approx from '../../../../tools/approx.js'
 import math from '../../../../src/defaultInstance.js'
 const lgamma = math.lgamma
 
-const EPSILON = 1e-11
+function isInternetExplorer () {
+  return typeof window !== 'undefined'
+    ? window?.navigator?.userAgent?.indexOf('MSIE ') > 0
+    : false
+}
+
+// IE does have less precision for unclear reason, therefore this hack
+const EPSILON = isInternetExplorer() ? 1e-9 : 1e-11
 // TODO: lgamma for some cases of complex numbers is not quite as precise as
 // lgamma for reals
 const CEPSILON = 5e-8

--- a/test/unit-tests/function/probability/lgamma.test.js
+++ b/test/unit-tests/function/probability/lgamma.test.js
@@ -6,8 +6,8 @@ import math from '../../../../src/defaultInstance.js'
 const lgamma = math.lgamma
 
 function isInternetExplorer () {
-  return typeof window !== 'undefined'
-    ? window?.navigator?.userAgent?.indexOf('MSIE ') > 0
+  return typeof window !== 'undefined' && window.navigator && window.navigator.userAgent
+    ? window.navigator.userAgent.indexOf('MSIE ') > 0
     : false
 }
 


### PR DESCRIPTION
Right now one unit test on the `develop` branch fail on IE 11. I think this issue was introduced in https://github.com/josdejong/mathjs/pull/2525 and not noticed before since the BrowserStack tests with IE11 only run after merging a PR (because of security reasons).

https://github.com/josdejong/mathjs/runs/6028744969?check_suite_focus=true

```
FAILED TESTS:
  lgamma
    ✖ should calculate the lgamma of a complex number
      IE 11.0 (Windows 10)
    AssertionError: 20.37669223739772 ~= 20.376692246089224
       at fail (eval code:199:3)
       at ok (eval code:219:15)
       at equal (eval code:41:7)
       at deepEqual (eval code:94:5)
       at deepEqual (eval code:83:9)
       at Anonymous function (eval code:106:5)
```

I made an ugly little workaround for this by testing with less precision on IE11. Does this make sense @gwhitney ? Or do you have other ideas to tackle this issue?