### PR TITLE
Add TS type for `resolve` function

### DIFF
--- a/src/function/algebra/resolve.js
+++ b/src/function/algebra/resolve.js
@@ -35,11 +35,12 @@ export const createResolve = /* #__PURE__ */ factory(name, dependencies, ({
    *
    *     simplify, evaluate
    *
-   * @param {Node} node
-   *     The expression tree to be simplified
+   * @template nodeOrNodes
+   * @param {nodeOrNodes} node
+   *     The expression tree (or trees) to be simplified
    * @param {Object} scope
    *     Scope specifying variables to be resolved
-   * @return {Node} Returns `node` with variables recursively substituted.
+   * @return {numOrStr extends Node[] ? Node[] : Node} Returns `nodeOrNodes` with variables recursively substituted.
    * @throws {ReferenceError}
    *     If there is a cyclic dependency among the variables in `scope`,
    *     resolution is impossible and a ReferenceError is thrown.

--- a/src/function/algebra/resolve.js
+++ b/src/function/algebra/resolve.js
@@ -85,6 +85,7 @@ export const createResolve = /* #__PURE__ */ factory(name, dependencies, ({
       })
       return new FunctionNode(node.name, args)
     }
+
     // Otherwise just recursively resolve any children (might also work
     // for some of the above special cases)
     return node.map(child => resolve(child, scope, within))

--- a/src/function/algebra/resolve.js
+++ b/src/function/algebra/resolve.js
@@ -35,12 +35,11 @@ export const createResolve = /* #__PURE__ */ factory(name, dependencies, ({
    *
    *     simplify, evaluate
    *
-   * @template nodeOrNodes
-   * @param {nodeOrNodes} node
+   * @param {Node | Node[]} node
    *     The expression tree (or trees) to be simplified
    * @param {Object} scope
    *     Scope specifying variables to be resolved
-   * @return {numOrStr extends Node[] ? Node[] : Node} Returns `nodeOrNodes` with variables recursively substituted.
+   * @return {Node | Node[]} Returns `node` with variables recursively substituted.
    * @throws {ReferenceError}
    *     If there is a cyclic dependency among the variables in `scope`,
    *     resolution is impossible and a ReferenceError is thrown.

--- a/test/unit-tests/function/algebra/resolve.test.js
+++ b/test/unit-tests/function/algebra/resolve.test.js
@@ -48,6 +48,21 @@ describe('resolve', function () {
     simplifyAndCompare('x+y', 'y+1', new Map([['x', math.parse('1')]]))
   })
 
+  it('should resolve multiple nodes', function () {
+    const scope = { x: 1, y: 2 }
+
+    assert.deepStrictEqual(
+      math.resolve([
+        math.parse('x+z'),
+        math.parse('y+z')
+      ], scope),
+      [
+        math.resolve(math.parse('x+z'), scope),
+        math.resolve(math.parse('y+z'), scope)
+      ]
+    )
+  })
+
   it('should throw an error in case of reference loop', function () {
     const sumxy = math.parse('x+y')
     assert.throws(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -815,13 +815,13 @@ declare namespace math {
      */
     simplify: Simplify
 
-     /**
+    /**
      *  Replaces variable nodes with their scoped values
      * @param node Tree to replace variable nodes in
      * @param scope Scope to read/write variables
      */
-    resolve(node: MathNode, scope?: Record<string, any>): MathNode;
-    resolve(node: MathNode[], scope?: Record<string, any>): MathNode[];
+    resolve(node: MathNode, scope?: Record<string, any>): MathNode
+    resolve(node: MathNode[], scope?: Record<string, any>): MathNode[]
 
     /**
      * Calculate the Sparse Matrix LU decomposition with full pivoting.
@@ -4138,7 +4138,7 @@ declare namespace math {
      *  Replaces variable nodes with their scoped values
      * @param scope Scope to read/write variables
      */
-    resolve(scope?: Record<string, any>): MathJsChain;
+    resolve(scope?: Record<string, any>): MathJsChain
 
     /*************************************************************************
      * Algebra functions
@@ -5653,4 +5653,3 @@ declare namespace math {
     [key: string]: any
   }
 }
-

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -820,7 +820,8 @@ declare namespace math {
      * @param node Tree to replace variable nodes in
      * @param scope Scope to read/write variables
      */
-    resolve<TNode = MathNode>(node: TNode, scope: Record<string, any>): TNode;
+    resolve(node: MathNode, scope?: Record<string, any>): MathNode;
+    resolve(node: MathNode[], scope?: Record<string, any>): MathNode[];
 
     /**
      * Calculate the Sparse Matrix LU decomposition with full pivoting.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -815,6 +815,13 @@ declare namespace math {
      */
     simplify: Simplify
 
+     /**
+     *  Replaces variable nodes with their scoped values
+     * @param node Tree to replace variable nodes in
+     * @param scope Scope to read/write variables
+     */
+    resolve<TNode = MathNode>(node: TNode, scope: Record<string, any>): TNode;
+
     /**
      * Calculate the Sparse Matrix LU decomposition with full pivoting.
      * Sparse Matrix A is decomposed in two matrices (L, U) and two
@@ -4125,6 +4132,12 @@ declare namespace math {
      * object.
      */
     parser(): MathJsChain
+
+    /**
+     *  Replaces variable nodes with their scoped values
+     * @param scope Scope to read/write variables
+     */
+    resolve(scope: Record<string, any>): MathJsChain;
 
     /*************************************************************************
      * Algebra functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5653,3 +5653,4 @@ declare namespace math {
     [key: string]: any
   }
 }
+

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4138,7 +4138,7 @@ declare namespace math {
      *  Replaces variable nodes with their scoped values
      * @param scope Scope to read/write variables
      */
-    resolve(scope: Record<string, any>): MathJsChain;
+    resolve(scope?: Record<string, any>): MathJsChain;
 
     /*************************************************************************
      * Algebra functions

--- a/types/index.ts
+++ b/types/index.ts
@@ -152,6 +152,9 @@ Chaining examples
 
   const r = math.chain(-0.483).round([0, 1, 2]).floor().add(0.52).fix(1).done()
   assert.deepStrictEqual(r, [0.5, -0.4, -0.4])
+
+  expectTypeOf(math.chain('x + y').resolve({ x: 1 }).done()).toMatchTypeOf<any>()
+  expectTypeOf(math.chain('x + y').resolve().done()).toMatchTypeOf<any>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,8 +8,8 @@ import {
   divideDependencies,
   formatDependencies,
   MathNode,
-} from 'mathjs';
-import * as assert from 'assert';
+} from 'mathjs'
+import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
 
 // This file serves a dual purpose:
@@ -153,7 +153,9 @@ Chaining examples
   const r = math.chain(-0.483).round([0, 1, 2]).floor().add(0.52).fix(1).done()
   assert.deepStrictEqual(r, [0.5, -0.4, -0.4])
 
-  expectTypeOf(math.chain('x + y').resolve({ x: 1 }).done()).toMatchTypeOf<any>()
+  expectTypeOf(
+    math.chain('x + y').resolve({ x: 1 }).done()
+  ).toMatchTypeOf<any>()
   expectTypeOf(math.chain('x + y').resolve().done()).toMatchTypeOf<any>()
 }
 
@@ -1258,9 +1260,13 @@ toTex examples
 Resolve examples
 */
 {
-  const math = create(all, {});
+  const math = create(all, {})
 
   expectTypeOf(math.resolve(math.parse('x + y'))).toMatchTypeOf<MathNode>()
-  expectTypeOf(math.resolve(math.parse('x + y'), { x: 0 })).toMatchTypeOf<MathNode>()
-  expectTypeOf(math.resolve([math.parse('x + y')], { x: 0 })).toMatchTypeOf<MathNode[]>()
+  expectTypeOf(
+    math.resolve(math.parse('x + y'), { x: 0 })
+  ).toMatchTypeOf<MathNode>()
+  expectTypeOf(math.resolve([math.parse('x + y')], { x: 0 })).toMatchTypeOf<
+    MathNode[]
+  >()
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,8 +7,9 @@ import {
   addDependencies,
   divideDependencies,
   formatDependencies,
-} from 'mathjs'
-import * as assert from 'assert'
+  MathNode,
+} from 'mathjs';
+import * as assert from 'assert';
 import { expectTypeOf } from 'expect-type'
 
 // This file serves a dual purpose:
@@ -1248,4 +1249,15 @@ toTex examples
       a: '123',
     })
   ).toMatchTypeOf<string>()
+}
+
+/*
+Resolve examples
+*/
+{
+  const math = create(all, {});
+
+  expectTypeOf(math.resolve(math.parse('x + y'))).toMatchTypeOf<MathNode>()
+  expectTypeOf(math.resolve(math.parse('x + y'), { x: 0 })).toMatchTypeOf<MathNode>()
+  expectTypeOf(math.resolve([math.parse('x + y')], { x: 0 })).toMatchTypeOf<MathNode[]>()
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -154,9 +154,11 @@ Chaining examples
   assert.deepStrictEqual(r, [0.5, -0.4, -0.4])
 
   expectTypeOf(
-    math.chain('x + y').resolve({ x: 1 }).done()
+    math.chain('x + y').parse().resolve({ x: 1 }).done()
   ).toMatchTypeOf<any>()
-  expectTypeOf(math.chain('x + y').resolve().done()).toMatchTypeOf<any>()
+  expectTypeOf(
+    math.chain('x + y').parse().resolve().done()
+  ).toMatchTypeOf<any>()
 }
 
 /*


### PR DESCRIPTION
Noticed that the `resolve` function was missing a type definition. Amazing library @josdejong, nice work 😊