### PR TITLE
Fix #2532: matrix index symbol `end` not working when used inside a sub-expression

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+# unpublished changes since version 10.5.0:
+
+- Fix #2532: matrix index symbol `end` not working when used inside
+  a sub-expression.
+
+
 # 2022-04-19, version 10.5.0
 
 - Implement #1563: function `pinv`, Moore–Penrose inverse (#2521). 

--- a/test/unit-tests/expression/node/AccessorNode.test.js
+++ b/test/unit-tests/expression/node/AccessorNode.test.js
@@ -76,6 +76,27 @@ describe('AccessorNode', function () {
     assert.deepStrictEqual(expr.evaluate(scope), [[3, 4]])
   })
 
+  it('should compile a AccessorNode with "end" in an expression', function () {
+    const a = new SymbolNode('a')
+    const index = new IndexNode([
+      new OperatorNode(
+        '-',
+        'subtract',
+        [
+          new SymbolNode('end'),
+          new ConstantNode(2)
+        ]
+      )
+    ])
+    const n = new AccessorNode(a, index)
+    const expr = n.compile()
+
+    const scope = {
+      a: [1, 2, 3, 4]
+    }
+    assert.deepStrictEqual(expr.evaluate(scope), 2)
+  })
+
   it('should compile a AccessorNode with a property', function () {
     const a = new SymbolNode('a')
     const index = new IndexNode([new ConstantNode('b')])


### PR DESCRIPTION
Fix #2532. Instead of only supporting the case where the index is `end`, it now handles any sub-expression inside with `end` is used.

@dvd101x or @gwhitney can you have a look at this PR?