### PR TITLE
Improve typing for MathJsChain

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1480,9 +1480,9 @@ declare namespace math {
      * @param x A complex number or array with complex numbers
      * @returns The imaginary part of x
      */
-    im(
-      x: number | BigNumber | Complex | MathCollection
-    ): number | BigNumber | MathCollection
+    im(x: MathJsChain<number | Complex>): MathJsChain<number>
+    im(x: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    im(x: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
      * Get the real part of a complex number. For a complex number a + bi,
@@ -1491,9 +1491,9 @@ declare namespace math {
      * @param x A complex number or array of complex numbers
      * @returns The real part of x
      */
-    re(
-      x: number | BigNumber | Complex | MathCollection
-    ): number | BigNumber | MathCollection
+    re(x: MathJsChain<number | Complex>): MathJsChain<number>
+    re(x: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    re(x: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /*************************************************************************
      * Geometry functions
@@ -4943,18 +4943,18 @@ declare namespace math {
      * bi, the function returns b. For matrices, the function is evaluated
      * element wise.
      */
-    im(
-      this: MathJsChain<number | BigNumber | Complex | MathCollection>
-    ): MathJsChain<number | BigNumber | MathCollection>
+    im(this: MathJsChain<number | Complex>): MathJsChain<number>
+    im(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    im(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
      * Get the real part of a complex number. For a complex number a + bi,
      * the function returns a. For matrices, the function is evaluated
      * element wise.
      */
-    re(
-      x: MathJsChain<number | BigNumber | Complex | MathCollection>
-    ): MathJsChain<number | BigNumber | MathCollection>
+    re(this: MathJsChain<number | Complex>): MathJsChain<number>
+    re(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    re(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /*************************************************************************
      * Geometry functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -878,7 +878,8 @@ declare namespace math {
      * @param b A column vector with the b values
      * @returns A column vector with the linear system solution (x)
      */
-    usolve(U: Matrix | MathArray, b: Matrix | MathArray): Matrix | MathArray
+    usolve(U: Matrix, b: Matrix | MathArray): Matrix
+    usolve(U: MathArray, b: Matrix | MathArray): MathArray
 
     /*************************************************************************
      * Arithmetic functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4138,17 +4138,18 @@ declare namespace math {
     help(this: MathJsChain<unknown>): MathJsChain<unknown>
 
     /**
+     * @param options Available options: nodes - a set of custome nodes
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parse(this: MathJsChain<MathExpression[]>, options?: any): MathJsChain<MathNode[]>
+
+    /**
      * Parse an expression. Returns a node tree, which can be evaluated by
      * invoking node.evaluate();
      * @param options Available options: nodes - a set of custome nodes
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parse(this: MathJsChain<unknown>, options?: any): MathJsChain<unknown>
-    /**
-     * @param options Available options: nodes - a set of custome nodes
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parse(this: MathJsChain<unknown>, options?: any): MathJsChain<unknown>
+    parse(this: MathJsChain<MathExpression>, options?: any): MathJsChain<MathNode>
 
     /**
      * Create a parser. The function creates a new math.expression.Parser

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4366,21 +4366,24 @@ declare namespace math {
      * element wise.
      * @param n Number of decimals Default value: 0.
      */
-    fix(this: MathJsChain<unknown>, n?: number | BigNumber | MathCollection): MathJsChain<unknown>
+    fix(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
+    fix(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
 
     /**
      * Round a value towards minus infinity. For matrices, the function is
      * evaluated element wise.
      * @param n Number of decimals Default value: 0.
      */
-    floor(this: MathJsChain<unknown>, n?: number | BigNumber | MathCollection): MathJsChain<unknown>
+    floor(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
+    floor(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
 
     /**
      * Round a value towards the nearest integer. For matrices, the function
      * is evaluated element wise.
      * @param n Number of decimals Default value: 0.
      */
-    round(this: MathJsChain<unknown>, n?: number | BigNumber | MathCollection): MathJsChain<unknown>
+    round(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
+    round(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
 
     // End of rounding group
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4186,7 +4186,8 @@ declare namespace math {
      * must be a lower triangular matrix.
      * @param b A column vector with the b values
      */
-    lsolve(this: MathJsChain<unknown>, b: Matrix | MathArray): MathJsChain<unknown>
+    lsolve(this: MathJsChain<Matrix>, b: Matrix | MathArray): MathJsChain<Matrix>
+    lsolve(this: MathJsChain<MathArray>, b: Matrix | MathArray): MathJsChain<MathArray>
 
     /**
      * Calculate the Matrix LU decomposition with partial pivoting. Matrix A

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4465,7 +4465,8 @@ declare namespace math {
      * matrix input, the hypotenusa is calculated for all values in the
      * matrix.
      */
-    hypot(this: MathJsChain<unknown>): MathJsChain<unknown>
+    hypot(this: MathJsChain<number[]>): MathJsChain<number>
+    hypot(this: MathJsChain<BigNumber[]>): MathJsChain<BigNumber>
 
     /**
      * Calculate the least common multiple for two or more values or arrays.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4316,7 +4316,9 @@ declare namespace math {
      * element wise.
      * @param y Second value to add
      */
-    add(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    add(this: MathJsChain<MathArray>, y: MathType): MathJsChain<MathArray>
+    add(this: MathJsChain<Matrix>, y: MathType): MathJsChain<Matrix>
+    add(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Apply a function that maps an array to a scalar along a given axis of the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -559,7 +559,9 @@ declare namespace math {
      * fraction
      * @returns Returns a fraction
      */
-    fraction(value: number | string | BigNumber | Fraction | FractionDefinition): Fraction
+    fraction(
+      value: number | string | BigNumber | Fraction | FractionDefinition
+    ): Fraction
     fraction(values: MathCollection): MathCollection
     /**
      * @param numerator Argument specifying the numerator of the fraction
@@ -4040,9 +4042,7 @@ declare namespace math {
       this: MathJsChain<Complex | string | PolarCoordinates>,
       im?: number
     ): MathJsChain<Complex>
-    complex(
-      this: MathJsChain<MathCollection>
-    ): MathJsChain<MathCollection>
+    complex(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
      * Create a user-defined unit and register it with the Unit type.
@@ -4081,7 +4081,12 @@ declare namespace math {
      * @param denominator Argument specifying the denominator of the
      * fraction
      */
-    fraction(this: MathJsChain<number | string | BigNumber | Fraction | FractionDefinition>, denominator?: number): MathJsChain<Fraction>
+    fraction(
+      this: MathJsChain<
+        number | string | BigNumber | Fraction | FractionDefinition
+      >,
+      denominator?: number
+    ): MathJsChain<Fraction>
     fraction(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
@@ -4554,9 +4559,15 @@ declare namespace math {
      * arrays. For matrices, the function is evaluated element wise.
      */
     gcd(this: MathJsChain<number[]>, ...args: number[]): MathJsChain<number>
-    gcd(this: MathJsChain<BigNumber[]>, ...args: BigNumber[]): MathJsChain<BigNumber>
+    gcd(
+      this: MathJsChain<BigNumber[]>,
+      ...args: BigNumber[]
+    ): MathJsChain<BigNumber>
     gcd(this: MathJsChain<Complex[]>, ...args: Fraction[]): MathJsChain<Complex>
-    gcd(this: MathJsChain<MathArray[]>, ...args: MathArray[]): MathJsChain<MathArray>
+    gcd(
+      this: MathJsChain<MathArray[]>,
+      ...args: MathArray[]
+    ): MathJsChain<MathArray>
     gcd(this: MathJsChain<Matrix[]>, ...args: Matrix[]): MathJsChain<Matrix>
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4329,11 +4329,11 @@ declare namespace math {
      * array or 1-d matrix as an input and return a number.
      * @returns The residual matrix with the function applied over some dimension.
      */
-    apply(
-      this: MathJsChain<unknown>,
+    apply<T extends MathCollection>(
+      this: MathJsChain<T>,
       dim: number,
       callback: (array: Array<MathType> | Matrix) => number
-    ): MathJsChain<unknown>
+    ): MathJsChain<T>
 
     /**
      * Calculate the cubic root of a value. For matrices, the function is

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -735,7 +735,8 @@ declare namespace math {
      * @param b A column vector with the b values
      * @returns A column vector with the linear system solution (x)
      */
-    lsolve(L: Matrix | MathArray, b: Matrix | MathArray): Matrix | MathArray
+    lsolve(L: Matrix, b: Matrix | MathArray): Matrix
+    lsolve(L: MathArray, b: Matrix | MathArray): MathArray
 
     /**
      * Calculate the Matrix LU decomposition with partial pivoting. Matrix A

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4292,7 +4292,8 @@ declare namespace math {
      * must be an upper triangular matrix. U * x = b
      * @param b A column vector with the b values
      */
-    usolve(this: MathJsChain<unknown>, b: Matrix | MathArray): MathJsChain<unknown>
+    usolve(this: MathJsChain<Matrix>, b: Matrix | MathArray): MathJsChain<Matrix>
+    usolve(this: MathJsChain<MathArray>, b: Matrix | MathArray): MathJsChain<MathArray>
 
     /*************************************************************************
      * Arithmetic functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -652,7 +652,8 @@ declare namespace math {
      * @param unit The unit to be created
      * @returns The created unit
      */
-    unit(value: number | MathCollection | BigNumber, unit: string): Unit
+    unit(value: number | BigNumber, unit: string): Unit
+    unit(value: MathCollection, unit: string): Unit[]
 
     /*************************************************************************
      * Expression functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4115,7 +4115,7 @@ declare namespace math {
      * Parse and compile an expression. Returns a an object with a function
      * evaluate([scope]) to evaluate the compiled expression.
      */
-    compile(this: MathJsChain<unknown>): MathJsChain<unknown>
+    compile(this: MathJsChain<MathExpression>): MathJsChain<EvalFunction>
 
     /**
      * Evaluate an expression.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4303,7 +4303,13 @@ declare namespace math {
      * Calculate the absolute value of a number. For matrices, the function
      * is evaluated element wise.
      */
-    abs(this: MathJsChain<unknown>): MathJsChain<unknown>
+    abs(this: MathJsChain<number>): MathJsChain<number>
+    abs(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    abs(this: MathJsChain<Fraction>): MathJsChain<Fraction>
+    abs(this: MathJsChain<Complex>): MathJsChain<Complex>
+    abs(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    abs(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    abs(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Add two values, x + y. For matrices, the function is evaluated

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4485,24 +4485,44 @@ declare namespace math {
      * @param base Optional base for the logarithm. If not provided, the
      * natural logarithm of x is calculated. Default value: e.
      */
-    log(this: MathJsChain<unknown>, base?: number | BigNumber | Complex): MathJsChain<unknown>
+    log<T extends number | BigNumber | Complex | MathCollection>(
+      this: MathJsChain<T>,
+      base?: number | BigNumber | Complex
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Calculate the 10-base of a value. This is the same as calculating
      * log(x, 10). For matrices, the function is evaluated element wise.
      */
     log10(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // log10(x: number): number
+    // log10(x: BigNumber): BigNumber
+    // log10(x: Complex): Complex
+    // log10(x: MathArray): MathArray
+    // log10(x: Matrix): Matrix
 
     /**
      * Calculate the logarithm of a value+1. For matrices, the function is
      * evaluated element wise.
      */
     log1p(this: MathJsChain<unknown>, base?: number | BigNumber | Complex): MathJsChain<unknown>
+    // log1p(x: number, base?: number | BigNumber | Complex): number
+    // log1p(x: BigNumber, base?: number | BigNumber | Complex): BigNumber
+    // log1p(x: Complex, base?: number | BigNumber | Complex): Complex
+    // log1p(x: MathArray, base?: number | BigNumber | Complex): MathArray
+    // log1p(x: Matrix, base?: number | BigNumber | Complex): Matrix
+
     /**
      * Calculate the 2-base of a value. This is the same as calculating
      * log(x, 2). For matrices, the function is evaluated element wise.
      */
     log2(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // log2(x: number): number
+    // log2(x: BigNumber): BigNumber
+    // log2(x: Complex): Complex
+    // log2(x: MathArray): MathArray
+    // log2(x: Matrix): Matrix
+
     /**
      * Calculates the modulus, the remainder of an integer division. For
      * matrices, the function is evaluated element wise. The modulus is
@@ -4511,6 +4531,10 @@ declare namespace math {
      * @param y Divisor
      */
     mod(this: MathJsChain<unknown>, y: number | BigNumber | Fraction | MathCollection): MathJsChain<unknown>
+    // mod<T extends number | BigNumber | Fraction | MathCollection>(
+    //   x: T,
+    //   y: number | BigNumber | Fraction | MathCollection
+    // ): NoLiteralType<T>
 
     /**
      * Multiply two values, x * y. The result is squeezed. For matrices, the
@@ -4518,6 +4542,10 @@ declare namespace math {
      * @param y The second value to multiply
      */
     multiply(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    // multiply<T extends Matrix | MathArray>(x: T, y: MathType): T
+    // multiply(x: Unit, y: Unit): Unit
+    // multiply(x: number, y: number): number
+    // multiply(x: MathType, y: MathType): MathType
 
     /**
      * Calculate the norm of a number, vector or matrix. The second
@@ -4527,6 +4555,10 @@ declare namespace math {
      * Frobenius norm) Default value: 2.
      */
     norm(this: MathJsChain<unknown>, p?: number | BigNumber | string): MathJsChain<unknown>
+    // norm(
+    //   x: number | BigNumber | Complex | MathCollection,
+    //   p?: number | BigNumber | string
+    // ): number | BigNumber
 
     /**
      * Calculate the nth root of a value. The principal nth root of a
@@ -4535,6 +4567,10 @@ declare namespace math {
      * @param root The root. Default value: 2.
      */
     nthRoot(this: MathJsChain<unknown>, root?: number | BigNumber): MathJsChain<unknown>
+    // nthRoot(
+    //   a: number | BigNumber | MathCollection | Complex,
+    //   root?: number | BigNumber
+    // ): number | Complex | MathCollection
 
     /**
      * Calculates the power of x to y, x ^ y. Matrix exponentiation is
@@ -4542,6 +4578,7 @@ declare namespace math {
      * @param y The exponent
      */
     pow(this: MathJsChain<unknown>, y: number | BigNumber): MathJsChain<unknown>
+    // pow(x: MathType, y: number | BigNumber | Complex): MathType
 
     /**
      * Compute the sign of a value. The sign of a value x is: 1 when x > 1
@@ -4551,25 +4588,47 @@ declare namespace math {
      * @returns The sign of x
      */
     sign(this: MathJsChain<unknown>, x: number | BigNumber): MathJsChain<unknown>
+    // sign(x: number): number
+    // sign(x: BigNumber): BigNumber
+    // sign(x: Fraction): Fraction
+    // sign(x: Complex): Complex
+    // sign(x: MathArray): MathArray
+    // sign(x: Matrix): Matrix
+    // sign(x: Unit): Unit
 
     /**
      * Calculate the square root of a value. For matrices, the function is
      * evaluated element wise.
      */
     sqrt(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // sqrt(x: number): number
+    // sqrt(x: BigNumber): BigNumber
+    // sqrt(x: Complex): Complex
+    // sqrt(x: MathArray): MathArray
+    // sqrt(x: Matrix): Matrix
+    // sqrt(x: Unit): Unit
 
     /**
      * Compute the square of a value, x * x. For matrices, the function is
      * evaluated element wise.
      */
     square(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // square(x: number): number
+    // square(x: BigNumber): BigNumber
+    // square(x: Fraction): Fraction
+    // square(x: Complex): Complex
+    // square(x: MathArray): MathArray
+    // square(x: Matrix): Matrix
+    // square(x: Unit): Unit
 
     /**
      * Subtract two values, x - y. For matrices, the function is evaluated
      * element wise.
      * @param y Value to subtract from x
      */
-    subtract(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    // subtract(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    subtract<T extends MathType>(x: T, y: T): T
+    // subtract(x: MathType, y: MathType): MathType
 
     /**
      * Inverse the sign of a value, apply a unary minus operation. For
@@ -4578,6 +4637,13 @@ declare namespace math {
      * and complex value are inverted.
      */
     unaryMinus(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // unaryMinus(x: number): number
+    // unaryMinus(x: BigNumber): BigNumber
+    // unaryMinus(x: Fraction): Fraction
+    // unaryMinus(x: Complex): Complex
+    // unaryMinus(x: MathArray): MathArray
+    // unaryMinus(x: Matrix): Matrix
+    // unaryMinus(x: Unit): Unit
 
     /**
      * Unary plus operation. Boolean values and strings will be converted to
@@ -4585,6 +4651,14 @@ declare namespace math {
      * function is evaluated element wise.
      */
     unaryPlus(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // unaryPlus(x: number): number
+    // unaryPlus(x: BigNumber): BigNumber
+    // unaryPlus(x: Fraction): Fraction
+    // unaryPlus(x: string): string
+    // unaryPlus(x: Complex): Complex
+    // unaryPlus(x: MathArray): MathArray
+    // unaryPlus(x: Matrix): Matrix
+    // unaryPlus(x: Unit): Unit
 
     /**
      * Calculate the extended greatest common divisor for two values. See
@@ -4592,6 +4666,7 @@ declare namespace math {
      * @param b An integer number
      */
     xgcd(this: MathJsChain<unknown>, b: number | BigNumber): MathJsChain<unknown>
+    // xgcd(a: number | BigNumber, b: number | BigNumber): MathArray
 
     /*************************************************************************
      * Bitwise functions
@@ -4603,6 +4678,10 @@ declare namespace math {
      * @param y Second value to and
      */
     bitAnd(this: MathJsChain<unknown>, y: number | BigNumber | MathCollection): MathJsChain<unknown>
+    // bitAnd<T extends number | BigNumber | MathCollection>(
+    //   x: T,
+    //   y: number | BigNumber | MathCollection
+    // ): NoLiteralType<T>
 
     /**
      * Bitwise NOT value, ~x. For matrices, the function is evaluated
@@ -4610,6 +4689,10 @@ declare namespace math {
      * base.
      */
     bitNot(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // bitNot(x: number): number
+    // bitNot(x: BigNumber): BigNumber
+    // bitNot(x: MathArray): MathArray
+    // bitNot(x: Matrix): Matrix
 
     /**
      * Bitwise OR two values, x | y. For matrices, the function is evaluated
@@ -4618,6 +4701,10 @@ declare namespace math {
      * @param y Second value to or
      */
     bitOr(this: MathJsChain<unknown>, y: number | BigNumber | MathCollection): MathJsChain<unknown>
+    // bitOr(x: number, y: number): number
+    // bitOr(x: BigNumber, y: BigNumber): BigNumber
+    // bitOr(x: MathArray, y: MathArray): MathArray
+    // bitOr(x: Matrix, y: Matrix): Matrix
 
     /**
      * Bitwise XOR two values, x ^ y. For matrices, the function is
@@ -4625,6 +4712,10 @@ declare namespace math {
      * @param y Second value to xor
      */
     bitXor(this: MathJsChain<unknown>, y: number | BigNumber | MathCollection): MathJsChain<unknown>
+    // bitXor<T extends number | BigNumber | MathCollection>(
+    //   x: T,
+    //   y: number | BigNumber | MathCollection
+    // ): NoLiteralType<T>
 
     /**
      * Bitwise left logical shift of a value x by y number of bits, x << y.
@@ -4633,6 +4724,10 @@ declare namespace math {
      * @param y Amount of shifts
      */
     leftShift(this: MathJsChain<unknown>, y: number | BigNumber): MathJsChain<unknown>
+    // leftShift<T extends number | BigNumber | MathCollection>(
+    //   x: T,
+    //   y: number | BigNumber
+    // ): NoLiteralType<T>
 
     /**
      * Bitwise right arithmetic shift of a value x by y number of bits, x >>
@@ -4641,6 +4736,10 @@ declare namespace math {
      * @param y Amount of shifts
      */
     rightArithShift(this: MathJsChain<unknown>, y: number | BigNumber): MathJsChain<unknown>
+    // rightArithShift<T extends number | BigNumber | MathCollection>(
+    //   x: T,
+    //   y: number | BigNumber
+    // ): NoLiteralType<T>
 
     /**
      * Bitwise right logical shift of value x by y number of bits, x >>> y.
@@ -4649,6 +4748,10 @@ declare namespace math {
      * @param y Amount of shifts
      */
     rightLogShift(this: MathJsChain<unknown>, y: number): MathJsChain<unknown>
+    // rightLogShift<T extends number | MathCollection>(
+    //   x: T,
+    //   y: number
+    // ): NoLiteralType<T>
 
     /*************************************************************************
      * Combinatorics functions
@@ -4661,6 +4764,8 @@ declare namespace math {
      * >= 0
      */
     bellNumbers(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // bellNumbers(n: number): number
+    // bellNumbers(n: BigNumber): BigNumber
 
     /**
      * The Catalan Numbers enumerate combinatorial structures of many
@@ -4668,6 +4773,8 @@ declare namespace math {
      * condition must be enforced: n >= 0
      */
     catalan(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // catalan(n: number): number
+    // catalan(n: BigNumber): BigNumber
 
     /**
      * The composition counts of n into k parts. Composition only takes
@@ -4675,6 +4782,10 @@ declare namespace math {
      * @param k Number of objects in the subset
      */
     composition(this: MathJsChain<unknown>, k: number | BigNumber): MathJsChain<unknown>
+    // composition<T extends number | BigNumber>(
+    //   n: T,
+    //   k: number | BigNumber
+    // ): NoLiteralType<T>
 
     /**
      * The Stirling numbers of the second kind, counts the number of ways to
@@ -4685,6 +4796,10 @@ declare namespace math {
      * @param k Number of objects in the subset
      */
     stirlingS2(this: MathJsChain<unknown>, k: number | BigNumber): MathJsChain<unknown>
+    // stirlingS2<T extends number | BigNumber>(
+    //   n: T,
+    //   k: number | BigNumber
+    // ): NoLiteralType<T>
 
     /*************************************************************************
      * Complex functions
@@ -4696,6 +4811,10 @@ declare namespace math {
      * is evaluated element wise.
      */
     arg(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // arg(x: number | Complex): number
+    // arg(x: BigNumber | Complex): BigNumber
+    // arg(x: MathArray): MathArray
+    // arg(x: Matrix): Matrix
 
     /**
      * Compute the complex conjugate of a complex value. If x = a+bi, the
@@ -4703,6 +4822,9 @@ declare namespace math {
      * evaluated element wise.
      */
     conj(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // conj<T extends number | BigNumber | Complex | MathCollection>(
+    //   x: T
+    // ): NoLiteralType<T>
 
     /**
      * Get the imaginary part of a complex number. For a complex number a +
@@ -4710,6 +4832,9 @@ declare namespace math {
      * element wise.
      */
     im(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // im(
+    //   x: number | BigNumber | Complex | MathCollection
+    // ): number | BigNumber | MathCollection
 
     /**
      * Get the real part of a complex number. For a complex number a + bi,
@@ -4717,6 +4842,9 @@ declare namespace math {
      * element wise.
      */
     re(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // re(
+    //   x: number | BigNumber | Complex | MathCollection
+    // ): number | BigNumber | MathCollection
 
     /*************************************************************************
      * Geometry functions
@@ -4733,6 +4861,10 @@ declare namespace math {
      * @param y Coordinates of the second point
      */
     distance(this: MathJsChain<unknown>, y: MathCollection | object): MathJsChain<unknown>
+    // distance(
+    //   x: MathCollection | object,
+    //   y: MathCollection | object
+    // ): number | BigNumber
 
     /**
      * Calculates the point of intersection of two lines in two or three
@@ -4753,6 +4885,12 @@ declare namespace math {
       y: MathCollection,
       z: MathCollection
     ): MathJsChain<unknown>
+    // intersect(
+    //   w: MathCollection,
+    //   x: MathCollection,
+    //   y: MathCollection,
+    //   z: MathCollection
+    // ): MathArray
 
     /*************************************************************************
      * Logical functions
@@ -4765,12 +4903,19 @@ declare namespace math {
      * @param y Second value to and
      */
     and(this: MathJsChain<unknown>, y: number | BigNumber | Complex | Unit | MathCollection): MathJsChain<unknown>
+    // and(
+    //   x: number | BigNumber | Complex | Unit | MathCollection,
+    //   y: number | BigNumber | Complex | Unit | MathCollection
+    // ): boolean | MathCollection
 
     /**
      * Logical not. Flips boolean value of a given parameter. For matrices,
      * the function is evaluated element wise.
      */
     not(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // not(
+    //   x: number | BigNumber | Complex | Unit | MathCollection
+    // ): boolean | MathCollection
 
     /**
      * Logical or. Test if at least one value is defined with a
@@ -4779,6 +4924,10 @@ declare namespace math {
      * @param y Second value to or
      */
     or(this: MathJsChain<unknown>, y: number | BigNumber | Complex | Unit | MathCollection): MathJsChain<unknown>
+    // or(
+    //   x: number | BigNumber | Complex | Unit | MathCollection,
+    //   y: number | BigNumber | Complex | Unit | MathCollection
+    // ): boolean | MathCollection
 
     /**
      * Logical xor. Test whether one and only one value is defined with a
@@ -4787,6 +4936,10 @@ declare namespace math {
      * @param y Second value to xor
      */
     xor(this: MathJsChain<unknown>, y: number | BigNumber | Complex | Unit | MathCollection): MathJsChain<unknown>
+    // xor(
+    //   x: number | BigNumber | Complex | Unit | MathCollection,
+    //   y: number | BigNumber | Complex | Unit | MathCollection
+    // ): boolean | MathCollection
 
     /*************************************************************************
      * Matrix functions
@@ -4798,6 +4951,7 @@ declare namespace math {
      * dimension of the matrices.
      */
     concat(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // concat(...args: Array<MathCollection | number | BigNumber>): MathCollection
 
     /**
      * Calculate the cross product for two vectors in three dimensional
@@ -4807,11 +4961,13 @@ declare namespace math {
      * @param y Second vector
      */
     cross(this: MathJsChain<unknown>, y: MathCollection): MathJsChain<unknown>
+    // cross(x: MathCollection, y: MathCollection): Matrix | MathArray
 
     /**
      * Calculate the determinant of a matrix.
      */
     det(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // det(x: MathCollection): number
 
     /**
      * Create a diagonal matrix or retrieve the diagonal of a matrix. When x
@@ -4827,6 +4983,13 @@ declare namespace math {
     diag(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
     diag(this: MathJsChain<unknown>, k: number | BigNumber, format?: string): MathJsChain<unknown>
 
+    // diag(X: MathCollection, format?: string): Matrix
+    // diag(
+    //   X: MathCollection,
+    //   k: number | BigNumber,
+    //   format?: string
+    // ): Matrix | MathArray
+
     /**
      * Calculate the dot product of two vectors. The dot product of A = [a1,
      * a2, a3, ..., an] and B = [b1, b2, b3, ..., bn] is defined as: dot(A,
@@ -4834,6 +4997,7 @@ declare namespace math {
      * @param y Second vector
      */
     dot(this: MathJsChain<unknown>, y: MathCollection): MathJsChain<unknown>
+    // dot(x: MathCollection, y: MathCollection): number
 
     /**
      * Compute the matrix exponential, expm(A) = e^A. The matrix must be
@@ -4843,6 +5007,7 @@ declare namespace math {
      * Compute the Exponential of a Matrix,” by Moler and Van Loan.
      */
     expm(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // expm(x: Matrix): Matrix
 
     /**
      * Create a 2-dimensional identity matrix with size m x n or n x n. The
@@ -4850,11 +5015,17 @@ declare namespace math {
      * @param format The Matrix storage format
      */
     identity(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
+    // identity(
+    //   size: number | number[] | Matrix | MathArray,
+    //   format?: string
+    // ): Matrix | MathArray | number
+
     /**
      * @param n The y dimension for the matrix
      * @param format The Matrix storage format
      */
     identity(this: MathJsChain<unknown>, n: number, format?: string): MathJsChain<unknown>
+    // identity(m: number, n: number, format?: string): Matrix | MathArray | number
 
     /**
      * Filter the items in an array or one dimensional matrix.
@@ -4864,11 +5035,24 @@ declare namespace math {
       test: // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ((value: any, index: any, matrix: Matrix | MathArray) => boolean) | RegExp
     ): MathJsChain<unknown>
+    // filter(
+    //   x: Matrix | MathArray | string[],
+    //   test:
+    //     | ((
+    //         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //         value: any,
+    //         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //         index: any,
+    //         matrix: Matrix | MathArray | string[]
+    //       ) => boolean)
+    //     | RegExp
+    // ): Matrix | MathArray
 
     /**
      * Flatten a multi dimensional matrix into a single dimensional matrix.
      */
     flatten(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // flatten<T extends MathCollection>(x: T): T
 
     /**
      * Iterate over all elements of a matrix/array, and executes the given
@@ -4879,17 +5063,24 @@ declare namespace math {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       callback: (value: any, index: any, matrix: Matrix | MathArray) => void
     ): MathJsChain<unknown>
+    // forEach<T extends Matrix | MathArray>(
+    //   x: T,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   callback: (value: any, index: any, matrix: T) => void
+    // ): void
 
     /**
      * Calculate the inverse of a square matrix.
      */
     inv(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // inv<T extends number | Complex | MathCollection>(x: T): NoLiteralType<T>
 
     /**
      * Calculate the kronecker product of two matrices or vectors
      * @param y Second vector
      */
     kron(this: MathJsChain<unknown>, y: Matrix | MathArray): MathJsChain<unknown>
+    // kron(x: Matrix | MathArray, y: Matrix | MathArray): Matrix
 
     /**
      * Iterate over all elements of a matrix/array, and executes the given
@@ -4908,6 +5099,11 @@ declare namespace math {
         matrix: Matrix | MathArray
       ) => Matrix | MathArray
     ): MathJsChain<unknown>
+    // map<T extends Matrix | MathArray>(
+    //   x: T,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   callback: (value: any, index: any, matrix: T) => MathType | string
+    // ): T
 
     /**
      * Create a matrix filled with ones. The created matrix can have one or
@@ -4915,10 +5111,14 @@ declare namespace math {
      * @param format The matrix storage format
      */
     ones(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
+    // ones(size: number | number[], format?: string): MathCollection
+
     /**
      * @param format The matrix storage format
      */
     ones(this: MathJsChain<unknown>, n: number, format?: string): MathJsChain<unknown>
+    // ones(m: number, n: number, format?: string): MathCollection
+
     /**
      * Partition-based selection of an array or 1D matrix. Will find the kth
      * smallest value, and mutates the input array. Uses Quickselect.
@@ -4933,6 +5133,13 @@ declare namespace math {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compare?: 'asc' | 'desc' | ((a: any, b: any) => number)
     ): MathJsChain<unknown>
+    // partitionSelect(
+    //   x: MathCollection,
+    //   k: number,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   compare?: 'asc' | 'desc' | ((a: any, b: any) => number)
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // ): any
 
     /**
      * Create an array from a range. By default, the range end is excluded.
@@ -4952,12 +5159,26 @@ declare namespace math {
       includeEnd?: boolean
     ): MathJsChain<unknown>
 
+    // range(str: string, includeEnd?: boolean): Matrix
+    // range(
+    //   start: number | BigNumber,
+    //   end: number | BigNumber,
+    //   includeEnd?: boolean
+    // ): Matrix
+    // range(
+    //   start: number | BigNumber,
+    //   end: number | BigNumber,
+    //   step: number | BigNumber,
+    //   includeEnd?: boolean
+    // ): Matrix
+
     /**
      * Reshape a multi dimensional array to fit the specified dimensions
      * @param sizes One dimensional array with integral sizes for each
      * dimension
      */
     reshape(this: MathJsChain<unknown>, sizes: number[]): MathJsChain<unknown>
+    // reshape<T extends MathCollection>(x: T, sizes: number[]): T
 
     /**
      * Resize a matrix
@@ -4966,11 +5187,19 @@ declare namespace math {
      * that case defaultValue = ' ' Default value: 0.
      */
     resize(this: MathJsChain<unknown>, size: MathCollection, defaultValue?: number | string): MathJsChain<unknown>
+    // resize<T extends MathCollection>(
+    //   x: T,
+    //   size: MathCollection,
+    //   defaultValue?: number | string
+    // ): T
 
     /**
      * Calculate the size of a matrix or scalar.
      */
     size(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // size(
+    //   x: boolean | number | Complex | Unit | string | MathCollection
+    // ): MathCollection
 
     /**
      * Sort the items in a matrix
@@ -4984,17 +5213,25 @@ declare namespace math {
       compare: ((a: any, b: any) => number) | 'asc' | 'desc' | 'natural'
     ): MathJsChain<unknown>
 
+    // sort<T extends Matrix | MathArray>(
+    //   x: T,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   compare: ((a: any, b: any) => number) | 'asc' | 'desc' | 'natural'
+    // ): T
+
     /**
      * Calculate the principal square root of a square matrix. The principal
      * square root matrix X of another matrix A is such that X * X = A.
      */
     sqrtm(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // sqrtm<T extends MathCollection>(A: T): T
 
     /**
      * Squeeze a matrix, remove inner and outer singleton dimensions from a
      * matrix.
      */
     squeeze(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // squeeze<T extends MathCollection>(x: T): T
 
     /**
      * Get or set a subset of a matrix or string.
@@ -5008,18 +5245,28 @@ declare namespace math {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subset(this: MathJsChain<unknown>, index: Index, replacement?: any, defaultValue?: any): MathJsChain<unknown>
+    // subset<T extends MathCollection | string>(
+    //   value: T,
+    //   index: Index,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   replacement?: any,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   defaultValue?: any
+    // ): T
 
     /**
      * Calculate the trace of a matrix: the sum of the elements on the main
      * diagonal of a square matrix.
      */
     trace(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // trace(x: MathCollection): number
 
     /**
      * Transpose a matrix. All values of the matrix are reflected over its
      * main diagonal. Only two dimensional matrices are supported.
      */
     transpose(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // transpose<T extends MathCollection>(x: T): T
 
     /**
      * Create a matrix filled with zeros. The created matrix can have one or
@@ -5028,11 +5275,14 @@ declare namespace math {
      * @returns A matrix filled with zeros
      */
     zeros(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
+    // zeros(size: number | number[], format?: string): MathCollection
+
     /**
      * @param n The y dimension of the matrix
      * @param format The matrix storage format
      */
     zeros(this: MathJsChain<unknown>, n: number, format?: string): MathJsChain<unknown>
+    // zeros(m: number, n: number, format?: string): MathCollection
 
     /*************************************************************************
      * Probability functions
@@ -5045,6 +5295,10 @@ declare namespace math {
      * @param k Number of objects in the subset
      */
     combinations(this: MathJsChain<unknown>, k: number | BigNumber): MathJsChain<unknown>
+    // combinations<T extends number | BigNumber>(
+    //   n: T,
+    //   k: number | BigNumber
+    // ): NoLiteralType<T>
 
     /**
      * Compute the factorial of a value Factorial only supports an integer
@@ -5052,6 +5306,9 @@ declare namespace math {
      * wise.
      */
     factorial(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // factorial<T extends number | BigNumber | MathCollection>(
+    //   n: T
+    // ): NoLiteralType<T>
 
     /**
      * Compute the gamma function of a value using Lanczos approximation for
@@ -5059,6 +5316,9 @@ declare namespace math {
      * values. For matrices, the function is evaluated element wise.
      */
     gamma(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // gamma<T extends number | BigNumber | Complex | MathCollection>(
+    //   n: T
+    // ): NoLiteralType<T>
 
     /**
      * Calculate the Kullback-Leibler (KL) divergence between two
@@ -5066,6 +5326,7 @@ declare namespace math {
      * @param p Second vector
      */
     kldivergence(this: MathJsChain<unknown>, p: MathCollection): MathJsChain<unknown>
+    // kldivergence(q: MathCollection, p: MathCollection): number
 
     /**
      * Multinomial Coefficients compute the number of ways of picking a1,
@@ -5074,6 +5335,7 @@ declare namespace math {
      * must be enforced: every ai <= 0
      */
     multinomial(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // multinomial<T extends number | BigNumber>(a: T[]): NoLiteralType<T>
 
     /**
      * Compute the number of ways of obtaining an ordered subset of k
@@ -5082,6 +5344,10 @@ declare namespace math {
      * @param k The number of objects in the subset
      */
     permutations(this: MathJsChain<unknown>, k?: number | BigNumber): MathJsChain<unknown>
+    // permutations<T extends number | BigNumber>(
+    //   n: T,
+    //   k?: number | BigNumber
+    // ): NoLiteralType<T>
 
     /**
      * Random pick a value from a one dimensional array. Array element is
@@ -5090,6 +5356,11 @@ declare namespace math {
      * @param weights An array of ints or floats
      */
     pickRandom(this: MathJsChain<unknown>, number?: number, weights?: number[]): MathJsChain<unknown>
+    // pickRandom(
+    //   array: number[],
+    //   number?: number,
+    //   weights?: number[]
+    // ): number | number[]
 
     /**
      * Return a random number larger or equal to min and smaller than max
@@ -5098,8 +5369,11 @@ declare namespace math {
      * @param max Maximum boundary for the random value, excluded
      */
     random(this: MathJsChain<unknown>, max?: number): MathJsChain<unknown>
+    // random(min?: number, max?: number): number
+
     // tslint:disable-next-line unified-signatures
     random(this: MathJsChain<unknown>, min: number, max: number): MathJsChain<unknown>
+    // random<T extends MathCollection>(size: T, min?: number, max?: number): T
 
     /**
      * Return a random integer number larger or equal to min and smaller
@@ -5108,8 +5382,10 @@ declare namespace math {
      * @param max Maximum boundary for the random value, excluded
      */
     randomInt(this: MathJsChain<unknown>, max?: number): MathJsChain<unknown>
+    // randomInt(min: number, max?: number): number
     // tslint:disable-next-line unified-signatures
     randomInt(this: MathJsChain<unknown>, min: number, max: number): MathJsChain<unknown>
+    // randomInt<T extends MathCollection>(size: T, min?: number, max?: number): T
 
     /*************************************************************************
      * Relational functions
@@ -5124,6 +5400,10 @@ declare namespace math {
      * @param y Second value to compare
      */
     compare(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // compare(
+    //   x: MathType | string,
+    //   y: MathType | string
+    // ): number | BigNumber | Fraction | MathCollection
 
     /**
      * Compare two values of any type in a deterministic, natural way. For
@@ -5134,6 +5414,7 @@ declare namespace math {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     compareNatural(this: MathJsChain<unknown>, y: any): MathJsChain<unknown>
+    // compareNatural(x: any, y: any): number
 
     /**
      * Compare two strings lexically. Comparison is case sensitive. Returns
@@ -5142,6 +5423,10 @@ declare namespace math {
      * @param y Second string to compare
      */
     compareText(this: MathJsChain<unknown>, y: string | MathCollection): MathJsChain<unknown>
+    // compareText(
+    //   x: string | MathCollection,
+    //   y: string | MathCollection
+    // ): number | MathCollection
 
     /**
      * Test element wise whether two matrices are equal. The function
@@ -5149,6 +5434,10 @@ declare namespace math {
      * @param y Second amtrix to compare
      */
     deepEqual(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    // deepEqual(
+    //   x: MathType,
+    //   y: MathType
+    // ): number | BigNumber | Fraction | Complex | Unit | MathCollection
 
     /**
      * Test whether two values are equal.
@@ -5163,6 +5452,7 @@ declare namespace math {
      * @param y Second value to compare
      */
     equal(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // equal(x: MathType | string, y: MathType | string): boolean | MathCollection
 
     /**
      * Check equality of two strings. Comparison is case sensitive. For
@@ -5170,6 +5460,10 @@ declare namespace math {
      * @param y Second string to compare
      */
     equalText(this: MathJsChain<unknown>, y: string | MathCollection): MathJsChain<unknown>
+    // equalText(
+    //   x: string | MathCollection,
+    //   y: string | MathCollection
+    // ): number | MathCollection
 
     /**
      * Test whether value x is larger than y. The function returns true when
@@ -5180,6 +5474,7 @@ declare namespace math {
      * @param y Second value to compare
      */
     larger(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // larger(x: MathType | string, y: MathType | string): boolean | MathCollection
 
     /**
      * Test whether value x is larger or equal to y. The function returns
@@ -5190,6 +5485,10 @@ declare namespace math {
      * @param y Second value to vcompare
      */
     largerEq(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // largerEq(
+    //   x: MathType | string,
+    //   y: MathType | string
+    // ): boolean | MathCollection
 
     /**
      * Test whether value x is smaller than y. The function returns true
@@ -5200,6 +5499,10 @@ declare namespace math {
      * @param y Second value to vcompare
      */
     smaller(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // smaller(
+    //   x: MathType | string,
+    //   y: MathType | string
+    // ): boolean | MathCollection
 
     /**
      * Test whether value x is smaller or equal to y. The function returns
@@ -5210,6 +5513,10 @@ declare namespace math {
      * @param y Second value to compare
      */
     smallerEq(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // smallerEq(
+    //   x: MathType | string,
+    //   y: MathType | string
+    // ): boolean | MathCollection
 
     /**
      * Test whether two values are unequal. The function tests whether the
@@ -5223,6 +5530,10 @@ declare namespace math {
      * @param y Second value to vcompare
      */
     unequal(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
+    // unequal(
+    //   x: MathType | string,
+    //   y: MathType | string
+    // ): boolean | MathCollection
 
     /*************************************************************************
      * Set functions
@@ -5235,6 +5546,7 @@ declare namespace math {
      * @param a2 A (multi)set
      */
     setCartesian(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
+    // setCartesian<T extends MathCollection>(a1: T, a2: MathCollection): T
 
     /**
      * Create the difference of two (multi)sets: every element of set1, that
@@ -5243,12 +5555,14 @@ declare namespace math {
      * @param a2 A (multi)set
      */
     setDifference(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
+    // setDifference<T extends MathCollection>(a1: T, a2: MathCollection): T
 
     /**
      * Collect the distinct elements of a multiset. A multi-dimension array
      * will be converted to a single-dimension array before the operation.
      */
     setDistinct(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // setDistinct<T extends MathCollection>(a: T): T
 
     /**
      * Create the intersection of two (multi)sets. Multi-dimension arrays
@@ -5256,6 +5570,7 @@ declare namespace math {
      * @param a2 A (multi)set
      */
     setIntersect(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
+    // setIntersect<T extends MathCollection>(a1: T, a2: MathCollection): T
 
     /**
      * Check whether a (multi)set is a subset of another (multi)set. (Every
@@ -5264,6 +5579,7 @@ declare namespace math {
      * @param a2 A (multi)set
      */
     setIsSubset(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
+    // setIsSubset(a1: MathCollection, a2: MathCollection): boolean
 
     /**
      * Count the multiplicity of an element in a multiset. A multi-dimension
@@ -5272,6 +5588,10 @@ declare namespace math {
      * @param a A multiset
      */
     setMultiplicity(this: MathJsChain<unknown>, a: MathCollection): MathJsChain<unknown>
+    // setMultiplicity(
+    //   e: number | BigNumber | Fraction | Complex,
+    //   a: MathCollection
+    // ): number
 
     /**
      * Create the powerset of a (multi)set. (The powerset contains very
@@ -5279,6 +5599,7 @@ declare namespace math {
      * converted to a single-dimension array before the operation.
      */
     setPowerset(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // setPowerset<T extends MathCollection>(a: T): T
 
     /**
      * Count the number of elements of a (multi)set. When a second parameter
@@ -5286,6 +5607,7 @@ declare namespace math {
      * be converted to a single-dimension array before the operation.
      */
     setSize(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // setSize(a: MathCollection): number
 
     /**
      * Create the symmetric difference of two (multi)sets. Multi-dimension
@@ -5294,6 +5616,7 @@ declare namespace math {
      * @param a2 A (multi)set
      */
     setSymDifference(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
+    // setSymDifference<T extends MathCollection>(a1: T, a2: MathCollection): T
 
     /**
      * Create the union of two (multi)sets. Multi-dimension arrays will be
@@ -5301,6 +5624,7 @@ declare namespace math {
      * @param a2 A (multi)set
      */
     setUnion(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
+    // setUnion<T extends MathCollection>(a1: T, a2: MathCollection): T
 
     /*************************************************************************
      * Special functions
@@ -5311,6 +5635,7 @@ declare namespace math {
      * approximations for different intervals of x.
      */
     erf(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // erf<T extends number | MathCollection>(x: T): NoLiteralType<T>
 
     /*************************************************************************
      * Statistics functions
@@ -5322,6 +5647,7 @@ declare namespace math {
      * absolute deviations from the median.
      */
     mad(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // mad(array: MathCollection): any
 
     /**
      * Compute the maximum value of a matrix or a list with values. In case
@@ -5331,6 +5657,8 @@ declare namespace math {
      * @param dim The maximum over the selected dimension
      */
     max(this: MathJsChain<unknown>, dim?: number): MathJsChain<unknown>
+    // max(...args: MathType[]): any
+    // max(A: MathCollection, dim?: number): any
 
     /**
      * Compute the mean value of matrix or a list with values. In case of a
@@ -5340,6 +5668,8 @@ declare namespace math {
      * @param dim The mean over the selected dimension
      */
     mean(this: MathJsChain<unknown>, dim?: number): MathJsChain<unknown>
+    // mean(...args: MathType[]): any
+    // mean(A: MathCollection, dim?: number): any
 
     /**
      * Compute the median of a matrix or a list with values. The values are
@@ -5350,6 +5680,7 @@ declare namespace math {
      * calculated.
      */
     median(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // median(...args: MathType[]): any
 
     /**
      * Compute the maximum value of a matrix or a list of values. In case of
@@ -5359,6 +5690,8 @@ declare namespace math {
      * @param dim The minimum over the selected dimension
      */
     min(this: MathJsChain<unknown>, dim?: number): MathJsChain<unknown>
+    // min(...args: MathType[]): any
+    // min(A: MathCollection, dim?: number): any
 
     /**
      * Computes the mode of a set of numbers or a list with values(numbers
@@ -5366,6 +5699,7 @@ declare namespace math {
      * of those values.
      */
     mode(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // mode(...args: MathType[]): any
 
     /**
      * Compute the product of a matrix or a list with values. In case of a
@@ -5373,6 +5707,7 @@ declare namespace math {
      * calculated.
      */
     prod(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // prod(...args: MathType[]): any
 
     /**
      * Compute the prob order quantile of a matrix or a list with values.
@@ -5391,6 +5726,12 @@ declare namespace math {
       prob: number | BigNumber | MathArray,
       sorted?: boolean
     ): MathJsChain<unknown>
+    // quantileSeq(
+    //   A: MathCollection,
+    //   prob: number | BigNumber | MathArray,
+    //   sorted?: boolean
+    // ): number | BigNumber | Unit | MathArray
+
     /**
      * Compute the standard deviation of a matrix or a list with values. The
      * standard deviations is defined as the square root of the variance:
@@ -5412,6 +5753,8 @@ declare namespace math {
       dim?: number,
       normalization?: 'unbiased' | 'uncorrected' | 'biased'
     ): MathJsChain<unknown>
+    // std(...values: number[]): number
+
     /**
      * Compute the standard deviation of a matrix or a list with values. The
      * standard deviations is defined as the square root of the variance:
@@ -5428,6 +5771,11 @@ declare namespace math {
      * @returns The standard deviation
      */
     std(this: MathJsChain<unknown>, normalization: 'unbiased' | 'uncorrected' | 'biased'): MathJsChain<unknown>
+    // std(
+    //   array: MathCollection,
+    //   dimension?: number,
+    //   normalization?: 'unbiased' | 'uncorrected' | 'biased'
+    // ): number[]
 
     /**
      * Compute the sum of a matrix or a list with values. In case of a
@@ -5435,6 +5783,11 @@ declare namespace math {
      * calculated.
      */
     sum(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // std(
+    //   array: MathCollection,
+    //   normalization: 'unbiased' | 'uncorrected' | 'biased'
+    // ): number
+
     /**
      * Compute the variance of a matrix or a list with values. In case of a
      * (multi dimensional) array or matrix, the variance over all elements
@@ -5457,6 +5810,8 @@ declare namespace math {
       dim?: number,
       normalization?: 'unbiased' | 'uncorrected' | 'biased'
     ): MathJsChain<unknown>
+    // variance(...args: Array<number | BigNumber | Fraction>): number
+
     /**
      * Compute the variance of a matrix or a list with values. In case of a
      * (multi dimensional) array or matrix, the variance over all elements
@@ -5474,6 +5829,11 @@ declare namespace math {
      * @returns The variance
      */
     variance(this: MathJsChain<unknown>, normalization: 'unbiased' | 'uncorrected' | 'biased'): MathJsChain<unknown>
+    // variance(
+    //   array: MathCollection,
+    //   dimension?: number,
+    //   normalization?: 'unbiased' | 'uncorrected' | 'biased'
+    // ): number[]
 
     /*************************************************************************
      * String functions
@@ -5499,6 +5859,14 @@ declare namespace math {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       callback?: (value: any) => string
     ): MathJsChain<unknown>
+    // format(
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   value: any,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   options?: FormatOptions | number | ((item: any) => string),
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   callback?: (value: any) => string
+    // ): string
 
     /**
      * Interpolate values into a string template.
@@ -5516,6 +5884,13 @@ declare namespace math {
       precision?: number,
       options?: number | object
     ): MathJsChain<unknown>
+    // print(
+    //   template: string,
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   values: any,
+    //   precision?: number,
+    //   options?: number | object
+    // ): void
 
     /*************************************************************************
      * Trigonometry functions
@@ -5526,6 +5901,11 @@ declare namespace math {
      * is evaluated element wise.
      */
     acos(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // acos(x: number): number
+    // acos(x: BigNumber): BigNumber
+    // acos(x: Complex): Complex
+    // acos(x: MathArray): MathArray
+    // acos(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic arccos of a value, defined as acosh(x) =
@@ -5533,12 +5913,21 @@ declare namespace math {
      * element wise.
      */
     acosh(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // acosh(x: number): number
+    // acosh(x: BigNumber): BigNumber
+    // acosh(x: Complex): Complex
+    // acosh(x: MathArray): MathArray
+    // acosh(x: Matrix): Matrix
 
     /**
      * Calculate the inverse cotangent of a value. For matrices, the
      * function is evaluated element wise.
      */
     acot(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // acot(x: number): number
+    // acot(x: BigNumber): BigNumber
+    // acot(x: MathArray): MathArray
+    // acot(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic arccotangent of a value, defined as acoth(x)
@@ -5546,12 +5935,20 @@ declare namespace math {
      * evaluated element wise.
      */
     acoth(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // acoth(x: number): number
+    // acoth(x: BigNumber): BigNumber
+    // acoth(x: MathArray): MathArray
+    // acoth(x: Matrix): Matrix
 
     /**
      * Calculate the inverse cosecant of a value. For matrices, the function
      * is evaluated element wise.
      */
     acsc(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // acsc(x: number): number
+    // acsc(x: BigNumber): BigNumber
+    // acsc(x: MathArray): MathArray
+    // acsc(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic arccosecant of a value, defined as acsch(x)
@@ -5559,12 +5956,20 @@ declare namespace math {
      * element wise.
      */
     acsch(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // acsch(x: number): number
+    // acsch(x: BigNumber): BigNumber
+    // acsch(x: MathArray): MathArray
+    // acsch(x: Matrix): Matrix
 
     /**
      * Calculate the inverse secant of a value. For matrices, the function
      * is evaluated element wise.
      */
     asec(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // asec(x: number): number
+    // asec(x: BigNumber): BigNumber
+    // asec(x: MathArray): MathArray
+    // asec(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic arcsecant of a value, defined as asech(x) =
@@ -5572,12 +5977,21 @@ declare namespace math {
      * element wise.
      */
     asech(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // asech(x: number): number
+    // asech(x: BigNumber): BigNumber
+    // asech(x: MathArray): MathArray
+    // asech(x: Matrix): Matrix
 
     /**
      * Calculate the inverse sine of a value. For matrices, the function is
      * evaluated element wise.
      */
     asin(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // asin(x: number): number
+    // asin(x: BigNumber): BigNumber
+    // asin(x: Complex): Complex
+    // asin(x: MathArray): MathArray
+    // asin(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic arcsine of a value, defined as asinh(x) =
@@ -5585,12 +5999,20 @@ declare namespace math {
      * element wise.
      */
     asinh(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // asinh(x: number): number
+    // asinh(x: BigNumber): BigNumber
+    // asinh(x: MathArray): MathArray
+    // asinh(x: Matrix): Matrix
 
     /**
      * Calculate the inverse tangent of a value. For matrices, the function
      * is evaluated element wise.
      */
     atan(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // atan(x: number): number
+    // atan(x: BigNumber): BigNumber
+    // atan(x: MathArray): MathArray
+    // atan(x: Matrix): Matrix
 
     /**
      * Calculate the inverse tangent function with two arguments, y/x. By
@@ -5598,6 +6020,8 @@ declare namespace math {
      * be determined. For matrices, the function is evaluated element wise.
      */
     atan2(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // atan2(y: number, x: number): number
+    // atan2(y: MathCollection, x: MathCollection): MathCollection
 
     /**
      * Calculate the hyperbolic arctangent of a value, defined as atanh(x) =
@@ -5605,12 +6029,21 @@ declare namespace math {
      * element wise.
      */
     atanh(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // atanh(x: number): number
+    // atanh(x: BigNumber): BigNumber
+    // atanh(x: MathArray): MathArray
+    // atanh(x: Matrix): Matrix
 
     /**
      * Calculate the cosine of a value. For matrices, the function is
      * evaluated element wise.
      */
     cos(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // cos(x: number | Unit): number
+    // cos(x: BigNumber): BigNumber
+    // cos(x: Complex): Complex
+    // cos(x: MathArray): MathArray
+    // cos(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic cosine of a value, defined as cosh(x) = 1/2
@@ -5618,48 +6051,82 @@ declare namespace math {
      * wise.
      */
     cosh(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // cosh(x: number | Unit): number
+    // cosh(x: BigNumber): BigNumber
+    // cosh(x: Complex): Complex
+    // cosh(x: MathArray): MathArray
+    // cosh(x: Matrix): Matrix
 
     /**
      * Calculate the cotangent of a value. cot(x) is defined as 1 / tan(x).
      * For matrices, the function is evaluated element wise.
      */
     cot(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // cot(x: number | Unit): number
+    // cot(x: Complex): Complex
+    // cot(x: MathArray): MathArray
+    // cot(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic cotangent of a value, defined as coth(x) = 1
      * / tanh(x). For matrices, the function is evaluated element wise.
      */
     coth(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // coth(x: number | Unit): number
+    // coth(x: Complex): Complex
+    // coth(x: MathArray): MathArray
+    // coth(x: Matrix): Matrix
 
     /**
      * Calculate the cosecant of a value, defined as csc(x) = 1/sin(x). For
      * matrices, the function is evaluated element wise.
      */
     csc(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // csc(x: number | Unit): number
+    // csc(x: Complex): Complex
+    // csc(x: MathArray): MathArray
+    // csc(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic cosecant of a value, defined as csch(x) = 1
      * / sinh(x). For matrices, the function is evaluated element wise.
      */
     csch(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // csch(x: number | Unit): number
+    // csch(x: Complex): Complex
+    // csch(x: MathArray): MathArray
+    // csch(x: Matrix): Matrix
 
     /**
      * Calculate the secant of a value, defined as sec(x) = 1/cos(x). For
      * matrices, the function is evaluated element wise.
      */
     sec(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // sec(x: number | Unit): number
+    // sec(x: Complex): Complex
+    // sec(x: MathArray): MathArray
+    // sec(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic secant of a value, defined as sech(x) = 1 /
      * cosh(x). For matrices, the function is evaluated element wise.
      */
     sech(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // sech(x: number | Unit): number
+    // sech(x: Complex): Complex
+    // sech(x: MathArray): MathArray
+    // sech(x: Matrix): Matrix
 
     /**
      * Calculate the sine of a value. For matrices, the function is
      * evaluated element wise.
      */
     sin(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // sin(x: number | Unit): number
+    // sin(x: BigNumber): BigNumber
+    // sin(x: Complex): Complex
+    // sin(x: MathArray): MathArray
+    // sin(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic sine of a value, defined as sinh(x) = 1/2 *
@@ -5667,12 +6134,22 @@ declare namespace math {
      * wise.
      */
     sinh(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // sinh(x: number | Unit): number
+    // sinh(x: BigNumber): BigNumber
+    // sinh(x: Complex): Complex
+    // sinh(x: MathArray): MathArray
+    // sinh(x: Matrix): Matrix
 
     /**
      * Calculate the tangent of a value. tan(x) is equal to sin(x) / cos(x).
      * For matrices, the function is evaluated element wise.
      */
     tan(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // tan(x: number | Unit): number
+    // tan(x: BigNumber): BigNumber
+    // tan(x: Complex): Complex
+    // tan(x: MathArray): MathArray
+    // tan(x: Matrix): Matrix
 
     /**
      * Calculate the hyperbolic tangent of a value, defined as tanh(x) =
@@ -5680,6 +6157,11 @@ declare namespace math {
      * evaluated element wise.
      */
     tanh(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // tanh(x: number | Unit): number
+    // tanh(x: BigNumber): BigNumber
+    // tanh(x: Complex): Complex
+    // tanh(x: MathArray): MathArray
+    // tanh(x: Matrix): Matrix
 
     /*************************************************************************
      * Unit functions
@@ -5692,6 +6174,7 @@ declare namespace math {
      * value.
      */
     to(this: MathJsChain<unknown>, unit: Unit | string): MathJsChain<unknown>
+    // to(x: Unit | MathCollection, unit: Unit | string): Unit | MathCollection
 
     /*************************************************************************
      * Utils functions
@@ -5701,6 +6184,7 @@ declare namespace math {
      * Clone an object.
      */
     clone(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // clone(x: any): any
 
     /**
      * Test whether a value is an integer number. The function supports
@@ -5708,6 +6192,7 @@ declare namespace math {
      * element-wise in case of Array or Matrix input.
      */
     isInteger(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isInteger(x: number | BigNumber | Fraction | MathCollection): boolean
 
     /**
      * Test whether a value is NaN (not a number). The function supports
@@ -5715,6 +6200,7 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
     isNaN(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isNaN(x: number | BigNumber | Fraction | MathCollection | Unit): boolean
 
     /**
      * Test whether a value is negative: smaller than zero. The function
@@ -5722,12 +6208,16 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
     isNegative(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isNegative(
+    //   x: number | BigNumber | Fraction | MathCollection | Unit
+    // ): boolean
 
     /**
      * Test whether a value is an numeric value. The function is evaluated
      * element-wise in case of Array or Matrix input.
      */
     isNumeric(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isNumeric(x: any): x is number | BigNumber | Fraction | boolean
 
     /**
      * Test whether a value is positive: larger than zero. The function
@@ -5735,6 +6225,9 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
     isPositive(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isPositive(
+    //   x: number | BigNumber | Fraction | MathCollection | Unit
+    // ): boolean
 
     /**
      * Test whether a value is prime: has no divisors other than itself and
@@ -5742,6 +6235,7 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
     isPrime(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isPrime(x: number | BigNumber | MathCollection): boolean
 
     /**
      * Test whether a value is zero. The function can check for zero for
@@ -5749,11 +6243,15 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
     isZero(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // isZero(
+    //   x: number | BigNumber | Fraction | MathCollection | Unit | Complex
+    // ): boolean
 
     /**
      * Determine the type of a variable.
      */
     typeOf(this: MathJsChain<unknown>): MathJsChain<unknown>
+    // typeOf(x: any): string
   }
 
   interface ImportOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4250,7 +4250,7 @@ declare namespace math {
      * @param detailed  optional True if return an object, false if return
      * expression node (default)
      */
-    rationalize(this: MathJsChain<unknown>, optional?: object | boolean, detailed?: boolean): MathJsChain<unknown>
+    rationalize(this: MathJsChain<MathNode | string>, optional?: object | boolean, detailed?: boolean): MathJsChain<MathNode>
 
     /**
      * Simplify an expression tree.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -359,6 +359,10 @@ declare namespace math {
     p: number[]
   }
 
+  interface SLUDecomposition extends LUDecomposition {
+    q: number[]
+  }
+
   interface QRDecomposition {
     Q: MathCollection
     R: MathCollection
@@ -865,7 +869,7 @@ declare namespace math {
      * @returns The lower triangular matrix, the upper triangular matrix and
      * the permutation vectors.
      */
-    slu(A: Matrix, order: number, threshold: number): object
+    slu(A: Matrix, order: number, threshold: number): SLUDecomposition
 
     /**
      * Solves the linear equation system by backward substitution. Matrix

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -602,14 +602,7 @@ declare namespace math {
      * @returns The created number
      */
     number(
-      value?:
-        | string
-        | number
-        | BigNumber
-        | Fraction
-        | boolean
-        | Unit
-        | null
+      value?: string | number | BigNumber | Fraction | boolean | Unit | null
     ): number
     number(value?: MathCollection): number | MathCollection
     /**
@@ -4017,7 +4010,9 @@ declare namespace math {
      * BigNumber.
      */
     bignumber(
-      this: MathJsChain<number | string | Fraction | BigNumber | boolean | Fraction | null>,
+      this: MathJsChain<
+        number | string | Fraction | BigNumber | boolean | Fraction | null
+      >
     ): MathJsChain<BigNumber>
     bignumber<T extends MathCollection>(this: MathJsChain<T>): MathJsChain<T>
 
@@ -4027,7 +4022,9 @@ declare namespace math {
      * of zero. Strings can be 'true' or 'false', or can contain a number.
      * When value is a matrix, all elements will be converted to boolean.
      */
-    boolean(this: MathJsChain<string | number | boolean | null>): MathJsChain<boolean>
+    boolean(
+      this: MathJsChain<string | number | boolean | null>
+    ): MathJsChain<boolean>
     boolean(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
@@ -4035,8 +4032,14 @@ declare namespace math {
      * @param im Argument specifying the imaginary part of the complex
      * number
      */
-    complex(this: MathJsChain<Complex | string | PolarCoordinates>, im?: number): MathJsChain<Complex>
-    complex(this: MathJsChain<MathCollection>, im?: number): MathJsChain<MathCollection>
+    complex(
+      this: MathJsChain<Complex | string | PolarCoordinates>,
+      im?: number
+    ): MathJsChain<Complex>
+    complex(
+      this: MathJsChain<MathCollection>,
+      im?: number
+    ): MathJsChain<MathCollection>
 
     /**
      * Create a user-defined unit and register it with the Unit type.
@@ -4065,15 +4068,24 @@ declare namespace math {
      * the unit. For example, the offset for celsius is 273.15. Default is
      * 0.
      */
-    createUnit(this: MathJsChain<Record<string, string | UnitDefinition>>, options?: CreateUnitOptions): MathJsChain<Unit>
+    createUnit(
+      this: MathJsChain<Record<string, string | UnitDefinition>>,
+      options?: CreateUnitOptions
+    ): MathJsChain<Unit>
 
     /**
      * Create a fraction convert a value to a fraction.
      * @param denominator Argument specifying the denominator of the
      * fraction
      */
-    fraction(this: MathJsChain<MathCollection>, denominator?: number | string | MathCollection): MathJsChain<MathCollection>
-    fraction(this: MathJsChain<number | string | BigNumber | Fraction | object>, denominator?: number | string | MathCollection): MathJsChain<Fraction>
+    fraction(
+      this: MathJsChain<MathCollection>,
+      denominator?: number | string | MathCollection
+    ): MathJsChain<MathCollection>
+    fraction(
+      this: MathJsChain<number | string | BigNumber | Fraction | object>,
+      denominator?: number | string | MathCollection
+    ): MathJsChain<Fraction>
 
     /**
      * Create an index. An Index can store ranges having start, step, and
@@ -4088,7 +4100,11 @@ declare namespace math {
      * in the matrix, like getting the size and getting or setting values in
      * the matrix. Supported storage formats are 'dense' and 'sparse'.
      */
-    matrix(this: MathJsChain<MathCollection>, format?: 'sparse' | 'dense', dataType?: string): MathJsChain<Matrix>
+    matrix(
+      this: MathJsChain<MathCollection>,
+      format?: 'sparse' | 'dense',
+      dataType?: string
+    ): MathJsChain<Matrix>
 
     /**
      * Create a number or convert a string, boolean, or unit to a number.
@@ -4096,8 +4112,16 @@ declare namespace math {
      * @param valuelessUnit A valueless unit, used to convert a unit to a
      * number
      */
-    number(this: MathJsChain<string | number | BigNumber | Fraction | boolean | Unit | null>, valuelessUnit?: Unit | string): MathJsChain<number>
-    number(this: MathJsChain<MathCollection>, valuelessUnit?: Unit | string): MathJsChain<MathCollection>
+    number(
+      this: MathJsChain<
+        string | number | BigNumber | Fraction | boolean | Unit | null
+      >,
+      valuelessUnit?: Unit | string
+    ): MathJsChain<number>
+    number(
+      this: MathJsChain<MathCollection>,
+      valuelessUnit?: Unit | string
+    ): MathJsChain<MathCollection>
 
     /**
      * Create a Sparse Matrix. The function creates a new math.type.Matrix
@@ -4106,7 +4130,10 @@ declare namespace math {
      * values in the matrix.
      * @param dataType Sparse Matrix data type
      */
-    sparse(this: MathJsChain<MathCollection>, dataType?: string): MathJsChain<Matrix>
+    sparse(
+      this: MathJsChain<MathCollection>,
+      dataType?: string
+    ): MathJsChain<Matrix>
 
     /**
      * Split a unit in an array of units whose sum is equal to the original
@@ -4119,7 +4146,9 @@ declare namespace math {
      * Create a string or convert any object into a string. Elements of
      * Arrays and Matrices are processed element wise.
      */
-    string(this: MathJsChain<MathNumericType | string | Unit | null>): MathJsChain<string>
+    string(
+      this: MathJsChain<MathNumericType | string | Unit | null>
+    ): MathJsChain<string>
     string(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
@@ -4130,7 +4159,10 @@ declare namespace math {
      */
     unit(this: MathJsChain<string>, unit?: string): MathJsChain<Unit>
     unit(this: MathJsChain<Unit>, unit?: string): MathJsChain<Unit>
-    unit(this: MathJsChain<number | BigNumber>, unit?: string): MathJsChain<Unit>
+    unit(
+      this: MathJsChain<number | BigNumber>,
+      unit?: string
+    ): MathJsChain<Unit>
     unit(this: MathJsChain<MathCollection>, unit?: string): MathJsChain<Unit[]>
 
     /*************************************************************************
@@ -4148,8 +4180,14 @@ declare namespace math {
      * Evaluate an expression.
      * @param scope Scope to read/write variables
      */
-    evaluate(this: MathJsChain<MathExpression | Matrix>, scope?: object): MathJsChain<any>
-    evaluate(this: MathJsChain<MathExpression[]>, scope?: object): MathJsChain<any[]>
+    evaluate(
+      this: MathJsChain<MathExpression | Matrix>,
+      scope?: object
+    ): MathJsChain<any>
+    evaluate(
+      this: MathJsChain<MathExpression[]>,
+      scope?: object
+    ): MathJsChain<any[]>
 
     /**
      * Retrieve help on a function or data type. Help files are retrieved
@@ -4161,7 +4199,10 @@ declare namespace math {
      * @param options Available options: nodes - a set of custome nodes
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parse(this: MathJsChain<MathExpression[]>, options?: any): MathJsChain<MathNode[]>
+    parse(
+      this: MathJsChain<MathExpression[]>,
+      options?: any
+    ): MathJsChain<MathNode[]>
 
     /**
      * Parse an expression. Returns a node tree, which can be evaluated by
@@ -4169,7 +4210,10 @@ declare namespace math {
      * @param options Available options: nodes - a set of custome nodes
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parse(this: MathJsChain<MathExpression>, options?: any): MathJsChain<MathNode>
+    parse(
+      this: MathJsChain<MathExpression>,
+      options?: any
+    ): MathJsChain<MathNode>
 
     // TODO properly type return value
     /**
@@ -4183,8 +4227,14 @@ declare namespace math {
      * @param scope Scope to read/write variables
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolve(this: MathJsChain<MathNode>, scope?: Record<string, any>): MathJsChain<MathNode>
-    resolve(this: MathJsChain<MathNode[]>, scope?: Record<string, any>): MathJsChain<MathNode[]>
+    resolve(
+      this: MathJsChain<MathNode>,
+      scope?: Record<string, any>
+    ): MathJsChain<MathNode>
+    resolve(
+      this: MathJsChain<MathNode[]>,
+      scope?: Record<string, any>
+    ): MathJsChain<MathNode[]>
 
     /*************************************************************************
      * Algebra functions
@@ -4205,8 +4255,14 @@ declare namespace math {
      * must be a lower triangular matrix.
      * @param b A column vector with the b values
      */
-    lsolve(this: MathJsChain<Matrix>, b: Matrix | MathArray): MathJsChain<Matrix>
-    lsolve(this: MathJsChain<MathArray>, b: Matrix | MathArray): MathJsChain<MathArray>
+    lsolve(
+      this: MathJsChain<Matrix>,
+      b: Matrix | MathArray
+    ): MathJsChain<Matrix>
+    lsolve(
+      this: MathJsChain<MathArray>,
+      b: Matrix | MathArray
+    ): MathJsChain<MathArray>
 
     /**
      * Calculate the Matrix LU decomposition with partial pivoting. Matrix A
@@ -4255,7 +4311,11 @@ declare namespace math {
      * @param detailed  optional True if return an object, false if return
      * expression node (default)
      */
-    rationalize(this: MathJsChain<MathNode | string>, optional?: object | boolean, detailed?: boolean): MathJsChain<MathNode>
+    rationalize(
+      this: MathJsChain<MathNode | string>,
+      optional?: object | boolean,
+      detailed?: boolean
+    ): MathJsChain<MathNode>
 
     /**
      * Simplify an expression tree.
@@ -4265,7 +4325,11 @@ declare namespace math {
      * can be specified as an object, string, or function.
      * @param scope Scope to variables
      */
-    simplify(this: MathJsChain<MathNode | string>, rules?: SimplifyRule[], scope?: object): MathJsChain<MathNode>
+    simplify(
+      this: MathJsChain<MathNode | string>,
+      rules?: SimplifyRule[],
+      scope?: object
+    ): MathJsChain<MathNode>
 
     // TODO check that this should even be here...
     simplifyCore(expr: MathNode): MathNode
@@ -4285,15 +4349,25 @@ declare namespace math {
      * with more than 10*sqr(columns) entries.
      * @param threshold Partial pivoting threshold (1 for partial pivoting)
      */
-    slu(this: MathJsChain<Matrix>, order: number, threshold: number): MathJsChain<SLUDecomposition>
+    slu(
+      this: MathJsChain<Matrix>,
+      order: number,
+      threshold: number
+    ): MathJsChain<SLUDecomposition>
 
     /**
      * Solves the linear equation system by backward substitution. Matrix
      * must be an upper triangular matrix. U * x = b
      * @param b A column vector with the b values
      */
-    usolve(this: MathJsChain<Matrix>, b: Matrix | MathArray): MathJsChain<Matrix>
-    usolve(this: MathJsChain<MathArray>, b: Matrix | MathArray): MathJsChain<MathArray>
+    usolve(
+      this: MathJsChain<Matrix>,
+      b: Matrix | MathArray
+    ): MathJsChain<Matrix>
+    usolve(
+      this: MathJsChain<MathArray>,
+      b: Matrix | MathArray
+    ): MathJsChain<MathArray>
 
     /*************************************************************************
      * Arithmetic functions
@@ -4343,10 +4417,16 @@ declare namespace math {
      * if false (default) the principal root is returned.
      */
     cbrt(this: MathJsChain<number>, allRoots?: boolean): MathJsChain<number>
-    cbrt(this: MathJsChain<BigNumber>, allRoots?: boolean): MathJsChain<BigNumber>
+    cbrt(
+      this: MathJsChain<BigNumber>,
+      allRoots?: boolean
+    ): MathJsChain<BigNumber>
     cbrt(this: MathJsChain<Fraction>, allRoots?: boolean): MathJsChain<Fraction>
     cbrt(this: MathJsChain<Complex>, allRoots?: boolean): MathJsChain<Complex>
-    cbrt(this: MathJsChain<MathArray>, allRoots?: boolean): MathJsChain<MathArray>
+    cbrt(
+      this: MathJsChain<MathArray>,
+      allRoots?: boolean
+    ): MathJsChain<MathArray>
     cbrt(this: MathJsChain<Matrix>, allRoots?: boolean): MathJsChain<Matrix>
     cbrt(this: MathJsChain<Unit>, allRoots?: boolean): MathJsChain<Unit>
 
@@ -4358,32 +4438,56 @@ declare namespace math {
      * function is evaluated element wise.
      * @param n Number of decimals Default value: 0.
      */
-    ceil(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
-    ceil(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
+    ceil(
+      this: MathJsChain<MathNumericType>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathNumericType>
+    ceil(
+      this: MathJsChain<MathCollection>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathCollection>
 
     /**
      * Round a value towards zero. For matrices, the function is evaluated
      * element wise.
      * @param n Number of decimals Default value: 0.
      */
-    fix(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
-    fix(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
+    fix(
+      this: MathJsChain<MathNumericType>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathNumericType>
+    fix(
+      this: MathJsChain<MathCollection>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathCollection>
 
     /**
      * Round a value towards minus infinity. For matrices, the function is
      * evaluated element wise.
      * @param n Number of decimals Default value: 0.
      */
-    floor(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
-    floor(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
+    floor(
+      this: MathJsChain<MathNumericType>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathNumericType>
+    floor(
+      this: MathJsChain<MathCollection>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathCollection>
 
     /**
      * Round a value towards the nearest integer. For matrices, the function
      * is evaluated element wise.
      * @param n Number of decimals Default value: 0.
      */
-    round(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
-    round(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
+    round(
+      this: MathJsChain<MathNumericType>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathNumericType>
+    round(
+      this: MathJsChain<MathCollection>,
+      n?: number | BigNumber | MathCollection
+    ): MathJsChain<MathCollection>
 
     // End of rounding group
 
@@ -4505,11 +4609,26 @@ declare namespace math {
      * Calculate the logarithm of a value+1. For matrices, the function is
      * evaluated element wise.
      */
-    log1p(this: MathJsChain<number>, base?: number | BigNumber | Complex): MathJsChain<number>
-    log1p(this: MathJsChain<BigNumber>, base?: number | BigNumber | Complex): MathJsChain<BigNumber>
-    log1p(this: MathJsChain<Complex>, base?: number | BigNumber | Complex): MathJsChain<Complex>
-    log1p(this: MathJsChain<MathArray>, base?: number | BigNumber | Complex): MathJsChain<MathArray>
-    log1p(this: MathJsChain<Matrix>, base?: number | BigNumber | Complex): MathJsChain<Matrix>
+    log1p(
+      this: MathJsChain<number>,
+      base?: number | BigNumber | Complex
+    ): MathJsChain<number>
+    log1p(
+      this: MathJsChain<BigNumber>,
+      base?: number | BigNumber | Complex
+    ): MathJsChain<BigNumber>
+    log1p(
+      this: MathJsChain<Complex>,
+      base?: number | BigNumber | Complex
+    ): MathJsChain<Complex>
+    log1p(
+      this: MathJsChain<MathArray>,
+      base?: number | BigNumber | Complex
+    ): MathJsChain<MathArray>
+    log1p(
+      this: MathJsChain<Matrix>,
+      base?: number | BigNumber | Complex
+    ): MathJsChain<Matrix>
 
     /**
      * Calculate the 2-base of a value. This is the same as calculating
@@ -4539,7 +4658,10 @@ declare namespace math {
      * matrix product is calculated.
      * @param y The second value to multiply
      */
-    multiply<T extends Matrix | MathArray>(this: MathJsChain<T>, y: MathType): MathJsChain<T>
+    multiply<T extends Matrix | MathArray>(
+      this: MathJsChain<T>,
+      y: MathType
+    ): MathJsChain<T>
     multiply(this: MathJsChain<Unit>, y: Unit): MathJsChain<Unit>
     multiply(this: MathJsChain<number>, y: number): MathJsChain<number>
     multiply(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
@@ -4572,7 +4694,10 @@ declare namespace math {
      * supported for square matrices x, and positive integer exponents y.
      * @param y The exponent
      */
-    pow(this: MathJsChain<MathType>, y: number | BigNumber | Complex): MathJsChain<MathType>
+    pow(
+      this: MathJsChain<MathType>,
+      y: number | BigNumber | Complex
+    ): MathJsChain<MathType>
 
     /**
      * Compute the sign of a value. The sign of a value x is: 1 when x > 1
@@ -4657,7 +4782,10 @@ declare namespace math {
      * http://en.wikipedia.org/wiki/Extended_Euclidean_algorithm.
      * @param b An integer number
      */
-    xgcd(this: MathJsChain<number | BigNumber>, b: number | BigNumber): MathJsChain<MathArray>
+    xgcd(
+      this: MathJsChain<number | BigNumber>,
+      b: number | BigNumber
+    ): MathJsChain<MathArray>
 
     /*************************************************************************
      * Bitwise functions
@@ -4920,7 +5048,9 @@ declare namespace math {
      * dimension of the matrices.
      */
 
-    concat(this: MathJsChain<Array<MathCollection | number | BigNumber>>): MathJsChain<MathCollection>
+    concat(
+      this: MathJsChain<Array<MathCollection | number | BigNumber>>
+    ): MathJsChain<MathCollection>
 
     /**
      * Calculate the cross product for two vectors in three dimensional
@@ -4929,7 +5059,10 @@ declare namespace math {
      * * b2 - a2 * b1 ]
      * @param y Second vector
      */
-    cross(this: MathJsChain<MathCollection>, y: MathCollection): MathJsChain<Matrix | MathArray>
+    cross(
+      this: MathJsChain<MathCollection>,
+      y: MathCollection
+    ): MathJsChain<Matrix | MathArray>
 
     /**
      * Calculate the determinant of a matrix.
@@ -4948,7 +5081,10 @@ declare namespace math {
      * retrieved. Default value: 0.
      * @param format The matrix storage format. Default value: 'dense'.
      */
-    diag(this: MathJsChain<MathCollection>, format?: string): MathJsChain<Matrix>
+    diag(
+      this: MathJsChain<MathCollection>,
+      format?: string
+    ): MathJsChain<Matrix>
     diag(
       this: MathJsChain<MathCollection>,
       k: number | BigNumber,
@@ -4961,7 +5097,10 @@ declare namespace math {
      * B) = a1 * b1 + a2 * b2 + a3 * b3 + ... + an * bn
      * @param y Second vector
      */
-    dot(this: MathJsChain<MathCollection>, y: MathCollection): MathJsChain<number>
+    dot(
+      this: MathJsChain<MathCollection>,
+      y: MathCollection
+    ): MathJsChain<number>
 
     /**
      * Compute the matrix exponential, expm(A) = e^A. The matrix must be
@@ -4987,7 +5126,11 @@ declare namespace math {
      * @param n The y dimension for the matrix
      * @param format The Matrix storage format
      */
-    identity(this: MathJsChain<number>, n: number, format?: string): MathJsChain<Matrix | MathArray | number>
+    identity(
+      this: MathJsChain<number>,
+      n: number,
+      format?: string
+    ): MathJsChain<Matrix | MathArray | number>
 
     /**
      * Filter the items in an array or one dimensional matrix.
@@ -5025,13 +5168,18 @@ declare namespace math {
      * Calculate the inverse of a square matrix.
      */
 
-    inv<T extends number | Complex | MathCollection>(this: MathJsChain<T>): MathJsChain<NoLiteralType<T>>
+    inv<T extends number | Complex | MathCollection>(
+      this: MathJsChain<T>
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Calculate the kronecker product of two matrices or vectors
      * @param y Second vector
      */
-    kron(this: MathJsChain<Matrix | MathArray>, y: Matrix | MathArray): MathJsChain<Matrix>
+    kron(
+      this: MathJsChain<Matrix | MathArray>,
+      y: Matrix | MathArray
+    ): MathJsChain<Matrix>
 
     /**
      * Iterate over all elements of a matrix/array, and executes the given
@@ -5051,12 +5199,19 @@ declare namespace math {
      * multiple dimensions.
      * @param format The matrix storage format
      */
-    ones(this: MathJsChain<number | number[]>, format?: string): MathJsChain<MathCollection>
+    ones(
+      this: MathJsChain<number | number[]>,
+      format?: string
+    ): MathJsChain<MathCollection>
 
     /**
      * @param format The matrix storage format
      */
-    ones(this: MathJsChain<number>, n: number, format?: string): MathJsChain<MathCollection>
+    ones(
+      this: MathJsChain<number>,
+      n: number,
+      format?: string
+    ): MathJsChain<MathCollection>
 
     /**
      * Partition-based selection of an array or 1D matrix. Will find the kth
@@ -5083,25 +5238,28 @@ declare namespace math {
      * @param includeEnd: Option to specify whether to include the end or
      * not. False by default
      */
-     range(this: MathJsChain<string>, includeEnd?: boolean): MathJsChain<Matrix>
-     range(
-       this: MathJsChain<number | BigNumber>,
-       end: number | BigNumber,
-       includeEnd?: boolean
-     ): MathJsChain<Matrix>
-     range(
-       this: MathJsChain<number | BigNumber>,
-       end: number | BigNumber,
-       step: number | BigNumber,
-       includeEnd?: boolean
-     ): MathJsChain<Matrix>
+    range(this: MathJsChain<string>, includeEnd?: boolean): MathJsChain<Matrix>
+    range(
+      this: MathJsChain<number | BigNumber>,
+      end: number | BigNumber,
+      includeEnd?: boolean
+    ): MathJsChain<Matrix>
+    range(
+      this: MathJsChain<number | BigNumber>,
+      end: number | BigNumber,
+      step: number | BigNumber,
+      includeEnd?: boolean
+    ): MathJsChain<Matrix>
 
     /**
      * Reshape a multi dimensional array to fit the specified dimensions
      * @param sizes One dimensional array with integral sizes for each
      * dimension
      */
-    reshape<T extends MathCollection>(this: MathJsChain<T>, sizes: number[]): MathJsChain<T>
+    reshape<T extends MathCollection>(
+      this: MathJsChain<T>,
+      sizes: number[]
+    ): MathJsChain<T>
 
     /**
      * Resize a matrix
@@ -5119,7 +5277,9 @@ declare namespace math {
      * Calculate the size of a matrix or scalar.
      */
     size(
-      this: MathJsChain<boolean | number | Complex | Unit | string | MathCollection>
+      this: MathJsChain<
+        boolean | number | Complex | Unit | string | MathCollection
+      >
     ): MathJsChain<MathCollection>
 
     /**
@@ -5166,7 +5326,7 @@ declare namespace math {
       replacement?: any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       defaultValue?: any
-    ):  MathJsChain<T>
+    ): MathJsChain<T>
 
     /**
      * Calculate the trace of a matrix: the sum of the elements on the main
@@ -5188,13 +5348,20 @@ declare namespace math {
      * @param format The matrix storage format
      * @returns A matrix filled with zeros
      */
-    zeros(this: MathJsChain<number | number[]>, format?: string): MathJsChain<MathCollection>
+    zeros(
+      this: MathJsChain<number | number[]>,
+      format?: string
+    ): MathJsChain<MathCollection>
 
     /**
      * @param n The y dimension of the matrix
      * @param format The matrix storage format
      */
-    zeros(this: MathJsChain<number>, n: number, format?: string): MathJsChain<MathCollection>
+    zeros(
+      this: MathJsChain<number>,
+      n: number,
+      format?: string
+    ): MathJsChain<MathCollection>
 
     /*************************************************************************
      * Probability functions
@@ -5236,7 +5403,10 @@ declare namespace math {
      * distributions
      * @param p Second vector
      */
-    kldivergence(this: MathJsChain<MathCollection>, p: MathCollection): MathJsChain<number>
+    kldivergence(
+      this: MathJsChain<MathCollection>,
+      p: MathCollection
+    ): MathJsChain<number>
 
     /**
      * Multinomial Coefficients compute the number of ways of picking a1,
@@ -5245,7 +5415,9 @@ declare namespace math {
      * must be enforced: every ai <= 0
      */
 
-    multinomial<T extends number | BigNumber>(a: MathJsChain<T[]>): MathJsChain<NoLiteralType<T>>
+    multinomial<T extends number | BigNumber>(
+      a: MathJsChain<T[]>
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Compute the number of ways of obtaining an ordered subset of k
@@ -5279,7 +5451,11 @@ declare namespace math {
     random(this: MathJsChain<number>, max?: number): MathJsChain<number>
 
     // tslint:disable-next-line unified-signatures
-    random<T extends MathCollection>(this: MathJsChain<T>, min?: number, max?: number): MathJsChain<T>
+    random<T extends MathCollection>(
+      this: MathJsChain<T>,
+      min?: number,
+      max?: number
+    ): MathJsChain<T>
 
     /**
      * Return a random integer number larger or equal to min and smaller
@@ -5287,10 +5463,20 @@ declare namespace math {
      * @param min Minimum boundary for the random value, included
      * @param max Maximum boundary for the random value, excluded
      */
-    randomInt<T extends MathCollection>(this: MathJsChain<T>, max?: number): MathJsChain<T>
-    randomInt<T extends MathCollection>(this: MathJsChain<T>, max?: number): MathJsChain<T>
+    randomInt<T extends MathCollection>(
+      this: MathJsChain<T>,
+      max?: number
+    ): MathJsChain<T>
+    randomInt<T extends MathCollection>(
+      this: MathJsChain<T>,
+      max?: number
+    ): MathJsChain<T>
     // tslint:disable-next-line unified-signatures
-    randomInt<T extends MathCollection>(this: MathJsChain<T>, min: number, max: number): MathJsChain<T>
+    randomInt<T extends MathCollection>(
+      this: MathJsChain<T>,
+      min: number,
+      max: number
+    ): MathJsChain<T>
 
     /*************************************************************************
      * Relational functions
@@ -5338,7 +5524,9 @@ declare namespace math {
     deepEqual(
       this: MathJsChain<MathType>,
       y: MathType
-    ): MathJsChain<number | BigNumber | Fraction | Complex | Unit | MathCollection>
+    ): MathJsChain<
+      number | BigNumber | Fraction | Complex | Unit | MathCollection
+    >
 
     /**
      * Test whether two values are equal.
@@ -5352,7 +5540,10 @@ declare namespace math {
      * else, and undefined is only equal to undefined and nothing else.
      * @param y Second value to compare
      */
-    equal(this: MathJsChain<MathType | string>, y: MathType | string): MathJsChain<boolean | MathCollection>
+    equal(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Check equality of two strings. Comparison is case sensitive. For
@@ -5372,7 +5563,10 @@ declare namespace math {
      * function is evaluated element wise.
      * @param y Second value to compare
      */
-    larger(this: MathJsChain<MathType | string>, y: MathType | string): MathJsChain<boolean | MathCollection>
+    larger(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Test whether value x is larger or equal to y. The function returns
@@ -5439,7 +5633,10 @@ declare namespace math {
      * will be sorted in ascending order before the operation.
      * @param a2 A (multi)set
      */
-    setCartesian<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
+    setCartesian<T extends MathCollection>(
+      this: MathJsChain<T>,
+      a2: MathCollection
+    ): MathJsChain<T>
 
     /**
      * Create the difference of two (multi)sets: every element of set1, that
@@ -5447,7 +5644,10 @@ declare namespace math {
      * to single-dimension arrays before the operation
      * @param a2 A (multi)set
      */
-    setDifference<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
+    setDifference<T extends MathCollection>(
+      this: MathJsChain<T>,
+      a2: MathCollection
+    ): MathJsChain<T>
 
     /**
      * Collect the distinct elements of a multiset. A multi-dimension array
@@ -5461,7 +5661,10 @@ declare namespace math {
      * will be converted to single-dimension arrays before the operation.
      * @param a2 A (multi)set
      */
-    setIntersect<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
+    setIntersect<T extends MathCollection>(
+      this: MathJsChain<T>,
+      a2: MathCollection
+    ): MathJsChain<T>
 
     /**
      * Check whether a (multi)set is a subset of another (multi)set. (Every
@@ -5469,7 +5672,10 @@ declare namespace math {
      * be converted to single-dimension arrays before the operation.
      * @param a2 A (multi)set
      */
-    setIsSubset(this: MathJsChain<MathCollection>, a2: MathCollection): MathJsChain<boolean>
+    setIsSubset(
+      this: MathJsChain<MathCollection>,
+      a2: MathCollection
+    ): MathJsChain<boolean>
 
     /**
      * Count the multiplicity of an element in a multiset. A multi-dimension
@@ -5504,14 +5710,20 @@ declare namespace math {
      * operation.
      * @param a2 A (multi)set
      */
-    setSymDifference<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
+    setSymDifference<T extends MathCollection>(
+      this: MathJsChain<T>,
+      a2: MathCollection
+    ): MathJsChain<T>
 
     /**
      * Create the union of two (multi)sets. Multi-dimension arrays will be
      * converted to single-dimension arrays before the operation.
      * @param a2 A (multi)set
      */
-    setUnion<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
+    setUnion<T extends MathCollection>(
+      this: MathJsChain<T>,
+      a2: MathCollection
+    ): MathJsChain<T>
 
     /*************************************************************************
      * Special functions
@@ -5521,7 +5733,9 @@ declare namespace math {
      * Compute the erf function of a value using a rational Chebyshev
      * approximations for different intervals of x.
      */
-    erf<T extends number | MathCollection>(this: MathJsChain<T>): MathJsChain<NoLiteralType<T>>
+    erf<T extends number | MathCollection>(
+      this: MathJsChain<T>
+    ): MathJsChain<NoLiteralType<T>>
 
     /*************************************************************************
      * Statistics functions
@@ -5701,7 +5915,10 @@ declare namespace math {
      * Default value: ‘unbiased’.
      * @returns The variance
      */
-    variance(this: MathJsChain<MathCollection>, normalization: 'unbiased' | 'uncorrected' | 'biased'): MathJsChain<number[]>
+    variance(
+      this: MathJsChain<MathCollection>,
+      normalization: 'unbiased' | 'uncorrected' | 'biased'
+    ): MathJsChain<number[]>
 
     /*************************************************************************
      * String functions
@@ -5874,7 +6091,10 @@ declare namespace math {
      */
 
     atan2(this: MathJsChain<number>, x: number): MathJsChain<number>
-    atan2(this: MathJsChain<MathCollection>, x: MathCollection): MathJsChain<MathCollection>
+    atan2(
+      this: MathJsChain<MathCollection>,
+      x: MathCollection
+    ): MathJsChain<MathCollection>
 
     /**
      * Calculate the hyperbolic arctangent of a value, defined as atanh(x) =
@@ -6026,7 +6246,10 @@ declare namespace math {
      * @param unit New unit. Can be a string like "cm" or a unit without
      * value.
      */
-    to(this: MathJsChain<Unit | MathCollection>, unit: Unit | string): MathJsChain<Unit | MathCollection>
+    to(
+      this: MathJsChain<Unit | MathCollection>,
+      unit: Unit | string
+    ): MathJsChain<Unit | MathCollection>
 
     /*************************************************************************
      * Utils functions
@@ -6044,7 +6267,9 @@ declare namespace math {
      * element-wise in case of Array or Matrix input.
      */
 
-    isInteger(this: MathJsChain<number | BigNumber | Fraction | MathCollection>): MathJsChain<boolean>
+    isInteger(
+      this: MathJsChain<number | BigNumber | Fraction | MathCollection>
+    ): MathJsChain<boolean>
 
     /**
      * Test whether a value is NaN (not a number). The function supports
@@ -6052,7 +6277,9 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
 
-    isNaN(this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit>): MathJsChain<boolean>
+    isNaN(
+      this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit>
+    ): MathJsChain<boolean>
 
     /**
      * Test whether a value is negative: smaller than zero. The function
@@ -6087,7 +6314,9 @@ declare namespace math {
      * evaluated element-wise in case of Array or Matrix input.
      */
 
-    isPrime(this: MathJsChain<number | BigNumber | MathCollection>): MathJsChain<boolean>
+    isPrime(
+      this: MathJsChain<number | BigNumber | MathCollection>
+    ): MathJsChain<boolean>
 
     /**
      * Test whether a value is zero. The function can check for zero for
@@ -6096,7 +6325,9 @@ declare namespace math {
      */
 
     isZero(
-      this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit | Complex>
+      this: MathJsChain<
+        number | BigNumber | Fraction | MathCollection | Unit | Complex
+      >
     ): MathJsChain<boolean>
 
     /**
@@ -6117,4 +6348,3 @@ declare namespace math {
     [key: string]: any
   }
 }
-

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4102,7 +4102,10 @@ declare namespace math {
      * provided, all elements will be converted to units.
      * @param unit The unit to be created
      */
-    unit(this: MathJsChain<unknown>, unit?: string): MathJsChain<unknown>
+    unit(this: MathJsChain<string>, unit?: string): MathJsChain<Unit>
+    unit(this: MathJsChain<Unit>, unit?: string): MathJsChain<Unit>
+    unit(this: MathJsChain<number | BigNumber>, unit?: string): MathJsChain<Unit>
+    unit(this: MathJsChain<MathCollection>, unit?: string): MathJsChain<Unit[]>
 
     /*************************************************************************
      * Expression functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4391,7 +4391,13 @@ declare namespace math {
      * Compute the cube of a value, x * x * x. For matrices, the function is
      * evaluated element wise.
      */
-    cube(this: MathJsChain<unknown>): MathJsChain<unknown>
+    cube(this: MathJsChain<number>): MathJsChain<number>
+    cube(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    cube(this: MathJsChain<Fraction>): MathJsChain<Fraction>
+    cube(this: MathJsChain<Complex>): MathJsChain<Complex>
+    cube(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    cube(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    cube(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Divide two values, x / y. To divide matrices, x is multiplied with

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4358,7 +4358,8 @@ declare namespace math {
      * function is evaluated element wise.
      * @param n Number of decimals Default value: 0.
      */
-    ceil(this: MathJsChain<unknown>, n?: number | BigNumber | MathCollection): MathJsChain<unknown>
+    ceil(this: MathJsChain<MathNumericType>, n?: number | BigNumber | MathCollection): MathJsChain<MathNumericType>
+    ceil(this: MathJsChain<MathCollection>, n?: number | BigNumber | MathCollection): MathJsChain<MathCollection>
 
     /**
      * Round a value towards zero. For matrices, the function is evaluated

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4175,10 +4175,10 @@ declare namespace math {
      * by default. When false, output will not be simplified.
      */
     derivative(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<MathNode | string>,
       variable: MathNode | string,
       options?: { simplify: boolean }
-    ): MathJsChain<unknown>
+    ): MathJsChain<MathNode>
 
     /**
      * Solves the linear equation system by forwards substitution. Matrix

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4163,7 +4163,8 @@ declare namespace math {
      * @param scope Scope to read/write variables
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolve(scope?: Record<string, any>): MathJsChain
+    resolve(this: MathJsChain<MathNode>, scope?: Record<string, any>): MathJsChain<MathNode>
+    resolve(this: MathJsChain<MathNode[]>, scope?: Record<string, any>): MathJsChain<MathNode[]>
 
     /*************************************************************************
      * Algebra functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -768,11 +768,18 @@ declare namespace math {
      * b
      */
     lusolve(
-      A: Matrix | MathArray | number,
+      A: Matrix,
       b: Matrix | MathArray,
       order?: number,
       threshold?: number
-    ): Matrix | MathArray
+    ): Matrix
+
+    lusolve(
+      A: MathArray,
+      b: Matrix | MathArray,
+      order?: number,
+      threshold?: number
+    ): MathArray
 
     /**
      * Calculate the Matrix QR decomposition. Matrix A is decomposed in two

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4085,7 +4085,7 @@ declare namespace math {
      * unit.
      * @param parts An array of strings or valueless units
      */
-    splitUnit(this: MathJsChain<unknown>, parts: Unit[]): MathJsChain<unknown>
+    splitUnit(this: MathJsChain<Unit>, parts: Unit[]): MathJsChain<Unit[]>
 
     /**
      * Create a string or convert any object into a string. Elements of

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2615,6 +2615,7 @@ declare namespace math {
      * @returns The variance
      */
     variance(...args: Array<number | BigNumber | Fraction>): number
+
     /**
      * Compute the variance of a matrix or a list with values. In case of a
      * (multi dimensional) array or matrix, the variance over all elements
@@ -4392,7 +4393,8 @@ declare namespace math {
      */
     add(this: MathJsChain<MathArray>, y: MathType): MathJsChain<MathArray>
     add(this: MathJsChain<Matrix>, y: MathType): MathJsChain<Matrix>
-    add(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
+    add(this: MathJsChain<Unit>, y: MathType): MathJsChain<Unit>
+    add(this: MathJsChain<MathNumericType>, y: MathType): MathJsChain<MathNumericType>
 
     /**
      * Apply a function that maps an array to a scalar along a given axis of the
@@ -5893,11 +5895,7 @@ declare namespace math {
      * Default value: ‘unbiased’.
      * @returns The variance
      */
-    variance(
-      this: MathJsChain<(number | BigNumber | Fraction)[]>,
-      dim?: number,
-      normalization?: 'unbiased' | 'uncorrected' | 'biased'
-    ): MathJsChain<number>
+    variance(this: MathJsChain<Array<Array<number | BigNumber | Fraction>>>): MathJsChain<number>
 
     /**
      * Compute the variance of a matrix or a list with values. In case of a
@@ -5915,10 +5913,16 @@ declare namespace math {
      * Default value: ‘unbiased’.
      * @returns The variance
      */
+     variance(
+      this: MathJsChain<MathCollection>,
+      dimension?: number,
+      normalization?: 'unbiased' | 'uncorrected' | 'biased'
+    ): MathJsChain<number[]>
+
     variance(
       this: MathJsChain<MathCollection>,
       normalization: 'unbiased' | 'uncorrected' | 'biased'
-    ): MathJsChain<number[]>
+    ): MathJsChain<number>
 
     /*************************************************************************
      * String functions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -672,6 +672,7 @@ declare namespace math {
      */
     compile(exprs: MathExpression[]): EvalFunction[]
 
+    // TODO properly type this
     /**
      * Evaluate an expression.
      * @param expr The expression to be evaluated
@@ -679,10 +680,15 @@ declare namespace math {
      * @returns The result of the expression
      */
     evaluate(
-      expr: MathExpression | MathExpression[] | Matrix,
+      expr: MathExpression | Matrix,
       scope?: object
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): any
+    evaluate(
+      expr: MathExpression[],
+      scope?: object
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): any[]
 
     /**
      * Retrieve help on a function or data type. Help files are retrieved

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4092,7 +4092,8 @@ declare namespace math {
      * Create a string or convert any object into a string. Elements of
      * Arrays and Matrices are processed element wise.
      */
-    string(this: MathJsChain<unknown>): MathJsChain<unknown>
+    string(this: MathJsChain<MathNumericType | string | Unit | null>): MathJsChain<string>
+    string(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
      * Create a unit. Depending on the passed arguments, the function will

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -353,6 +353,12 @@ declare namespace math {
 
   type MathJsFunctionName = keyof MathJsStatic
 
+  interface LUDecomposition {
+    L: MathCollection
+    U: MathCollection
+    p: number[]
+  }
+
   interface MathJsStatic extends FactoryDependencies {
     e: number
     pi: number
@@ -747,11 +753,7 @@ declare namespace math {
      * @returns The lower triangular matrix, the upper triangular matrix and
      * the permutation matrix.
      */
-    lup(A?: Matrix | MathArray): {
-      L: MathCollection
-      U: MathCollection
-      P: number[]
-    }
+    lup(A?: Matrix | MathArray): LUDecomposition
 
     /**
      * Solves the linear system A * x = b where A is an [n x n] matrix and b

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4217,14 +4217,6 @@ declare namespace math {
       options?: any
     ): MathJsChain<MathNode>
 
-    // TODO properly type return value and chain value
-    /**
-     * Create a parser. The function creates a new math.expression.Parser
-     * object.
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parser(this: MathJsChain<any>): MathJsChain<any>
-
     /**
      *  Replaces variable nodes with their scoped values
      * @param scope Scope to read/write variables

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4123,11 +4123,13 @@ declare namespace math {
      */
     compile(this: MathJsChain<MathExpression>): MathJsChain<EvalFunction>
 
+    // TODO properly type this
     /**
      * Evaluate an expression.
      * @param scope Scope to read/write variables
      */
-    evaluate(this: MathJsChain<unknown>, scope?: object): MathJsChain<unknown>
+    evaluate(this: MathJsChain<MathExpression | Matrix>, scope?: object): MathJsChain<any>
+    evaluate(this: MathJsChain<MathExpression[]>, scope?: object): MathJsChain<any[]>
 
     /**
      * Retrieve help on a function or data type. Help files are retrieved

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4389,13 +4389,8 @@ declare namespace math {
      * element wise.
      * @param y Second value to add
      */
-    add(this: MathJsChain<MathArray>, y: MathType): MathJsChain<MathArray>
-    add(this: MathJsChain<Matrix>, y: MathType): MathJsChain<Matrix>
-    add(this: MathJsChain<Unit>, y: MathType): MathJsChain<Unit>
-    add(
-      this: MathJsChain<MathNumericType>,
-      y: MathType
-    ): MathJsChain<MathNumericType>
+    add<T extends MathType>(this: MathJsChain<T>, y: T): MathJsChain<T>
+    add(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Apply a function that maps an array to a scalar along a given axis of the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -368,6 +368,11 @@ declare namespace math {
     R: MathCollection
   }
 
+  interface FractionDefinition {
+    a: number
+    b: number
+  }
+
   interface MathJsStatic extends FactoryDependencies {
     e: number
     pi: number
@@ -554,7 +559,7 @@ declare namespace math {
      * fraction
      * @returns Returns a fraction
      */
-    fraction(value: number | string | BigNumber | Fraction | object): Fraction
+    fraction(value: number | string | BigNumber | Fraction | FractionDefinition): Fraction
     fraction(values: MathCollection): MathCollection
     /**
      * @param numerator Argument specifying the numerator of the fraction
@@ -4078,14 +4083,8 @@ declare namespace math {
      * @param denominator Argument specifying the denominator of the
      * fraction
      */
-    fraction(
-      this: MathJsChain<MathCollection>,
-      denominator?: number | string | MathCollection
-    ): MathJsChain<MathCollection>
-    fraction(
-      this: MathJsChain<number | string | BigNumber | Fraction | object>,
-      denominator?: number | string | MathCollection
-    ): MathJsChain<Fraction>
+    fraction(this: MathJsChain<number | string | BigNumber | Fraction | FractionDefinition>, denominator?: number): MathJsChain<Fraction>
+    fraction(this: MathJsChain<MathCollection>): MathJsChain<MathCollection>
 
     /**
      * Create an index. An Index can store ranges having start, step, and

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4215,11 +4215,18 @@ declare namespace math {
      * see slu for details. Matrix must be a SparseMatrix.
      */
     lusolve(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<Matrix>,
       b: Matrix | MathArray,
       order?: number,
       threshold?: number
-    ): MathJsChain<unknown>
+    ): MathJsChain<Matrix>
+
+    lusolve(
+      this: MathJsChain<MathArray>,
+      b: Matrix | MathArray,
+      order?: number,
+      threshold?: number
+    ): MathJsChain<MathArray>
 
     /**
      * Calculate the Matrix QR decomposition. Matrix A is decomposed in two

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4196,7 +4196,7 @@ declare namespace math {
      * is decomposed in two matrices (L, U) and a row permutation vector p
      * where A[p,:] = L * U
      */
-    lup(this: MathJsChain<unknown>): MathJsChain<unknown>
+    lup(this: MathJsChain<Matrix | MathArray>): MathJsChain<LUDecomposition>
 
     /**
      * Solves the linear system A * x = b where A is an [n x n] matrix and b

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4553,11 +4553,11 @@ declare namespace math {
      * Calculate the greatest common divisor for two or more values or
      * arrays. For matrices, the function is evaluated element wise.
      */
-    gcd(this: MathJsChain<number[]>): MathJsChain<number>
-    gcd(this: MathJsChain<BigNumber[]>): MathJsChain<BigNumber>
-    gcd(this: MathJsChain<Complex[]>): MathJsChain<Complex>
-    gcd(this: MathJsChain<MathArray[]>): MathJsChain<MathArray>
-    gcd(this: MathJsChain<Matrix[]>): MathJsChain<Matrix>
+    gcd(this: MathJsChain<number[]>, ...args: number[]): MathJsChain<number>
+    gcd(this: MathJsChain<BigNumber[]>, ...args: BigNumber[]): MathJsChain<BigNumber>
+    gcd(this: MathJsChain<Complex[]>, ...args: Fraction[]): MathJsChain<Complex>
+    gcd(this: MathJsChain<MathArray[]>, ...args: MathArray[]): MathJsChain<MathArray>
+    gcd(this: MathJsChain<Matrix[]>, ...args: Matrix[]): MathJsChain<Matrix>
 
     /**
      * Calculate the hypotenusa of a list with values. The hypotenusa is

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4474,7 +4474,10 @@ declare namespace math {
      * the function is evaluated element wise.
      * @param b An integer number
      */
-    lcm(this: MathJsChain<unknown>, b: number | BigNumber | MathCollection): MathJsChain<unknown>
+    lcm(this: MathJsChain<number>, b: number): MathJsChain<number>
+    lcm(this: MathJsChain<BigNumber>, b: BigNumber): MathJsChain<BigNumber>
+    lcm(this: MathJsChain<MathArray>, b: MathArray): MathJsChain<MathArray>
+    lcm(this: MathJsChain<Matrix>, b: Matrix): MathJsChain<Matrix>
 
     /**
      * Calculate the logarithm of a value. For matrices, the function is

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4260,8 +4260,9 @@ declare namespace math {
      * can be specified as an object, string, or function.
      * @param scope Scope to variables
      */
-    simplify(this: MathJsChain<unknown>, rules?: SimplifyRule[], scope?: object): MathJsChain<unknown>
+    simplify(this: MathJsChain<MathNode | string>, rules?: SimplifyRule[], scope?: object): MathJsChain<MathNode>
 
+    // TODO check that this should even be here...
     simplifyCore(expr: MathNode): MathNode
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4284,7 +4284,7 @@ declare namespace math {
      * with more than 10*sqr(columns) entries.
      * @param threshold Partial pivoting threshold (1 for partial pivoting)
      */
-    slu(this: MathJsChain<unknown>, order: number, threshold: number): MathJsChain<unknown>
+    slu(this: MathJsChain<unknown>, order: number, threshold: number): MathJsChain<SLUDecomposition>
 
     /**
      * Solves the linear equation system by backward substitution. Matrix

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4433,13 +4433,21 @@ declare namespace math {
      * Calculate the exponent of a value. For matrices, the function is
      * evaluated element wise.
      */
-    exp(this: MathJsChain<unknown>): MathJsChain<unknown>
+    exp(this: MathJsChain<number>): MathJsChain<number>
+    exp(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    exp(this: MathJsChain<Complex>): MathJsChain<Complex>
+    exp(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    exp(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the value of subtracting 1 from the exponential value. For
      * matrices, the function is evaluated element wise.
      */
-    expm1(this: MathJsChain<unknown>): MathJsChain<unknown>
+    expm1(this: MathJsChain<number>): MathJsChain<number>
+    expm1(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    expm1(this: MathJsChain<Complex>): MathJsChain<Complex>
+    expm1(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    expm1(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the greatest common divisor for two or more values or

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4414,20 +4414,20 @@ declare namespace math {
      * and scalar values.
      * @param y Denominator
      */
-    dotDivide(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    dotDivide(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Multiply two matrices element wise. The function accepts both
      * matrices and scalar values.
      * @param y Right hand value
      */
-    dotMultiply(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    dotMultiply(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Calculates the power of x to y element wise.
      * @param y The exponent
      */
-    dotPow(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    dotPow(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Calculate the exponent of a value. For matrices, the function is

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4342,7 +4342,13 @@ declare namespace math {
      * a number or complex number. If true, all complex roots are returned,
      * if false (default) the principal root is returned.
      */
-    cbrt(this: MathJsChain<unknown>, allRoots?: boolean): MathJsChain<unknown>
+    cbrt(this: MathJsChain<number>, allRoots?: boolean): MathJsChain<number>
+    cbrt(this: MathJsChain<BigNumber>, allRoots?: boolean): MathJsChain<BigNumber>
+    cbrt(this: MathJsChain<Fraction>, allRoots?: boolean): MathJsChain<Fraction>
+    cbrt(this: MathJsChain<Complex>, allRoots?: boolean): MathJsChain<Complex>
+    cbrt(this: MathJsChain<MathArray>, allRoots?: boolean): MathJsChain<MathArray>
+    cbrt(this: MathJsChain<Matrix>, allRoots?: boolean): MathJsChain<Matrix>
+    cbrt(this: MathJsChain<Unit>, allRoots?: boolean): MathJsChain<Unit>
 
     // Rounding functions grouped for similarity
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4453,7 +4453,11 @@ declare namespace math {
      * Calculate the greatest common divisor for two or more values or
      * arrays. For matrices, the function is evaluated element wise.
      */
-    gcd(this: MathJsChain<unknown>): MathJsChain<unknown>
+    gcd(this: MathJsChain<number[]>): MathJsChain<number>
+    gcd(this: MathJsChain<BigNumber[]>): MathJsChain<BigNumber>
+    gcd(this: MathJsChain<Complex[]>): MathJsChain<Complex>
+    gcd(this: MathJsChain<MathArray[]>): MathJsChain<MathArray>
+    gcd(this: MathJsChain<Matrix[]>): MathJsChain<Matrix>
 
     /**
      * Calculate the hypotenusa of a list with values. The hypotenusa is

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4404,7 +4404,10 @@ declare namespace math {
      * the inverse of y: x * inv(y).
      * @param y Denominator
      */
-    divide(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
+    divide(this: MathJsChain<Unit>, y: Unit): MathJsChain<Unit | number>
+    divide(this: MathJsChain<Unit>, y: number): MathJsChain<Unit>
+    divide(this: MathJsChain<number>, y: number): MathJsChain<number>
+    divide(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Divide two matrices element wise. The function accepts both matrices

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -918,7 +918,6 @@ declare namespace math {
      */
     cbrt(x: number, allRoots?: boolean): number
     cbrt(x: BigNumber, allRoots?: boolean): BigNumber
-    cbrt(x: Fraction, allRoots?: boolean): Fraction
     cbrt(x: Complex, allRoots?: boolean): Complex
     cbrt(x: MathArray, allRoots?: boolean): MathArray
     cbrt(x: Matrix, allRoots?: boolean): Matrix
@@ -4421,7 +4420,6 @@ declare namespace math {
       this: MathJsChain<BigNumber>,
       allRoots?: boolean
     ): MathJsChain<BigNumber>
-    cbrt(this: MathJsChain<Fraction>, allRoots?: boolean): MathJsChain<Fraction>
     cbrt(this: MathJsChain<Complex>, allRoots?: boolean): MathJsChain<Complex>
     cbrt(
       this: MathJsChain<MathArray>,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4285,7 +4285,7 @@ declare namespace math {
      * with more than 10*sqr(columns) entries.
      * @param threshold Partial pivoting threshold (1 for partial pivoting)
      */
-    slu(this: MathJsChain<unknown>, order: number, threshold: number): MathJsChain<SLUDecomposition>
+    slu(this: MathJsChain<Matrix>, order: number, threshold: number): MathJsChain<SLUDecomposition>
 
     /**
      * Solves the linear equation system by backward substitution. Matrix
@@ -4494,34 +4494,33 @@ declare namespace math {
      * Calculate the 10-base of a value. This is the same as calculating
      * log(x, 10). For matrices, the function is evaluated element wise.
      */
-    log10(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // log10(x: number): number
-    // log10(x: BigNumber): BigNumber
-    // log10(x: Complex): Complex
-    // log10(x: MathArray): MathArray
-    // log10(x: Matrix): Matrix
+
+    log10(this: MathJsChain<number>): MathJsChain<number>
+    log10(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    log10(this: MathJsChain<Complex>): MathJsChain<Complex>
+    log10(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    log10(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the logarithm of a value+1. For matrices, the function is
      * evaluated element wise.
      */
-    log1p(this: MathJsChain<unknown>, base?: number | BigNumber | Complex): MathJsChain<unknown>
-    // log1p(x: number, base?: number | BigNumber | Complex): number
-    // log1p(x: BigNumber, base?: number | BigNumber | Complex): BigNumber
-    // log1p(x: Complex, base?: number | BigNumber | Complex): Complex
-    // log1p(x: MathArray, base?: number | BigNumber | Complex): MathArray
-    // log1p(x: Matrix, base?: number | BigNumber | Complex): Matrix
+    log1p(this: MathJsChain<number>, base?: number | BigNumber | Complex): MathJsChain<number>
+    log1p(this: MathJsChain<BigNumber>, base?: number | BigNumber | Complex): MathJsChain<BigNumber>
+    log1p(this: MathJsChain<Complex>, base?: number | BigNumber | Complex): MathJsChain<Complex>
+    log1p(this: MathJsChain<MathArray>, base?: number | BigNumber | Complex): MathJsChain<MathArray>
+    log1p(this: MathJsChain<Matrix>, base?: number | BigNumber | Complex): MathJsChain<Matrix>
 
     /**
      * Calculate the 2-base of a value. This is the same as calculating
      * log(x, 2). For matrices, the function is evaluated element wise.
      */
-    log2(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // log2(x: number): number
-    // log2(x: BigNumber): BigNumber
-    // log2(x: Complex): Complex
-    // log2(x: MathArray): MathArray
-    // log2(x: Matrix): Matrix
+
+    log2(this: MathJsChain<number>): MathJsChain<number>
+    log2(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    log2(this: MathJsChain<Complex>): MathJsChain<Complex>
+    log2(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    log2(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculates the modulus, the remainder of an integer division. For
@@ -4530,22 +4529,20 @@ declare namespace math {
      * @see http://en.wikipedia.org/wiki/Modulo_operation.
      * @param y Divisor
      */
-    mod(this: MathJsChain<unknown>, y: number | BigNumber | Fraction | MathCollection): MathJsChain<unknown>
-    // mod<T extends number | BigNumber | Fraction | MathCollection>(
-    //   x: T,
-    //   y: number | BigNumber | Fraction | MathCollection
-    // ): NoLiteralType<T>
+    mod<T extends number | BigNumber | Fraction | MathCollection>(
+      this: MathJsChain<T>,
+      y: number | BigNumber | Fraction | MathCollection
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Multiply two values, x * y. The result is squeezed. For matrices, the
      * matrix product is calculated.
      * @param y The second value to multiply
      */
-    multiply(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
-    // multiply<T extends Matrix | MathArray>(x: T, y: MathType): T
-    // multiply(x: Unit, y: Unit): Unit
-    // multiply(x: number, y: number): number
-    // multiply(x: MathType, y: MathType): MathType
+    multiply<T extends Matrix | MathArray>(this: MathJsChain<T>, y: MathType): MathJsChain<T>
+    multiply(this: MathJsChain<Unit>, y: Unit): MathJsChain<Unit>
+    multiply(this: MathJsChain<number>, y: number): MathJsChain<number>
+    multiply(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Calculate the norm of a number, vector or matrix. The second
@@ -4554,11 +4551,10 @@ declare namespace math {
      * -Infinity. Supported strings are: 'inf', '-inf', and 'fro' (The
      * Frobenius norm) Default value: 2.
      */
-    norm(this: MathJsChain<unknown>, p?: number | BigNumber | string): MathJsChain<unknown>
-    // norm(
-    //   x: number | BigNumber | Complex | MathCollection,
-    //   p?: number | BigNumber | string
-    // ): number | BigNumber
+    norm(
+      this: MathJsChain<number | BigNumber | Complex | MathCollection>,
+      p?: number | BigNumber | string
+    ): MathJsChain<number | BigNumber>
 
     /**
      * Calculate the nth root of a value. The principal nth root of a
@@ -4566,19 +4562,17 @@ declare namespace math {
      * x^root = A For matrices, the function is evaluated element wise.
      * @param root The root. Default value: 2.
      */
-    nthRoot(this: MathJsChain<unknown>, root?: number | BigNumber): MathJsChain<unknown>
-    // nthRoot(
-    //   a: number | BigNumber | MathCollection | Complex,
-    //   root?: number | BigNumber
-    // ): number | Complex | MathCollection
+    nthRoot(
+      this: MathJsChain<number | BigNumber | MathCollection | Complex>,
+      root?: number | BigNumber
+    ): MathJsChain<number | Complex | MathCollection>
 
     /**
      * Calculates the power of x to y, x ^ y. Matrix exponentiation is
      * supported for square matrices x, and positive integer exponents y.
      * @param y The exponent
      */
-    pow(this: MathJsChain<unknown>, y: number | BigNumber): MathJsChain<unknown>
-    // pow(x: MathType, y: number | BigNumber | Complex): MathType
+    pow(this: MathJsChain<MathType>, y: number | BigNumber | Complex): MathJsChain<MathType>
 
     /**
      * Compute the sign of a value. The sign of a value x is: 1 when x > 1
@@ -4587,48 +4581,46 @@ declare namespace math {
      * @param x The number for which to determine the sign
      * @returns The sign of x
      */
-    sign(this: MathJsChain<unknown>, x: number | BigNumber): MathJsChain<unknown>
-    // sign(x: number): number
-    // sign(x: BigNumber): BigNumber
-    // sign(x: Fraction): Fraction
-    // sign(x: Complex): Complex
-    // sign(x: MathArray): MathArray
-    // sign(x: Matrix): Matrix
-    // sign(x: Unit): Unit
+    sign(this: MathJsChain<number>): MathJsChain<number>
+    sign(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    sign(this: MathJsChain<Fraction>): MathJsChain<Fraction>
+    sign(this: MathJsChain<Complex>): MathJsChain<Complex>
+    sign(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    sign(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    sign(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Calculate the square root of a value. For matrices, the function is
      * evaluated element wise.
      */
-    sqrt(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // sqrt(x: number): number
-    // sqrt(x: BigNumber): BigNumber
-    // sqrt(x: Complex): Complex
-    // sqrt(x: MathArray): MathArray
-    // sqrt(x: Matrix): Matrix
-    // sqrt(x: Unit): Unit
+
+    sqrt(this: MathJsChain<number>): MathJsChain<number>
+    sqrt(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    sqrt(this: MathJsChain<Complex>): MathJsChain<Complex>
+    sqrt(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    sqrt(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    sqrt(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Compute the square of a value, x * x. For matrices, the function is
      * evaluated element wise.
      */
-    square(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // square(x: number): number
-    // square(x: BigNumber): BigNumber
-    // square(x: Fraction): Fraction
-    // square(x: Complex): Complex
-    // square(x: MathArray): MathArray
-    // square(x: Matrix): Matrix
-    // square(x: Unit): Unit
+
+    square(this: MathJsChain<number>): MathJsChain<number>
+    square(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    square(this: MathJsChain<Fraction>): MathJsChain<Fraction>
+    square(this: MathJsChain<Complex>): MathJsChain<Complex>
+    square(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    square(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    square(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Subtract two values, x - y. For matrices, the function is evaluated
      * element wise.
      * @param y Value to subtract from x
      */
-    // subtract(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
-    subtract<T extends MathType>(x: T, y: T): T
-    // subtract(x: MathType, y: MathType): MathType
+    subtract<T extends MathType>(this: MathJsChain<T>, y: T): MathJsChain<T>
+    subtract(this: MathJsChain<MathType>, y: MathType): MathJsChain<MathType>
 
     /**
      * Inverse the sign of a value, apply a unary minus operation. For
@@ -4636,37 +4628,36 @@ declare namespace math {
      * strings will be converted to a number. For complex numbers, both real
      * and complex value are inverted.
      */
-    unaryMinus(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // unaryMinus(x: number): number
-    // unaryMinus(x: BigNumber): BigNumber
-    // unaryMinus(x: Fraction): Fraction
-    // unaryMinus(x: Complex): Complex
-    // unaryMinus(x: MathArray): MathArray
-    // unaryMinus(x: Matrix): Matrix
-    // unaryMinus(x: Unit): Unit
+
+    unaryMinus(this: MathJsChain<number>): MathJsChain<number>
+    unaryMinus(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    unaryMinus(this: MathJsChain<Fraction>): MathJsChain<Fraction>
+    unaryMinus(this: MathJsChain<Complex>): MathJsChain<Complex>
+    unaryMinus(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    unaryMinus(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    unaryMinus(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Unary plus operation. Boolean values and strings will be converted to
      * a number, numeric values will be returned as is. For matrices, the
      * function is evaluated element wise.
      */
-    unaryPlus(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // unaryPlus(x: number): number
-    // unaryPlus(x: BigNumber): BigNumber
-    // unaryPlus(x: Fraction): Fraction
-    // unaryPlus(x: string): string
-    // unaryPlus(x: Complex): Complex
-    // unaryPlus(x: MathArray): MathArray
-    // unaryPlus(x: Matrix): Matrix
-    // unaryPlus(x: Unit): Unit
+
+    unaryPlus(this: MathJsChain<number>): MathJsChain<number>
+    unaryPlus(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    unaryPlus(this: MathJsChain<Fraction>): MathJsChain<Fraction>
+    unaryPlus(this: MathJsChain<string>): MathJsChain<string>
+    unaryPlus(this: MathJsChain<Complex>): MathJsChain<Complex>
+    unaryPlus(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    unaryPlus(this: MathJsChain<Matrix>): MathJsChain<Matrix>
+    unaryPlus(this: MathJsChain<Unit>): MathJsChain<Unit>
 
     /**
      * Calculate the extended greatest common divisor for two values. See
      * http://en.wikipedia.org/wiki/Extended_Euclidean_algorithm.
      * @param b An integer number
      */
-    xgcd(this: MathJsChain<unknown>, b: number | BigNumber): MathJsChain<unknown>
-    // xgcd(a: number | BigNumber, b: number | BigNumber): MathArray
+    xgcd(this: MathJsChain<number | BigNumber>, b: number | BigNumber): MathJsChain<MathArray>
 
     /*************************************************************************
      * Bitwise functions
@@ -4677,22 +4668,21 @@ declare namespace math {
      * evaluated element wise.
      * @param y Second value to and
      */
-    bitAnd(this: MathJsChain<unknown>, y: number | BigNumber | MathCollection): MathJsChain<unknown>
-    // bitAnd<T extends number | BigNumber | MathCollection>(
-    //   x: T,
-    //   y: number | BigNumber | MathCollection
-    // ): NoLiteralType<T>
+    bitAnd<T extends number | BigNumber | MathCollection>(
+      this: MathJsChain<T>,
+      y: number | BigNumber | MathCollection
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Bitwise NOT value, ~x. For matrices, the function is evaluated
      * element wise. For units, the function is evaluated on the best prefix
      * base.
      */
-    bitNot(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // bitNot(x: number): number
-    // bitNot(x: BigNumber): BigNumber
-    // bitNot(x: MathArray): MathArray
-    // bitNot(x: Matrix): Matrix
+
+    bitNot(this: MathJsChain<number>): MathJsChain<number>
+    bitNot(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    bitNot(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    bitNot(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Bitwise OR two values, x | y. For matrices, the function is evaluated
@@ -4700,22 +4690,20 @@ declare namespace math {
      * print base.
      * @param y Second value to or
      */
-    bitOr(this: MathJsChain<unknown>, y: number | BigNumber | MathCollection): MathJsChain<unknown>
-    // bitOr(x: number, y: number): number
-    // bitOr(x: BigNumber, y: BigNumber): BigNumber
-    // bitOr(x: MathArray, y: MathArray): MathArray
-    // bitOr(x: Matrix, y: Matrix): Matrix
+    bitOr(this: MathJsChain<number>, y: number): MathJsChain<number>
+    bitOr(this: MathJsChain<BigNumber>, y: BigNumber): MathJsChain<BigNumber>
+    bitOr(this: MathJsChain<MathArray>, y: MathArray): MathJsChain<MathArray>
+    bitOr(this: MathJsChain<Matrix>, y: Matrix): MathJsChain<Matrix>
 
     /**
      * Bitwise XOR two values, x ^ y. For matrices, the function is
      * evaluated element wise.
      * @param y Second value to xor
      */
-    bitXor(this: MathJsChain<unknown>, y: number | BigNumber | MathCollection): MathJsChain<unknown>
-    // bitXor<T extends number | BigNumber | MathCollection>(
-    //   x: T,
-    //   y: number | BigNumber | MathCollection
-    // ): NoLiteralType<T>
+    bitXor<T extends number | BigNumber | MathCollection>(
+      this: MathJsChain<T>,
+      y: number | BigNumber | MathCollection
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Bitwise left logical shift of a value x by y number of bits, x << y.
@@ -4723,11 +4711,10 @@ declare namespace math {
      * function is evaluated on the best prefix base.
      * @param y Amount of shifts
      */
-    leftShift(this: MathJsChain<unknown>, y: number | BigNumber): MathJsChain<unknown>
-    // leftShift<T extends number | BigNumber | MathCollection>(
-    //   x: T,
-    //   y: number | BigNumber
-    // ): NoLiteralType<T>
+    leftShift<T extends number | BigNumber | MathCollection>(
+      this: MathJsChain<T>,
+      y: number | BigNumber
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Bitwise right arithmetic shift of a value x by y number of bits, x >>
@@ -4735,11 +4722,10 @@ declare namespace math {
      * the function is evaluated on the best prefix base.
      * @param y Amount of shifts
      */
-    rightArithShift(this: MathJsChain<unknown>, y: number | BigNumber): MathJsChain<unknown>
-    // rightArithShift<T extends number | BigNumber | MathCollection>(
-    //   x: T,
-    //   y: number | BigNumber
-    // ): NoLiteralType<T>
+    rightArithShift<T extends number | BigNumber | MathCollection>(
+      this: MathJsChain<T>,
+      y: number | BigNumber
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Bitwise right logical shift of value x by y number of bits, x >>> y.
@@ -4747,11 +4733,10 @@ declare namespace math {
      * function is evaluated on the best prefix base.
      * @param y Amount of shifts
      */
-    rightLogShift(this: MathJsChain<unknown>, y: number): MathJsChain<unknown>
-    // rightLogShift<T extends number | MathCollection>(
-    //   x: T,
-    //   y: number
-    // ): NoLiteralType<T>
+    rightLogShift<T extends number | MathCollection>(
+      this: MathJsChain<T>,
+      y: number
+    ): MathJsChain<NoLiteralType<T>>
 
     /*************************************************************************
      * Combinatorics functions
@@ -4763,29 +4748,28 @@ declare namespace math {
      * takes integer arguments. The following condition must be enforced: n
      * >= 0
      */
-    bellNumbers(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // bellNumbers(n: number): number
-    // bellNumbers(n: BigNumber): BigNumber
+
+    bellNumbers(this: MathJsChain<number>): MathJsChain<number>
+    bellNumbers(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
 
     /**
      * The Catalan Numbers enumerate combinatorial structures of many
      * different types. catalan only takes integer arguments. The following
      * condition must be enforced: n >= 0
      */
-    catalan(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // catalan(n: number): number
-    // catalan(n: BigNumber): BigNumber
+
+    catalan(this: MathJsChain<number>): MathJsChain<number>
+    catalan(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
 
     /**
      * The composition counts of n into k parts. Composition only takes
      * integer arguments. The following condition must be enforced: k <= n.
      * @param k Number of objects in the subset
      */
-    composition(this: MathJsChain<unknown>, k: number | BigNumber): MathJsChain<unknown>
-    // composition<T extends number | BigNumber>(
-    //   n: T,
-    //   k: number | BigNumber
-    // ): NoLiteralType<T>
+    composition<T extends number | BigNumber>(
+      this: MathJsChain<T>,
+      k: number | BigNumber
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * The Stirling numbers of the second kind, counts the number of ways to
@@ -4795,11 +4779,10 @@ declare namespace math {
      * 1
      * @param k Number of objects in the subset
      */
-    stirlingS2(this: MathJsChain<unknown>, k: number | BigNumber): MathJsChain<unknown>
-    // stirlingS2<T extends number | BigNumber>(
-    //   n: T,
-    //   k: number | BigNumber
-    // ): NoLiteralType<T>
+    stirlingS2<T extends number | BigNumber>(
+      this: MathJsChain<T>,
+      k: number | BigNumber
+    ): MathJsChain<NoLiteralType<T>>
 
     /*************************************************************************
      * Complex functions
@@ -4810,41 +4793,38 @@ declare namespace math {
      * the argument is computed as atan2(b, a). For matrices, the function
      * is evaluated element wise.
      */
-    arg(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // arg(x: number | Complex): number
-    // arg(x: BigNumber | Complex): BigNumber
-    // arg(x: MathArray): MathArray
-    // arg(x: Matrix): Matrix
+
+    arg(this: MathJsChain<number | Complex>): MathJsChain<number>
+    arg(this: MathJsChain<BigNumber | Complex>): MathJsChain<BigNumber>
+    arg(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    arg(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Compute the complex conjugate of a complex value. If x = a+bi, the
      * complex conjugate of x is a - bi. For matrices, the function is
      * evaluated element wise.
      */
-    conj(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // conj<T extends number | BigNumber | Complex | MathCollection>(
-    //   x: T
-    // ): NoLiteralType<T>
+    conj<T extends number | BigNumber | Complex | MathCollection>(
+      this: MathJsChain<T>
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Get the imaginary part of a complex number. For a complex number a +
      * bi, the function returns b. For matrices, the function is evaluated
      * element wise.
      */
-    im(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // im(
-    //   x: number | BigNumber | Complex | MathCollection
-    // ): number | BigNumber | MathCollection
+    im(
+      this: MathJsChain<number | BigNumber | Complex | MathCollection>
+    ): MathJsChain<number | BigNumber | MathCollection>
 
     /**
      * Get the real part of a complex number. For a complex number a + bi,
      * the function returns a. For matrices, the function is evaluated
      * element wise.
      */
-    re(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // re(
-    //   x: number | BigNumber | Complex | MathCollection
-    // ): number | BigNumber | MathCollection
+    re(
+      x: MathJsChain<number | BigNumber | Complex | MathCollection>
+    ): MathJsChain<number | BigNumber | MathCollection>
 
     /*************************************************************************
      * Geometry functions
@@ -4860,11 +4840,10 @@ declare namespace math {
      * c)
      * @param y Coordinates of the second point
      */
-    distance(this: MathJsChain<unknown>, y: MathCollection | object): MathJsChain<unknown>
-    // distance(
-    //   x: MathCollection | object,
-    //   y: MathCollection | object
-    // ): number | BigNumber
+    distance(
+      this: MathJsChain<MathCollection | object>,
+      y: MathCollection | object
+    ): MathJsChain<number | BigNumber>
 
     /**
      * Calculates the point of intersection of two lines in two or three
@@ -4880,17 +4859,11 @@ declare namespace math {
      * the calculation is for line and plane
      */
     intersect(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<MathCollection>,
       x: MathCollection,
       y: MathCollection,
       z: MathCollection
-    ): MathJsChain<unknown>
-    // intersect(
-    //   w: MathCollection,
-    //   x: MathCollection,
-    //   y: MathCollection,
-    //   z: MathCollection
-    // ): MathArray
+    ): MathJsChain<MathArray>
 
     /*************************************************************************
      * Logical functions
@@ -4902,20 +4875,18 @@ declare namespace math {
      * element wise.
      * @param y Second value to and
      */
-    and(this: MathJsChain<unknown>, y: number | BigNumber | Complex | Unit | MathCollection): MathJsChain<unknown>
-    // and(
-    //   x: number | BigNumber | Complex | Unit | MathCollection,
-    //   y: number | BigNumber | Complex | Unit | MathCollection
-    // ): boolean | MathCollection
+    and(
+      this: MathJsChain<number | BigNumber | Complex | Unit | MathCollection>,
+      y: number | BigNumber | Complex | Unit | MathCollection
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Logical not. Flips boolean value of a given parameter. For matrices,
      * the function is evaluated element wise.
      */
-    not(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // not(
-    //   x: number | BigNumber | Complex | Unit | MathCollection
-    // ): boolean | MathCollection
+    not(
+      this: MathJsChain<number | BigNumber | Complex | Unit | MathCollection>
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Logical or. Test if at least one value is defined with a
@@ -4923,11 +4894,10 @@ declare namespace math {
      * element wise.
      * @param y Second value to or
      */
-    or(this: MathJsChain<unknown>, y: number | BigNumber | Complex | Unit | MathCollection): MathJsChain<unknown>
-    // or(
-    //   x: number | BigNumber | Complex | Unit | MathCollection,
-    //   y: number | BigNumber | Complex | Unit | MathCollection
-    // ): boolean | MathCollection
+    or(
+      this: MathJsChain<number | BigNumber | Complex | Unit | MathCollection>,
+      y: number | BigNumber | Complex | Unit | MathCollection
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Logical xor. Test whether one and only one value is defined with a
@@ -4935,11 +4905,10 @@ declare namespace math {
      * element wise.
      * @param y Second value to xor
      */
-    xor(this: MathJsChain<unknown>, y: number | BigNumber | Complex | Unit | MathCollection): MathJsChain<unknown>
-    // xor(
-    //   x: number | BigNumber | Complex | Unit | MathCollection,
-    //   y: number | BigNumber | Complex | Unit | MathCollection
-    // ): boolean | MathCollection
+    xor(
+      this: MathJsChain<number | BigNumber | Complex | Unit | MathCollection>,
+      y: number | BigNumber | Complex | Unit | MathCollection
+    ): MathJsChain<boolean | MathCollection>
 
     /*************************************************************************
      * Matrix functions
@@ -4950,8 +4919,8 @@ declare namespace math {
      * dimension over which to concatenate the matrices. By default the last
      * dimension of the matrices.
      */
-    concat(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // concat(...args: Array<MathCollection | number | BigNumber>): MathCollection
+
+    concat(this: MathJsChain<Array<MathCollection | number | BigNumber>>): MathJsChain<MathCollection>
 
     /**
      * Calculate the cross product for two vectors in three dimensional
@@ -4960,14 +4929,13 @@ declare namespace math {
      * * b2 - a2 * b1 ]
      * @param y Second vector
      */
-    cross(this: MathJsChain<unknown>, y: MathCollection): MathJsChain<unknown>
-    // cross(x: MathCollection, y: MathCollection): Matrix | MathArray
+    cross(this: MathJsChain<MathCollection>, y: MathCollection): MathJsChain<Matrix | MathArray>
 
     /**
      * Calculate the determinant of a matrix.
      */
-    det(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // det(x: MathCollection): number
+
+    det(this: MathJsChain<MathCollection>): MathJsChain<number>
 
     /**
      * Create a diagonal matrix or retrieve the diagonal of a matrix. When x
@@ -4980,15 +4948,12 @@ declare namespace math {
      * retrieved. Default value: 0.
      * @param format The matrix storage format. Default value: 'dense'.
      */
-    diag(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
-    diag(this: MathJsChain<unknown>, k: number | BigNumber, format?: string): MathJsChain<unknown>
-
-    // diag(X: MathCollection, format?: string): Matrix
-    // diag(
-    //   X: MathCollection,
-    //   k: number | BigNumber,
-    //   format?: string
-    // ): Matrix | MathArray
+    diag(this: MathJsChain<MathCollection>, format?: string): MathJsChain<Matrix>
+    diag(
+      this: MathJsChain<MathCollection>,
+      k: number | BigNumber,
+      format?: string
+    ): MathJsChain<Matrix | MathArray>
 
     /**
      * Calculate the dot product of two vectors. The dot product of A = [a1,
@@ -4996,8 +4961,7 @@ declare namespace math {
      * B) = a1 * b1 + a2 * b2 + a3 * b3 + ... + an * bn
      * @param y Second vector
      */
-    dot(this: MathJsChain<unknown>, y: MathCollection): MathJsChain<unknown>
-    // dot(x: MathCollection, y: MathCollection): number
+    dot(this: MathJsChain<MathCollection>, y: MathCollection): MathJsChain<number>
 
     /**
      * Compute the matrix exponential, expm(A) = e^A. The matrix must be
@@ -5006,81 +4970,68 @@ declare namespace math {
      * approximant with scaling and squaring; see “Nineteen Dubious Ways to
      * Compute the Exponential of a Matrix,” by Moler and Van Loan.
      */
-    expm(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // expm(x: Matrix): Matrix
+
+    expm(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Create a 2-dimensional identity matrix with size m x n or n x n. The
      * matrix has ones on the diagonal and zeros elsewhere.
      * @param format The Matrix storage format
      */
-    identity(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
-    // identity(
-    //   size: number | number[] | Matrix | MathArray,
-    //   format?: string
-    // ): Matrix | MathArray | number
+    identity(
+      this: MathJsChain<number | number[] | Matrix | MathArray>,
+      format?: string
+    ): MathJsChain<Matrix | MathArray | number>
 
     /**
      * @param n The y dimension for the matrix
      * @param format The Matrix storage format
      */
-    identity(this: MathJsChain<unknown>, n: number, format?: string): MathJsChain<unknown>
-    // identity(m: number, n: number, format?: string): Matrix | MathArray | number
+    identity(this: MathJsChain<number>, n: number, format?: string): MathJsChain<Matrix | MathArray | number>
 
     /**
      * Filter the items in an array or one dimensional matrix.
      */
     filter(
-      this: MathJsChain<unknown>,
-      test: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ((value: any, index: any, matrix: Matrix | MathArray) => boolean) | RegExp
-    ): MathJsChain<unknown>
-    // filter(
-    //   x: Matrix | MathArray | string[],
-    //   test:
-    //     | ((
-    //         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //         value: any,
-    //         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //         index: any,
-    //         matrix: Matrix | MathArray | string[]
-    //       ) => boolean)
-    //     | RegExp
-    // ): Matrix | MathArray
+      this: MathJsChain<Matrix | MathArray | string[]>,
+      test:
+        | ((
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            value: any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            index: any,
+            matrix: Matrix | MathArray | string[]
+          ) => boolean)
+        | RegExp
+    ): MathJsChain<Matrix | MathArray>
 
     /**
      * Flatten a multi dimensional matrix into a single dimensional matrix.
      */
-    flatten(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // flatten<T extends MathCollection>(x: T): T
+
+    flatten<T extends MathCollection>(x: MathJsChain<T>): MathJsChain<T>
 
     /**
      * Iterate over all elements of a matrix/array, and executes the given
      * callback function.
      */
-    forEach(
-      this: MathJsChain<unknown>,
+    forEach<T extends Matrix | MathArray>(
+      this: MathJsChain<T>,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      callback: (value: any, index: any, matrix: Matrix | MathArray) => void
-    ): MathJsChain<unknown>
-    // forEach<T extends Matrix | MathArray>(
-    //   x: T,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   callback: (value: any, index: any, matrix: T) => void
-    // ): void
+      callback: (value: any, index: any, matrix: T) => void
+    ): MathJsChain<T>
 
     /**
      * Calculate the inverse of a square matrix.
      */
-    inv(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // inv<T extends number | Complex | MathCollection>(x: T): NoLiteralType<T>
+
+    inv<T extends number | Complex | MathCollection>(this: MathJsChain<T>): MathJsChain<NoLiteralType<T>>
 
     /**
      * Calculate the kronecker product of two matrices or vectors
      * @param y Second vector
      */
-    kron(this: MathJsChain<unknown>, y: Matrix | MathArray): MathJsChain<unknown>
-    // kron(x: Matrix | MathArray, y: Matrix | MathArray): Matrix
+    kron(this: MathJsChain<Matrix | MathArray>, y: Matrix | MathArray): MathJsChain<Matrix>
 
     /**
      * Iterate over all elements of a matrix/array, and executes the given
@@ -5089,35 +5040,23 @@ declare namespace math {
      * parameters: the value of the element, the index of the element, and
      * the Matrix/array being traversed.
      */
-    map(
-      this: MathJsChain<unknown>,
-      callback: (
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: any,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        index: any,
-        matrix: Matrix | MathArray
-      ) => Matrix | MathArray
-    ): MathJsChain<unknown>
-    // map<T extends Matrix | MathArray>(
-    //   x: T,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   callback: (value: any, index: any, matrix: T) => MathType | string
-    // ): T
+    map<T extends Matrix | MathArray>(
+      this: MathJsChain<T>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      callback: (value: any, index: any, matrix: T) => MathType | string
+    ): MathJsChain<T>
 
     /**
      * Create a matrix filled with ones. The created matrix can have one or
      * multiple dimensions.
      * @param format The matrix storage format
      */
-    ones(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
-    // ones(size: number | number[], format?: string): MathCollection
+    ones(this: MathJsChain<number | number[]>, format?: string): MathJsChain<MathCollection>
 
     /**
      * @param format The matrix storage format
      */
-    ones(this: MathJsChain<unknown>, n: number, format?: string): MathJsChain<unknown>
-    // ones(m: number, n: number, format?: string): MathCollection
+    ones(this: MathJsChain<number>, n: number, format?: string): MathJsChain<MathCollection>
 
     /**
      * Partition-based selection of an array or 1D matrix. Will find the kth
@@ -5128,18 +5067,12 @@ declare namespace math {
      * and 0 when a == b. Default value: 'asc'.
      */
     partitionSelect(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<MathCollection>,
       k: number,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compare?: 'asc' | 'desc' | ((a: any, b: any) => number)
-    ): MathJsChain<unknown>
-    // partitionSelect(
-    //   x: MathCollection,
-    //   k: number,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   compare?: 'asc' | 'desc' | ((a: any, b: any) => number)
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // ): any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): MathJsChain<MathCollection>
 
     /**
      * Create an array from a range. By default, the range end is excluded.
@@ -5150,35 +5083,25 @@ declare namespace math {
      * @param includeEnd: Option to specify whether to include the end or
      * not. False by default
      */
-    range(includeEnd?: boolean): Matrix
-    range(this: MathJsChain<unknown>, end: number | BigNumber, includeEnd?: boolean): MathJsChain<unknown>
-    range(
-      this: MathJsChain<unknown>,
-      end: number | BigNumber,
-      step: number | BigNumber,
-      includeEnd?: boolean
-    ): MathJsChain<unknown>
-
-    // range(str: string, includeEnd?: boolean): Matrix
-    // range(
-    //   start: number | BigNumber,
-    //   end: number | BigNumber,
-    //   includeEnd?: boolean
-    // ): Matrix
-    // range(
-    //   start: number | BigNumber,
-    //   end: number | BigNumber,
-    //   step: number | BigNumber,
-    //   includeEnd?: boolean
-    // ): Matrix
+     range(this: MathJsChain<string>, includeEnd?: boolean): MathJsChain<Matrix>
+     range(
+       this: MathJsChain<number | BigNumber>,
+       end: number | BigNumber,
+       includeEnd?: boolean
+     ): MathJsChain<Matrix>
+     range(
+       this: MathJsChain<number | BigNumber>,
+       end: number | BigNumber,
+       step: number | BigNumber,
+       includeEnd?: boolean
+     ): MathJsChain<Matrix>
 
     /**
      * Reshape a multi dimensional array to fit the specified dimensions
      * @param sizes One dimensional array with integral sizes for each
      * dimension
      */
-    reshape(this: MathJsChain<unknown>, sizes: number[]): MathJsChain<unknown>
-    // reshape<T extends MathCollection>(x: T, sizes: number[]): T
+    reshape<T extends MathCollection>(this: MathJsChain<T>, sizes: number[]): MathJsChain<T>
 
     /**
      * Resize a matrix
@@ -5186,20 +5109,18 @@ declare namespace math {
      * @param defaultValue Zero by default, except in case of a string, in
      * that case defaultValue = ' ' Default value: 0.
      */
-    resize(this: MathJsChain<unknown>, size: MathCollection, defaultValue?: number | string): MathJsChain<unknown>
-    // resize<T extends MathCollection>(
-    //   x: T,
-    //   size: MathCollection,
-    //   defaultValue?: number | string
-    // ): T
+    resize<T extends MathCollection>(
+      this: MathJsChain<T>,
+      size: MathCollection,
+      defaultValue?: number | string
+    ): MathJsChain<T>
 
     /**
      * Calculate the size of a matrix or scalar.
      */
-    size(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // size(
-    //   x: boolean | number | Complex | Unit | string | MathCollection
-    // ): MathCollection
+    size(
+      this: MathJsChain<boolean | number | Complex | Unit | string | MathCollection>
+    ): MathJsChain<MathCollection>
 
     /**
      * Sort the items in a matrix
@@ -5207,31 +5128,25 @@ declare namespace math {
      * is called as compare(a, b), and must return 1 when a > b, -1 when a <
      * b, and 0 when a == b. Default value: ‘asc’
      */
-    sort(
-      this: MathJsChain<unknown>,
+    sort<T extends Matrix | MathArray>(
+      this: MathJsChain<T>,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compare: ((a: any, b: any) => number) | 'asc' | 'desc' | 'natural'
-    ): MathJsChain<unknown>
-
-    // sort<T extends Matrix | MathArray>(
-    //   x: T,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   compare: ((a: any, b: any) => number) | 'asc' | 'desc' | 'natural'
-    // ): T
+    ): MathJsChain<T>
 
     /**
      * Calculate the principal square root of a square matrix. The principal
      * square root matrix X of another matrix A is such that X * X = A.
      */
-    sqrtm(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // sqrtm<T extends MathCollection>(A: T): T
+
+    sqrtm<T extends MathCollection>(A: MathJsChain<T>): MathJsChain<T>
 
     /**
      * Squeeze a matrix, remove inner and outer singleton dimensions from a
      * matrix.
      */
-    squeeze(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // squeeze<T extends MathCollection>(x: T): T
+
+    squeeze<T extends MathCollection>(x: MathJsChain<T>): MathJsChain<T>
 
     /**
      * Get or set a subset of a matrix or string.
@@ -5244,29 +5159,28 @@ declare namespace math {
      * undefined. Default value: undefined.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    subset(this: MathJsChain<unknown>, index: Index, replacement?: any, defaultValue?: any): MathJsChain<unknown>
-    // subset<T extends MathCollection | string>(
-    //   value: T,
-    //   index: Index,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   replacement?: any,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   defaultValue?: any
-    // ): T
+    subset<T extends MathCollection | string>(
+      this: MathJsChain<T>,
+      index: Index,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      replacement?: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      defaultValue?: any
+    ):  MathJsChain<T>
 
     /**
      * Calculate the trace of a matrix: the sum of the elements on the main
      * diagonal of a square matrix.
      */
-    trace(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // trace(x: MathCollection): number
+
+    trace(this: MathJsChain<MathCollection>): MathJsChain<number>
 
     /**
      * Transpose a matrix. All values of the matrix are reflected over its
      * main diagonal. Only two dimensional matrices are supported.
      */
-    transpose(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // transpose<T extends MathCollection>(x: T): T
+
+    transpose<T extends MathCollection>(x: MathJsChain<T>): MathJsChain<T>
 
     /**
      * Create a matrix filled with zeros. The created matrix can have one or
@@ -5274,15 +5188,13 @@ declare namespace math {
      * @param format The matrix storage format
      * @returns A matrix filled with zeros
      */
-    zeros(this: MathJsChain<unknown>, format?: string): MathJsChain<unknown>
-    // zeros(size: number | number[], format?: string): MathCollection
+    zeros(this: MathJsChain<number | number[]>, format?: string): MathJsChain<MathCollection>
 
     /**
      * @param n The y dimension of the matrix
      * @param format The matrix storage format
      */
-    zeros(this: MathJsChain<unknown>, n: number, format?: string): MathJsChain<unknown>
-    // zeros(m: number, n: number, format?: string): MathCollection
+    zeros(this: MathJsChain<number>, n: number, format?: string): MathJsChain<MathCollection>
 
     /*************************************************************************
      * Probability functions
@@ -5294,39 +5206,37 @@ declare namespace math {
      * following condition must be enforced: k <= n.
      * @param k Number of objects in the subset
      */
-    combinations(this: MathJsChain<unknown>, k: number | BigNumber): MathJsChain<unknown>
-    // combinations<T extends number | BigNumber>(
-    //   n: T,
-    //   k: number | BigNumber
-    // ): NoLiteralType<T>
+    combinations<T extends number | BigNumber>(
+      n: MathJsChain<T>,
+      k: number | BigNumber
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Compute the factorial of a value Factorial only supports an integer
      * value as argument. For matrices, the function is evaluated element
      * wise.
      */
-    factorial(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // factorial<T extends number | BigNumber | MathCollection>(
-    //   n: T
-    // ): NoLiteralType<T>
+
+    factorial<T extends number | BigNumber | MathCollection>(
+      n: MathJsChain<T>
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Compute the gamma function of a value using Lanczos approximation for
      * small values, and an extended Stirling approximation for large
      * values. For matrices, the function is evaluated element wise.
      */
-    gamma(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // gamma<T extends number | BigNumber | Complex | MathCollection>(
-    //   n: T
-    // ): NoLiteralType<T>
+
+    gamma<T extends number | BigNumber | Complex | MathCollection>(
+      n: MathJsChain<T>
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Calculate the Kullback-Leibler (KL) divergence between two
      * distributions
      * @param p Second vector
      */
-    kldivergence(this: MathJsChain<unknown>, p: MathCollection): MathJsChain<unknown>
-    // kldivergence(q: MathCollection, p: MathCollection): number
+    kldivergence(this: MathJsChain<MathCollection>, p: MathCollection): MathJsChain<number>
 
     /**
      * Multinomial Coefficients compute the number of ways of picking a1,
@@ -5334,8 +5244,8 @@ declare namespace math {
      * takes one array of integers as an argument. The following condition
      * must be enforced: every ai <= 0
      */
-    multinomial(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // multinomial<T extends number | BigNumber>(a: T[]): NoLiteralType<T>
+
+    multinomial<T extends number | BigNumber>(a: MathJsChain<T[]>): MathJsChain<NoLiteralType<T>>
 
     /**
      * Compute the number of ways of obtaining an ordered subset of k
@@ -5343,11 +5253,10 @@ declare namespace math {
      * arguments. The following condition must be enforced: k <= n.
      * @param k The number of objects in the subset
      */
-    permutations(this: MathJsChain<unknown>, k?: number | BigNumber): MathJsChain<unknown>
-    // permutations<T extends number | BigNumber>(
-    //   n: T,
-    //   k?: number | BigNumber
-    // ): NoLiteralType<T>
+    permutations<T extends number | BigNumber>(
+      n: MathJsChain<T>,
+      k?: number | BigNumber
+    ): MathJsChain<NoLiteralType<T>>
 
     /**
      * Random pick a value from a one dimensional array. Array element is
@@ -5355,12 +5264,11 @@ declare namespace math {
      * @param number An int or float
      * @param weights An array of ints or floats
      */
-    pickRandom(this: MathJsChain<unknown>, number?: number, weights?: number[]): MathJsChain<unknown>
-    // pickRandom(
-    //   array: number[],
-    //   number?: number,
-    //   weights?: number[]
-    // ): number | number[]
+    pickRandom(
+      array: MathJsChain<number[]>,
+      number?: number,
+      weights?: number[]
+    ): MathJsChain<number | number[]>
 
     /**
      * Return a random number larger or equal to min and smaller than max
@@ -5368,12 +5276,10 @@ declare namespace math {
      * @param min Minimum boundary for the random value, included
      * @param max Maximum boundary for the random value, excluded
      */
-    random(this: MathJsChain<unknown>, max?: number): MathJsChain<unknown>
-    // random(min?: number, max?: number): number
+    random(this: MathJsChain<number>, max?: number): MathJsChain<number>
 
     // tslint:disable-next-line unified-signatures
-    random(this: MathJsChain<unknown>, min: number, max: number): MathJsChain<unknown>
-    // random<T extends MathCollection>(size: T, min?: number, max?: number): T
+    random<T extends MathCollection>(this: MathJsChain<T>, min?: number, max?: number): MathJsChain<T>
 
     /**
      * Return a random integer number larger or equal to min and smaller
@@ -5381,11 +5287,10 @@ declare namespace math {
      * @param min Minimum boundary for the random value, included
      * @param max Maximum boundary for the random value, excluded
      */
-    randomInt(this: MathJsChain<unknown>, max?: number): MathJsChain<unknown>
-    // randomInt(min: number, max?: number): number
+    randomInt<T extends MathCollection>(this: MathJsChain<T>, max?: number): MathJsChain<T>
+    randomInt<T extends MathCollection>(this: MathJsChain<T>, max?: number): MathJsChain<T>
     // tslint:disable-next-line unified-signatures
-    randomInt(this: MathJsChain<unknown>, min: number, max: number): MathJsChain<unknown>
-    // randomInt<T extends MathCollection>(size: T, min?: number, max?: number): T
+    randomInt<T extends MathCollection>(this: MathJsChain<T>, min: number, max: number): MathJsChain<T>
 
     /*************************************************************************
      * Relational functions
@@ -5399,11 +5304,10 @@ declare namespace math {
      * For matrices, the function is evaluated element wise.
      * @param y Second value to compare
      */
-    compare(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // compare(
-    //   x: MathType | string,
-    //   y: MathType | string
-    // ): number | BigNumber | Fraction | MathCollection
+    compare(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<number | BigNumber | Fraction | MathCollection>
 
     /**
      * Compare two values of any type in a deterministic, natural way. For
@@ -5413,8 +5317,7 @@ declare namespace math {
      * @param y Second value to compare
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    compareNatural(this: MathJsChain<unknown>, y: any): MathJsChain<unknown>
-    // compareNatural(x: any, y: any): number
+    compareNatural(this: MathJsChain<any>, y: any): MathJsChain<number>
 
     /**
      * Compare two strings lexically. Comparison is case sensitive. Returns
@@ -5422,22 +5325,20 @@ declare namespace math {
      * function is evaluated element wise.
      * @param y Second string to compare
      */
-    compareText(this: MathJsChain<unknown>, y: string | MathCollection): MathJsChain<unknown>
-    // compareText(
-    //   x: string | MathCollection,
-    //   y: string | MathCollection
-    // ): number | MathCollection
+    compareText(
+      this: MathJsChain<string | MathCollection>,
+      y: string | MathCollection
+    ): MathJsChain<number | MathCollection>
 
     /**
      * Test element wise whether two matrices are equal. The function
      * accepts both matrices and scalar values.
      * @param y Second amtrix to compare
      */
-    deepEqual(this: MathJsChain<unknown>, y: MathType): MathJsChain<unknown>
-    // deepEqual(
-    //   x: MathType,
-    //   y: MathType
-    // ): number | BigNumber | Fraction | Complex | Unit | MathCollection
+    deepEqual(
+      this: MathJsChain<MathType>,
+      y: MathType
+    ): MathJsChain<number | BigNumber | Fraction | Complex | Unit | MathCollection>
 
     /**
      * Test whether two values are equal.
@@ -5451,19 +5352,17 @@ declare namespace math {
      * else, and undefined is only equal to undefined and nothing else.
      * @param y Second value to compare
      */
-    equal(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // equal(x: MathType | string, y: MathType | string): boolean | MathCollection
+    equal(this: MathJsChain<MathType | string>, y: MathType | string): MathJsChain<boolean | MathCollection>
 
     /**
      * Check equality of two strings. Comparison is case sensitive. For
      * matrices, the function is evaluated element wise.
      * @param y Second string to compare
      */
-    equalText(this: MathJsChain<unknown>, y: string | MathCollection): MathJsChain<unknown>
-    // equalText(
-    //   x: string | MathCollection,
-    //   y: string | MathCollection
-    // ): number | MathCollection
+    equalText(
+      this: MathJsChain<string | MathCollection>,
+      y: string | MathCollection
+    ): MathJsChain<number | MathCollection>
 
     /**
      * Test whether value x is larger than y. The function returns true when
@@ -5473,8 +5372,7 @@ declare namespace math {
      * function is evaluated element wise.
      * @param y Second value to compare
      */
-    larger(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // larger(x: MathType | string, y: MathType | string): boolean | MathCollection
+    larger(this: MathJsChain<MathType | string>, y: MathType | string): MathJsChain<boolean | MathCollection>
 
     /**
      * Test whether value x is larger or equal to y. The function returns
@@ -5484,11 +5382,10 @@ declare namespace math {
      * the function is evaluated element wise.
      * @param y Second value to vcompare
      */
-    largerEq(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // largerEq(
-    //   x: MathType | string,
-    //   y: MathType | string
-    // ): boolean | MathCollection
+    largerEq(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Test whether value x is smaller than y. The function returns true
@@ -5498,11 +5395,10 @@ declare namespace math {
      * the function is evaluated element wise.
      * @param y Second value to vcompare
      */
-    smaller(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // smaller(
-    //   x: MathType | string,
-    //   y: MathType | string
-    // ): boolean | MathCollection
+    smaller(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Test whether value x is smaller or equal to y. The function returns
@@ -5512,11 +5408,10 @@ declare namespace math {
      * matrices, the function is evaluated element wise.
      * @param y Second value to compare
      */
-    smallerEq(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // smallerEq(
-    //   x: MathType | string,
-    //   y: MathType | string
-    // ): boolean | MathCollection
+    smallerEq(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<boolean | MathCollection>
 
     /**
      * Test whether two values are unequal. The function tests whether the
@@ -5529,11 +5424,10 @@ declare namespace math {
      * undefined is unequal with everything except undefined.
      * @param y Second value to vcompare
      */
-    unequal(this: MathJsChain<unknown>, y: MathType | string): MathJsChain<unknown>
-    // unequal(
-    //   x: MathType | string,
-    //   y: MathType | string
-    // ): boolean | MathCollection
+    unequal(
+      this: MathJsChain<MathType | string>,
+      y: MathType | string
+    ): MathJsChain<boolean | MathCollection>
 
     /*************************************************************************
      * Set functions
@@ -5545,8 +5439,7 @@ declare namespace math {
      * will be sorted in ascending order before the operation.
      * @param a2 A (multi)set
      */
-    setCartesian(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
-    // setCartesian<T extends MathCollection>(a1: T, a2: MathCollection): T
+    setCartesian<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
 
     /**
      * Create the difference of two (multi)sets: every element of set1, that
@@ -5554,23 +5447,21 @@ declare namespace math {
      * to single-dimension arrays before the operation
      * @param a2 A (multi)set
      */
-    setDifference(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
-    // setDifference<T extends MathCollection>(a1: T, a2: MathCollection): T
+    setDifference<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
 
     /**
      * Collect the distinct elements of a multiset. A multi-dimension array
      * will be converted to a single-dimension array before the operation.
      */
-    setDistinct(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // setDistinct<T extends MathCollection>(a: T): T
+
+    setDistinct<T extends MathCollection>(a: MathJsChain<T>): MathJsChain<T>
 
     /**
      * Create the intersection of two (multi)sets. Multi-dimension arrays
      * will be converted to single-dimension arrays before the operation.
      * @param a2 A (multi)set
      */
-    setIntersect(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
-    // setIntersect<T extends MathCollection>(a1: T, a2: MathCollection): T
+    setIntersect<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
 
     /**
      * Check whether a (multi)set is a subset of another (multi)set. (Every
@@ -5578,8 +5469,7 @@ declare namespace math {
      * be converted to single-dimension arrays before the operation.
      * @param a2 A (multi)set
      */
-    setIsSubset(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
-    // setIsSubset(a1: MathCollection, a2: MathCollection): boolean
+    setIsSubset(this: MathJsChain<MathCollection>, a2: MathCollection): MathJsChain<boolean>
 
     /**
      * Count the multiplicity of an element in a multiset. A multi-dimension
@@ -5587,27 +5477,26 @@ declare namespace math {
      * operation.
      * @param a A multiset
      */
-    setMultiplicity(this: MathJsChain<unknown>, a: MathCollection): MathJsChain<unknown>
-    // setMultiplicity(
-    //   e: number | BigNumber | Fraction | Complex,
-    //   a: MathCollection
-    // ): number
+    setMultiplicity(
+      e: MathJsChain<number | BigNumber | Fraction | Complex>,
+      a: MathCollection
+    ): MathJsChain<number>
 
     /**
      * Create the powerset of a (multi)set. (The powerset contains very
      * possible subsets of a (multi)set.) A multi-dimension array will be
      * converted to a single-dimension array before the operation.
      */
-    setPowerset(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // setPowerset<T extends MathCollection>(a: T): T
+
+    setPowerset<T extends MathCollection>(a: MathJsChain<T>): MathJsChain<T>
 
     /**
      * Count the number of elements of a (multi)set. When a second parameter
      * is ‘true’, count only the unique values. A multi-dimension array will
      * be converted to a single-dimension array before the operation.
      */
-    setSize(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // setSize(a: MathCollection): number
+
+    setSize(this: MathJsChain<MathCollection>): MathJsChain<number>
 
     /**
      * Create the symmetric difference of two (multi)sets. Multi-dimension
@@ -5615,16 +5504,14 @@ declare namespace math {
      * operation.
      * @param a2 A (multi)set
      */
-    setSymDifference(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
-    // setSymDifference<T extends MathCollection>(a1: T, a2: MathCollection): T
+    setSymDifference<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
 
     /**
      * Create the union of two (multi)sets. Multi-dimension arrays will be
      * converted to single-dimension arrays before the operation.
      * @param a2 A (multi)set
      */
-    setUnion(this: MathJsChain<unknown>, a2: MathCollection): MathJsChain<unknown>
-    // setUnion<T extends MathCollection>(a1: T, a2: MathCollection): T
+    setUnion<T extends MathCollection>(this: MathJsChain<T>, a2: MathCollection): MathJsChain<T>
 
     /*************************************************************************
      * Special functions
@@ -5634,8 +5521,7 @@ declare namespace math {
      * Compute the erf function of a value using a rational Chebyshev
      * approximations for different intervals of x.
      */
-    erf(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // erf<T extends number | MathCollection>(x: T): NoLiteralType<T>
+    erf<T extends number | MathCollection>(this: MathJsChain<T>): MathJsChain<NoLiteralType<T>>
 
     /*************************************************************************
      * Statistics functions
@@ -5646,8 +5532,8 @@ declare namespace math {
      * values. The median absolute deviation is defined as the median of the
      * absolute deviations from the median.
      */
-    mad(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // mad(array: MathCollection): any
+
+    mad(this: MathJsChain<MathCollection>): MathJsChain<any>
 
     /**
      * Compute the maximum value of a matrix or a list with values. In case
@@ -5656,9 +5542,8 @@ declare namespace math {
      * dimension will be calculated. Parameter dim is zero-based.
      * @param dim The maximum over the selected dimension
      */
-    max(this: MathJsChain<unknown>, dim?: number): MathJsChain<unknown>
-    // max(...args: MathType[]): any
-    // max(A: MathCollection, dim?: number): any
+    max(this: MathJsChain<MathType[]>, dim?: number): MathJsChain<any>
+    max(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
      * Compute the mean value of matrix or a list with values. In case of a
@@ -5667,9 +5552,8 @@ declare namespace math {
      * dimension will be calculated. Parameter dim is zero-based.
      * @param dim The mean over the selected dimension
      */
-    mean(this: MathJsChain<unknown>, dim?: number): MathJsChain<unknown>
-    // mean(...args: MathType[]): any
-    // mean(A: MathCollection, dim?: number): any
+    mean(this: MathJsChain<MathType[]>, dim?: number): MathJsChain<any>
+    mean(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
      * Compute the median of a matrix or a list with values. The values are
@@ -5679,8 +5563,8 @@ declare namespace math {
      * dimensional) array or matrix, the median of all elements will be
      * calculated.
      */
-    median(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // median(...args: MathType[]): any
+    median(this: MathJsChain<MathType[]>, dim?: number): MathJsChain<any>
+    median(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
      * Compute the maximum value of a matrix or a list of values. In case of
@@ -5689,25 +5573,23 @@ declare namespace math {
      * dimension will be calculated. Parameter dim is zero-based.
      * @param dim The minimum over the selected dimension
      */
-    min(this: MathJsChain<unknown>, dim?: number): MathJsChain<unknown>
-    // min(...args: MathType[]): any
-    // min(A: MathCollection, dim?: number): any
+    min(this: MathJsChain<MathType[]>): MathJsChain<MathType[]>
+    min(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
      * Computes the mode of a set of numbers or a list with values(numbers
      * or characters). If there are more than one modes, it returns a list
      * of those values.
      */
-    mode(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // mode(...args: MathType[]): any
+
+    mode(this: MathJsChain<MathType[]>): MathJsChain<MathType[]>
 
     /**
      * Compute the product of a matrix or a list with values. In case of a
      * (multi dimensional) array or matrix, the sum of all elements will be
      * calculated.
      */
-    prod(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // prod(...args: MathType[]): any
+    prod(this: MathJsChain<MathType[]>): MathJsChain<any>
 
     /**
      * Compute the prob order quantile of a matrix or a list with values.
@@ -5722,15 +5604,10 @@ declare namespace math {
      * @param sorted =false is data sorted in ascending order
      */
     quantileSeq(
-      this: MathJsChain<unknown>,
+      A: MathJsChain<MathCollection>,
       prob: number | BigNumber | MathArray,
       sorted?: boolean
-    ): MathJsChain<unknown>
-    // quantileSeq(
-    //   A: MathCollection,
-    //   prob: number | BigNumber | MathArray,
-    //   sorted?: boolean
-    // ): number | BigNumber | Unit | MathArray
+    ): MathJsChain<number | BigNumber | Unit | MathArray>
 
     /**
      * Compute the standard deviation of a matrix or a list with values. The
@@ -5749,11 +5626,10 @@ declare namespace math {
      * @returns The standard deviation
      */
     std(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<number[]>,
       dim?: number,
       normalization?: 'unbiased' | 'uncorrected' | 'biased'
-    ): MathJsChain<unknown>
-    // std(...values: number[]): number
+    ): MathJsChain<number>
 
     /**
      * Compute the standard deviation of a matrix or a list with values. The
@@ -5770,23 +5646,21 @@ declare namespace math {
      * ‘unbiased’.
      * @returns The standard deviation
      */
-    std(this: MathJsChain<unknown>, normalization: 'unbiased' | 'uncorrected' | 'biased'): MathJsChain<unknown>
-    // std(
-    //   array: MathCollection,
-    //   dimension?: number,
-    //   normalization?: 'unbiased' | 'uncorrected' | 'biased'
-    // ): number[]
+    std(
+      this: MathJsChain<MathCollection>,
+      dimension?: number,
+      normalization?: 'unbiased' | 'uncorrected' | 'biased'
+    ): MathJsChain<number[]>
 
     /**
      * Compute the sum of a matrix or a list with values. In case of a
      * (multi dimensional) array or matrix, the sum of all elements will be
      * calculated.
      */
-    sum(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // std(
-    //   array: MathCollection,
-    //   normalization: 'unbiased' | 'uncorrected' | 'biased'
-    // ): number
+    std(
+      this: MathJsChain<MathCollection>,
+      normalization: 'unbiased' | 'uncorrected' | 'biased'
+    ): MathJsChain<number>
 
     /**
      * Compute the variance of a matrix or a list with values. In case of a
@@ -5806,11 +5680,10 @@ declare namespace math {
      * @returns The variance
      */
     variance(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<(number | BigNumber | Fraction)[]>,
       dim?: number,
       normalization?: 'unbiased' | 'uncorrected' | 'biased'
-    ): MathJsChain<unknown>
-    // variance(...args: Array<number | BigNumber | Fraction>): number
+    ): MathJsChain<number>
 
     /**
      * Compute the variance of a matrix or a list with values. In case of a
@@ -5828,12 +5701,7 @@ declare namespace math {
      * Default value: ‘unbiased’.
      * @returns The variance
      */
-    variance(this: MathJsChain<unknown>, normalization: 'unbiased' | 'uncorrected' | 'biased'): MathJsChain<unknown>
-    // variance(
-    //   array: MathCollection,
-    //   dimension?: number,
-    //   normalization?: 'unbiased' | 'uncorrected' | 'biased'
-    // ): number[]
+    variance(this: MathJsChain<MathCollection>, normalization: 'unbiased' | 'uncorrected' | 'biased'): MathJsChain<number[]>
 
     /*************************************************************************
      * String functions
@@ -5851,22 +5719,14 @@ declare namespace math {
      * @see http://mathjs.org/docs/reference/functions/format.html
      */
     format(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<any>,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       value: any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       options?: FormatOptions | number | ((item: any) => string),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       callback?: (value: any) => string
-    ): MathJsChain<unknown>
-    // format(
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   value: any,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   options?: FormatOptions | number | ((item: any) => string),
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   callback?: (value: any) => string
-    // ): string
+    ): MathJsChain<string>
 
     /**
      * Interpolate values into a string template.
@@ -5878,19 +5738,12 @@ declare namespace math {
      * numbers. See function math.format for a description of all options.
      */
     print(
-      this: MathJsChain<unknown>,
+      this: MathJsChain<string>,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       values: any,
       precision?: number,
       options?: number | object
-    ): MathJsChain<unknown>
-    // print(
-    //   template: string,
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   values: any,
-    //   precision?: number,
-    //   options?: number | object
-    // ): void
+    ): MathJsChain<string>
 
     /*************************************************************************
      * Trigonometry functions
@@ -5900,268 +5753,268 @@ declare namespace math {
      * Calculate the inverse cosine of a value. For matrices, the function
      * is evaluated element wise.
      */
-    acos(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // acos(x: number): number
-    // acos(x: BigNumber): BigNumber
-    // acos(x: Complex): Complex
-    // acos(x: MathArray): MathArray
-    // acos(x: Matrix): Matrix
+
+    acos(this: MathJsChain<number>): MathJsChain<number>
+    acos(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    acos(this: MathJsChain<Complex>): MathJsChain<Complex>
+    acos(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    acos(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic arccos of a value, defined as acosh(x) =
      * ln(sqrt(x^2 - 1) + x). For matrices, the function is evaluated
      * element wise.
      */
-    acosh(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // acosh(x: number): number
-    // acosh(x: BigNumber): BigNumber
-    // acosh(x: Complex): Complex
-    // acosh(x: MathArray): MathArray
-    // acosh(x: Matrix): Matrix
+
+    acosh(this: MathJsChain<number>): MathJsChain<number>
+    acosh(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    acosh(this: MathJsChain<Complex>): MathJsChain<Complex>
+    acosh(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    acosh(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the inverse cotangent of a value. For matrices, the
      * function is evaluated element wise.
      */
-    acot(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // acot(x: number): number
-    // acot(x: BigNumber): BigNumber
-    // acot(x: MathArray): MathArray
-    // acot(x: Matrix): Matrix
+
+    acot(this: MathJsChain<number>): MathJsChain<number>
+    acot(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    acot(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    acot(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic arccotangent of a value, defined as acoth(x)
      * = (ln((x+1)/x) + ln(x/(x-1))) / 2. For matrices, the function is
      * evaluated element wise.
      */
-    acoth(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // acoth(x: number): number
-    // acoth(x: BigNumber): BigNumber
-    // acoth(x: MathArray): MathArray
-    // acoth(x: Matrix): Matrix
+
+    acoth(this: MathJsChain<number>): MathJsChain<number>
+    acoth(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    acoth(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    acoth(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the inverse cosecant of a value. For matrices, the function
      * is evaluated element wise.
      */
-    acsc(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // acsc(x: number): number
-    // acsc(x: BigNumber): BigNumber
-    // acsc(x: MathArray): MathArray
-    // acsc(x: Matrix): Matrix
+
+    acsc(this: MathJsChain<number>): MathJsChain<number>
+    acsc(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    acsc(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    acsc(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic arccosecant of a value, defined as acsch(x)
      * = ln(1/x + sqrt(1/x^2 + 1)). For matrices, the function is evaluated
      * element wise.
      */
-    acsch(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // acsch(x: number): number
-    // acsch(x: BigNumber): BigNumber
-    // acsch(x: MathArray): MathArray
-    // acsch(x: Matrix): Matrix
+
+    acsch(this: MathJsChain<number>): MathJsChain<number>
+    acsch(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    acsch(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    acsch(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the inverse secant of a value. For matrices, the function
      * is evaluated element wise.
      */
-    asec(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // asec(x: number): number
-    // asec(x: BigNumber): BigNumber
-    // asec(x: MathArray): MathArray
-    // asec(x: Matrix): Matrix
+
+    asec(this: MathJsChain<number>): MathJsChain<number>
+    asec(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    asec(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    asec(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic arcsecant of a value, defined as asech(x) =
      * ln(sqrt(1/x^2 - 1) + 1/x). For matrices, the function is evaluated
      * element wise.
      */
-    asech(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // asech(x: number): number
-    // asech(x: BigNumber): BigNumber
-    // asech(x: MathArray): MathArray
-    // asech(x: Matrix): Matrix
+
+    asech(this: MathJsChain<number>): MathJsChain<number>
+    asech(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    asech(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    asech(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the inverse sine of a value. For matrices, the function is
      * evaluated element wise.
      */
-    asin(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // asin(x: number): number
-    // asin(x: BigNumber): BigNumber
-    // asin(x: Complex): Complex
-    // asin(x: MathArray): MathArray
-    // asin(x: Matrix): Matrix
+
+    asin(this: MathJsChain<number>): MathJsChain<number>
+    asin(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    asin(this: MathJsChain<Complex>): MathJsChain<Complex>
+    asin(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    asin(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic arcsine of a value, defined as asinh(x) =
      * ln(x + sqrt(x^2 + 1)). For matrices, the function is evaluated
      * element wise.
      */
-    asinh(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // asinh(x: number): number
-    // asinh(x: BigNumber): BigNumber
-    // asinh(x: MathArray): MathArray
-    // asinh(x: Matrix): Matrix
+
+    asinh(this: MathJsChain<number>): MathJsChain<number>
+    asinh(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    asinh(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    asinh(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the inverse tangent of a value. For matrices, the function
      * is evaluated element wise.
      */
-    atan(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // atan(x: number): number
-    // atan(x: BigNumber): BigNumber
-    // atan(x: MathArray): MathArray
-    // atan(x: Matrix): Matrix
+
+    atan(this: MathJsChain<number>): MathJsChain<number>
+    atan(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    atan(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    atan(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the inverse tangent function with two arguments, y/x. By
      * providing two arguments, the right quadrant of the computed angle can
      * be determined. For matrices, the function is evaluated element wise.
      */
-    atan2(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // atan2(y: number, x: number): number
-    // atan2(y: MathCollection, x: MathCollection): MathCollection
+
+    atan2(this: MathJsChain<number>, x: number): MathJsChain<number>
+    atan2(this: MathJsChain<MathCollection>, x: MathCollection): MathJsChain<MathCollection>
 
     /**
      * Calculate the hyperbolic arctangent of a value, defined as atanh(x) =
      * ln((1 + x)/(1 - x)) / 2. For matrices, the function is evaluated
      * element wise.
      */
-    atanh(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // atanh(x: number): number
-    // atanh(x: BigNumber): BigNumber
-    // atanh(x: MathArray): MathArray
-    // atanh(x: Matrix): Matrix
+
+    atanh(this: MathJsChain<number>): MathJsChain<number>
+    atanh(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    atanh(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    atanh(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the cosine of a value. For matrices, the function is
      * evaluated element wise.
      */
-    cos(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // cos(x: number | Unit): number
-    // cos(x: BigNumber): BigNumber
-    // cos(x: Complex): Complex
-    // cos(x: MathArray): MathArray
-    // cos(x: Matrix): Matrix
+
+    cos(this: MathJsChain<number | Unit>): MathJsChain<number>
+    cos(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    cos(this: MathJsChain<Complex>): MathJsChain<Complex>
+    cos(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    cos(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic cosine of a value, defined as cosh(x) = 1/2
      * * (exp(x) + exp(-x)). For matrices, the function is evaluated element
      * wise.
      */
-    cosh(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // cosh(x: number | Unit): number
-    // cosh(x: BigNumber): BigNumber
-    // cosh(x: Complex): Complex
-    // cosh(x: MathArray): MathArray
-    // cosh(x: Matrix): Matrix
+
+    cosh(this: MathJsChain<number | Unit>): MathJsChain<number>
+    cosh(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    cosh(this: MathJsChain<Complex>): MathJsChain<Complex>
+    cosh(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    cosh(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the cotangent of a value. cot(x) is defined as 1 / tan(x).
      * For matrices, the function is evaluated element wise.
      */
-    cot(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // cot(x: number | Unit): number
-    // cot(x: Complex): Complex
-    // cot(x: MathArray): MathArray
-    // cot(x: Matrix): Matrix
+
+    cot(this: MathJsChain<number | Unit>): MathJsChain<number>
+    cot(this: MathJsChain<Complex>): MathJsChain<Complex>
+    cot(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    cot(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic cotangent of a value, defined as coth(x) = 1
      * / tanh(x). For matrices, the function is evaluated element wise.
      */
-    coth(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // coth(x: number | Unit): number
-    // coth(x: Complex): Complex
-    // coth(x: MathArray): MathArray
-    // coth(x: Matrix): Matrix
+
+    coth(this: MathJsChain<number | Unit>): MathJsChain<number>
+    coth(this: MathJsChain<Complex>): MathJsChain<Complex>
+    coth(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    coth(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the cosecant of a value, defined as csc(x) = 1/sin(x). For
      * matrices, the function is evaluated element wise.
      */
-    csc(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // csc(x: number | Unit): number
-    // csc(x: Complex): Complex
-    // csc(x: MathArray): MathArray
-    // csc(x: Matrix): Matrix
+
+    csc(this: MathJsChain<number | Unit>): MathJsChain<number>
+    csc(this: MathJsChain<Complex>): MathJsChain<Complex>
+    csc(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    csc(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic cosecant of a value, defined as csch(x) = 1
      * / sinh(x). For matrices, the function is evaluated element wise.
      */
-    csch(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // csch(x: number | Unit): number
-    // csch(x: Complex): Complex
-    // csch(x: MathArray): MathArray
-    // csch(x: Matrix): Matrix
+
+    csch(this: MathJsChain<number | Unit>): MathJsChain<number>
+    csch(this: MathJsChain<Complex>): MathJsChain<Complex>
+    csch(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    csch(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the secant of a value, defined as sec(x) = 1/cos(x). For
      * matrices, the function is evaluated element wise.
      */
-    sec(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // sec(x: number | Unit): number
-    // sec(x: Complex): Complex
-    // sec(x: MathArray): MathArray
-    // sec(x: Matrix): Matrix
+
+    sec(this: MathJsChain<number | Unit>): MathJsChain<number>
+    sec(this: MathJsChain<Complex>): MathJsChain<Complex>
+    sec(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    sec(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic secant of a value, defined as sech(x) = 1 /
      * cosh(x). For matrices, the function is evaluated element wise.
      */
-    sech(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // sech(x: number | Unit): number
-    // sech(x: Complex): Complex
-    // sech(x: MathArray): MathArray
-    // sech(x: Matrix): Matrix
+
+    sech(this: MathJsChain<number | Unit>): MathJsChain<number>
+    sech(this: MathJsChain<Complex>): MathJsChain<Complex>
+    sech(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    sech(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the sine of a value. For matrices, the function is
      * evaluated element wise.
      */
-    sin(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // sin(x: number | Unit): number
-    // sin(x: BigNumber): BigNumber
-    // sin(x: Complex): Complex
-    // sin(x: MathArray): MathArray
-    // sin(x: Matrix): Matrix
+
+    sin(this: MathJsChain<number | Unit>): MathJsChain<number>
+    sin(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    sin(this: MathJsChain<Complex>): MathJsChain<Complex>
+    sin(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    sin(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic sine of a value, defined as sinh(x) = 1/2 *
      * (exp(x) - exp(-x)). For matrices, the function is evaluated element
      * wise.
      */
-    sinh(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // sinh(x: number | Unit): number
-    // sinh(x: BigNumber): BigNumber
-    // sinh(x: Complex): Complex
-    // sinh(x: MathArray): MathArray
-    // sinh(x: Matrix): Matrix
+
+    sinh(this: MathJsChain<number | Unit>): MathJsChain<number>
+    sinh(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    sinh(this: MathJsChain<Complex>): MathJsChain<Complex>
+    sinh(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    sinh(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the tangent of a value. tan(x) is equal to sin(x) / cos(x).
      * For matrices, the function is evaluated element wise.
      */
-    tan(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // tan(x: number | Unit): number
-    // tan(x: BigNumber): BigNumber
-    // tan(x: Complex): Complex
-    // tan(x: MathArray): MathArray
-    // tan(x: Matrix): Matrix
+
+    tan(this: MathJsChain<number | Unit>): MathJsChain<number>
+    tan(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    tan(this: MathJsChain<Complex>): MathJsChain<Complex>
+    tan(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    tan(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /**
      * Calculate the hyperbolic tangent of a value, defined as tanh(x) =
      * (exp(2 * x) - 1) / (exp(2 * x) + 1). For matrices, the function is
      * evaluated element wise.
      */
-    tanh(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // tanh(x: number | Unit): number
-    // tanh(x: BigNumber): BigNumber
-    // tanh(x: Complex): Complex
-    // tanh(x: MathArray): MathArray
-    // tanh(x: Matrix): Matrix
+
+    tanh(this: MathJsChain<number | Unit>): MathJsChain<number>
+    tanh(this: MathJsChain<BigNumber>): MathJsChain<BigNumber>
+    tanh(this: MathJsChain<Complex>): MathJsChain<Complex>
+    tanh(this: MathJsChain<MathArray>): MathJsChain<MathArray>
+    tanh(this: MathJsChain<Matrix>): MathJsChain<Matrix>
 
     /*************************************************************************
      * Unit functions
@@ -6173,8 +6026,7 @@ declare namespace math {
      * @param unit New unit. Can be a string like "cm" or a unit without
      * value.
      */
-    to(this: MathJsChain<unknown>, unit: Unit | string): MathJsChain<unknown>
-    // to(x: Unit | MathCollection, unit: Unit | string): Unit | MathCollection
+    to(this: MathJsChain<Unit | MathCollection>, unit: Unit | string): MathJsChain<Unit | MathCollection>
 
     /*************************************************************************
      * Utils functions
@@ -6183,75 +6035,75 @@ declare namespace math {
     /**
      * Clone an object.
      */
-    clone(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // clone(x: any): any
+
+    clone(this: MathJsChain<any>): MathJsChain<any>
 
     /**
      * Test whether a value is an integer number. The function supports
      * number, BigNumber, and Fraction. The function is evaluated
      * element-wise in case of Array or Matrix input.
      */
-    isInteger(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isInteger(x: number | BigNumber | Fraction | MathCollection): boolean
+
+    isInteger(this: MathJsChain<number | BigNumber | Fraction | MathCollection>): MathJsChain<boolean>
 
     /**
      * Test whether a value is NaN (not a number). The function supports
      * types number, BigNumber, Fraction, Unit and Complex. The function is
      * evaluated element-wise in case of Array or Matrix input.
      */
-    isNaN(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isNaN(x: number | BigNumber | Fraction | MathCollection | Unit): boolean
+
+    isNaN(this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit>): MathJsChain<boolean>
 
     /**
      * Test whether a value is negative: smaller than zero. The function
      * supports types number, BigNumber, Fraction, and Unit. The function is
      * evaluated element-wise in case of Array or Matrix input.
      */
-    isNegative(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isNegative(
-    //   x: number | BigNumber | Fraction | MathCollection | Unit
-    // ): boolean
+
+    isNegative(
+      this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit>
+    ): MathJsChain<boolean>
 
     /**
      * Test whether a value is an numeric value. The function is evaluated
      * element-wise in case of Array or Matrix input.
      */
-    isNumeric(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isNumeric(x: any): x is number | BigNumber | Fraction | boolean
+
+    isNumeric(this: MathJsChain<any>): MathJsChain<boolean>
 
     /**
      * Test whether a value is positive: larger than zero. The function
      * supports types number, BigNumber, Fraction, and Unit. The function is
      * evaluated element-wise in case of Array or Matrix input.
      */
-    isPositive(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isPositive(
-    //   x: number | BigNumber | Fraction | MathCollection | Unit
-    // ): boolean
+
+    isPositive(
+      this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit>
+    ): MathJsChain<boolean>
 
     /**
      * Test whether a value is prime: has no divisors other than itself and
      * one. The function supports type number, bignumber. The function is
      * evaluated element-wise in case of Array or Matrix input.
      */
-    isPrime(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isPrime(x: number | BigNumber | MathCollection): boolean
+
+    isPrime(this: MathJsChain<number | BigNumber | MathCollection>): MathJsChain<boolean>
 
     /**
      * Test whether a value is zero. The function can check for zero for
      * types number, BigNumber, Fraction, Complex, and Unit. The function is
      * evaluated element-wise in case of Array or Matrix input.
      */
-    isZero(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // isZero(
-    //   x: number | BigNumber | Fraction | MathCollection | Unit | Complex
-    // ): boolean
+
+    isZero(
+      this: MathJsChain<number | BigNumber | Fraction | MathCollection | Unit | Complex>
+    ): MathJsChain<boolean>
 
     /**
      * Determine the type of a variable.
      */
-    typeOf(this: MathJsChain<unknown>): MathJsChain<unknown>
-    // typeOf(x: any): string
+
+    typeOf(this: MathJsChain<any>): MathJsChain<string>
   }
 
   interface ImportOptions {
@@ -6265,3 +6117,4 @@ declare namespace math {
     [key: string]: any
   }
 }
+

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4217,13 +4217,13 @@ declare namespace math {
       options?: any
     ): MathJsChain<MathNode>
 
-    // TODO properly type return value
+    // TODO properly type return value and chain value
     /**
      * Create a parser. The function creates a new math.expression.Parser
      * object.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parser(this: MathJsChain<string | string[]>): MathJsChain<any>
+    parser(this: MathJsChain<any>): MathJsChain<any>
 
     /**
      *  Replaces variable nodes with their scoped values

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -921,7 +921,6 @@ declare namespace math {
     cbrt(x: Complex, allRoots?: boolean): Complex
     cbrt(x: MathArray, allRoots?: boolean): MathArray
     cbrt(x: Matrix, allRoots?: boolean): Matrix
-    cbrt(x: Unit, allRoots?: boolean): Unit
 
     // Rounding functions, grouped for similarity, even though it breaks
     // the alphabetic order among arithmetic functions.
@@ -4426,7 +4425,6 @@ declare namespace math {
       allRoots?: boolean
     ): MathJsChain<MathArray>
     cbrt(this: MathJsChain<Matrix>, allRoots?: boolean): MathJsChain<Matrix>
-    cbrt(this: MathJsChain<Unit>, allRoots?: boolean): MathJsChain<Unit>
 
     // Rounding functions grouped for similarity
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4151,11 +4151,12 @@ declare namespace math {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parse(this: MathJsChain<MathExpression>, options?: any): MathJsChain<MathNode>
 
+    // TODO properly type return value
     /**
      * Create a parser. The function creates a new math.expression.Parser
      * object.
      */
-    parser(this: MathJsChain<unknown>): MathJsChain<unknown>
+    parser(this: MathJsChain<string | string[]>): MathJsChain<any>
 
     /**
      *  Replaces variable nodes with their scoped values

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4038,8 +4038,7 @@ declare namespace math {
       im?: number
     ): MathJsChain<Complex>
     complex(
-      this: MathJsChain<MathCollection>,
-      im?: number
+      this: MathJsChain<MathCollection>
     ): MathJsChain<MathCollection>
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4093,6 +4093,7 @@ declare namespace math {
      * end for multiple dimensions. Matrix.get, Matrix.set, and math.subset
      * accept an Index as input.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     index(this: MathJsChain<any[]>): MathJsChain<Index>
 
     /**
@@ -4184,10 +4185,12 @@ declare namespace math {
     evaluate(
       this: MathJsChain<MathExpression | Matrix>,
       scope?: object
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): MathJsChain<any>
     evaluate(
       this: MathJsChain<MathExpression[]>,
       scope?: object
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): MathJsChain<any[]>
 
     /**
@@ -4199,9 +4202,9 @@ declare namespace math {
     /**
      * @param options Available options: nodes - a set of custome nodes
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parse(
       this: MathJsChain<MathExpression[]>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       options?: any
     ): MathJsChain<MathNode[]>
 
@@ -4210,9 +4213,9 @@ declare namespace math {
      * invoking node.evaluate();
      * @param options Available options: nodes - a set of custome nodes
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parse(
       this: MathJsChain<MathExpression>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       options?: any
     ): MathJsChain<MathNode>
 
@@ -4221,19 +4224,21 @@ declare namespace math {
      * Create a parser. The function creates a new math.expression.Parser
      * object.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parser(this: MathJsChain<string | string[]>): MathJsChain<any>
 
     /**
      *  Replaces variable nodes with their scoped values
      * @param scope Scope to read/write variables
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolve(
       this: MathJsChain<MathNode>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       scope?: Record<string, any>
     ): MathJsChain<MathNode>
     resolve(
       this: MathJsChain<MathNode[]>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       scope?: Record<string, any>
     ): MathJsChain<MathNode[]>
 
@@ -4394,7 +4399,10 @@ declare namespace math {
     add(this: MathJsChain<MathArray>, y: MathType): MathJsChain<MathArray>
     add(this: MathJsChain<Matrix>, y: MathType): MathJsChain<Matrix>
     add(this: MathJsChain<Unit>, y: MathType): MathJsChain<Unit>
-    add(this: MathJsChain<MathNumericType>, y: MathType): MathJsChain<MathNumericType>
+    add(
+      this: MathJsChain<MathNumericType>,
+      y: MathType
+    ): MathJsChain<MathNumericType>
 
     /**
      * Apply a function that maps an array to a scalar along a given axis of the
@@ -5228,7 +5236,6 @@ declare namespace math {
       k: number,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compare?: 'asc' | 'desc' | ((a: any, b: any) => number)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): MathJsChain<MathCollection>
 
     /**
@@ -5748,7 +5755,7 @@ declare namespace math {
      * values. The median absolute deviation is defined as the median of the
      * absolute deviations from the median.
      */
-
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mad(this: MathJsChain<MathCollection>): MathJsChain<any>
 
     /**
@@ -5758,7 +5765,10 @@ declare namespace math {
      * dimension will be calculated. Parameter dim is zero-based.
      * @param dim The maximum over the selected dimension
      */
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     max(this: MathJsChain<MathType[]>, dim?: number): MathJsChain<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     max(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
@@ -5768,7 +5778,9 @@ declare namespace math {
      * dimension will be calculated. Parameter dim is zero-based.
      * @param dim The mean over the selected dimension
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mean(this: MathJsChain<MathType[]>, dim?: number): MathJsChain<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mean(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
@@ -5779,7 +5791,9 @@ declare namespace math {
      * dimensional) array or matrix, the median of all elements will be
      * calculated.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     median(this: MathJsChain<MathType[]>, dim?: number): MathJsChain<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     median(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
@@ -5789,7 +5803,9 @@ declare namespace math {
      * dimension will be calculated. Parameter dim is zero-based.
      * @param dim The minimum over the selected dimension
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     min(this: MathJsChain<MathType[]>): MathJsChain<MathType[]>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     min(this: MathJsChain<MathCollection>, dim?: number): MathJsChain<any>
 
     /**
@@ -5805,6 +5821,7 @@ declare namespace math {
      * (multi dimensional) array or matrix, the sum of all elements will be
      * calculated.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prod(this: MathJsChain<MathType[]>): MathJsChain<any>
 
     /**
@@ -5895,7 +5912,9 @@ declare namespace math {
      * Default value: ‘unbiased’.
      * @returns The variance
      */
-    variance(this: MathJsChain<Array<Array<number | BigNumber | Fraction>>>): MathJsChain<number>
+    variance(
+      this: MathJsChain<Array<Array<number | BigNumber | Fraction>>>
+    ): MathJsChain<number>
 
     /**
      * Compute the variance of a matrix or a list with values. In case of a
@@ -5913,7 +5932,7 @@ declare namespace math {
      * Default value: ‘unbiased’.
      * @returns The variance
      */
-     variance(
+    variance(
       this: MathJsChain<MathCollection>,
       dimension?: number,
       normalization?: 'unbiased' | 'uncorrected' | 'biased'
@@ -5940,6 +5959,7 @@ declare namespace math {
      * @see http://mathjs.org/docs/reference/functions/format.html
      */
     format(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this: MathJsChain<any>,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       value: any,
@@ -6263,6 +6283,7 @@ declare namespace math {
      * Clone an object.
      */
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     clone(this: MathJsChain<any>): MathJsChain<any>
 
     /**
@@ -6300,6 +6321,7 @@ declare namespace math {
      * element-wise in case of Array or Matrix input.
      */
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     isNumeric(this: MathJsChain<any>): MathJsChain<boolean>
 
     /**
@@ -6338,6 +6360,7 @@ declare namespace math {
      * Determine the type of a variable.
      */
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     typeOf(this: MathJsChain<any>): MathJsChain<string>
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4238,7 +4238,7 @@ declare namespace math {
      * matrices (Q, R) where Q is an orthogonal matrix and R is an upper
      * triangular matrix.
      */
-    qr(this: MathJsChain<unknown>): MathJsChain<unknown>
+    qr(this: MathJsChain<Matrix | MathArray>): MathJsChain<QRDecomposition>
 
     /**
      * Transform a rationalizable expression in a rational fraction. If

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -631,7 +631,8 @@ declare namespace math {
      * @param value A value to convert to a string
      * @returns The created string
      */
-    string(value: MathType | null): string | MathCollection
+    string(value: MathNumericType | string | Unit | null): string
+    string(value: MathCollection): MathCollection
 
     /**
      * Create a unit. Depending on the passed arguments, the function will

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -359,6 +359,11 @@ declare namespace math {
     p: number[]
   }
 
+  interface QRDecomposition {
+    Q: MathCollection
+    R: MathCollection
+  }
+
   interface MathJsStatic extends FactoryDependencies {
     e: number
     pi: number
@@ -789,7 +794,7 @@ declare namespace math {
      * decomposition.
      * @returns Q: the orthogonal matrix and R: the upper triangular matrix
      */
-    qr(A: Matrix | MathArray): { Q: MathCollection; R: MathCollection }
+    qr(A: Matrix | MathArray): QRDecomposition
 
     rationalize(
       expr: MathNode | string,

--- a/types/index.ts
+++ b/types/index.ts
@@ -290,6 +290,9 @@ Chaining examples
   expectTypeOf(math.chain(1).add(2)).toMatchTypeOf<MathJsChain<MathType>>()
   expectTypeOf(math.chain([1]).add(2)).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // apply
+  expectTypeOf(math.chain([1,2,3]).apply(1, () => 1)).toMatchTypeOf<MathJsChain<number[]>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -164,28 +164,21 @@ Chaining examples
   const r = math.chain(-0.483).round([0, 1, 2]).floor().add(0.52).fix(1).done()
   assert.deepStrictEqual(r, [0.5, -0.4, -0.4])
 
-  expectTypeOf(math.chain('x + y').parse().resolve({ x: 1 }).done())
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .toMatchTypeOf<any>()
-  expectTypeOf(math.chain('x + y').parse().resolve().done())
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .toMatchTypeOf<any>()
+  expectTypeOf(math.chain('x + y').parse().resolve({ x: 1 }).done()).toMatchTypeOf<MathNode>()
+  expectTypeOf(math.chain('x + y').parse().resolve().done()).toMatchTypeOf<MathNode>()
 
   // bignum
   expectTypeOf(math.chain(math.bignumber(12))).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain(math.bignumber(12)).done()).toMatchTypeOf<BigNumber>()
   expectTypeOf(math.chain(12).bignumber()).toMatchTypeOf<MathJsChain<BigNumber>>()
   expectTypeOf(math.chain([12, 13, 14]).bignumber()).toMatchTypeOf<MathJsChain<MathCollection>>()
 
   // boolean
   expectTypeOf(math.chain(math.boolean(true))).toMatchTypeOf<MathJsChain<boolean>>()
-  expectTypeOf(math.chain(math.boolean(true)).done()).toMatchTypeOf<boolean>()
   expectTypeOf(math.chain(true).boolean()).toMatchTypeOf<MathJsChain<boolean>>()
   expectTypeOf(math.chain([12, 13, 14]).boolean()).toMatchTypeOf<MathJsChain<MathCollection>>()
 
   // complex
   expectTypeOf(math.chain(math.complex('123'))).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain(math.complex('123')).done()).toMatchTypeOf<Complex>()
   expectTypeOf(math.chain('123').complex()).toMatchTypeOf<MathJsChain<Complex>>()
   expectTypeOf(math.chain('123').complex(1)).toMatchTypeOf<MathJsChain<Complex>>()
   expectTypeOf(math.chain([12, 13, 14]).complex()).toMatchTypeOf<MathJsChain<MathCollection>>()
@@ -199,7 +192,6 @@ Chaining examples
 
    // fraction
   expectTypeOf(math.chain(math.fraction('123'))).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain(math.fraction('123')).done()).toMatchTypeOf<Fraction>()
   expectTypeOf(math.chain('123').fraction()).toMatchTypeOf<MathJsChain<Fraction>>()
   expectTypeOf(math.chain('123').fraction(2)).toMatchTypeOf<MathJsChain<Fraction>>()
   expectTypeOf(math.chain([12, 13, 14]).fraction()).toMatchTypeOf<MathJsChain<MathCollection>>()
@@ -207,66 +199,52 @@ Chaining examples
 
    // index
   expectTypeOf(math.chain([12, 13, 14]).index()).toMatchTypeOf<MathJsChain<Index>>()
-  expectTypeOf(math.chain([12, 13, 14]).index().done()).toMatchTypeOf<Index>()
 
    // matrix
   expectTypeOf(math.chain([12, 13, 14, 15]).matrix()).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain([12, 13, 14, 15]).matrix().done()).toMatchTypeOf<Matrix>()
 
    // number
   expectTypeOf(math.chain('12').number()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain('12').number().done()).toMatchTypeOf<number>()
   expectTypeOf(math.chain([12, 13, 14]).number()).toMatchTypeOf<MathJsChain<MathCollection>>()
 
    // sparse
   expectTypeOf(math.chain([12, 13, 14, 15]).sparse()).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain([12, 13, 14, 15]).sparse().done()).toMatchTypeOf<Matrix>()
 
   // split unit
   expectTypeOf(math.chain(math.unit('furlong')).splitUnit([])).toMatchTypeOf<MathJsChain<Unit[]>>()
-  expectTypeOf(math.chain(math.unit('furlong')).splitUnit([]).done()).toMatchTypeOf<Unit[]>()
 
   // string
   expectTypeOf(math.chain('test').string()).toMatchTypeOf<MathJsChain<string>>()
-  expectTypeOf(math.chain('test').string().done()).toMatchTypeOf<string>()
   expectTypeOf(math.chain([1,2,3]).string()).toMatchTypeOf<MathJsChain<MathCollection>>()
 
   // unit
   expectTypeOf(math.chain(12).unit()).toMatchTypeOf<MathJsChain<Unit>>()
-  expectTypeOf(math.chain(12).unit().done()).toMatchTypeOf<Unit>()
   expectTypeOf(math.chain([1,2,3]).unit()).toMatchTypeOf<MathJsChain<Unit[]>>()
 
   // compile
   expectTypeOf(math.chain('a + b').compile()).toMatchTypeOf<MathJsChain<EvalFunction>>()
-  expectTypeOf(math.chain('a + b').compile().done()).toMatchTypeOf<EvalFunction>()
 
   // evaluate
   expectTypeOf(math.chain('1 + 1').evaluate()).toMatchTypeOf<MathJsChain<any>>()
-  expectTypeOf(math.chain('1 + 1').evaluate().done()).toMatchTypeOf<any>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).evaluate()).toMatchTypeOf<MathJsChain<any[]>>()
 
   // parse
   expectTypeOf(math.chain('1 + 1').parse()).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain('1 + 1').parse().done()).toMatchTypeOf<MathNode>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).parse()).toMatchTypeOf<MathJsChain<MathNode[]>>()
 
   // parser
   expectTypeOf(math.chain('1 + 1').parser()).toMatchTypeOf<MathJsChain<any>>()
-  expectTypeOf(math.chain('1 + 1').parser().done()).toMatchTypeOf<any>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<MathJsChain<any>>()
 
   // resolve
   expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain(math.parse('1 + 1')).resolve({}).done()).toMatchTypeOf<MathNode>()
   expectTypeOf(math.chain([math.parse('1 + 1'), math.parse('1 + 1')]).resolve({})).toMatchTypeOf<MathJsChain<MathNode[]>>()
 
   // derivative
   expectTypeOf(math.chain(math.parse('x^2')).derivative('x')).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain(math.parse('x^2')).derivative('x').done()).toMatchTypeOf<MathNode>()
 
   // lsolve
   expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2]).done()).toMatchTypeOf<MathArray>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lsolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // lup

--- a/types/index.ts
+++ b/types/index.ts
@@ -488,7 +488,7 @@ Chaining examples
 
   // add
   expectTypeOf(math.chain(1).add(2)).toMatchTypeOf<MathJsChain<MathType>>()
-  expectTypeOf(math.chain([1]).add(2)).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain([1]).add(2)).toMatchTypeOf<MathJsChain<MathType>>()
   expectTypeOf(
     math.chain(
       math.matrix([

--- a/types/index.ts
+++ b/types/index.ts
@@ -363,7 +363,10 @@ Chaining examples
         ])
       )
       .lusolve(
-        math.matrix([[1, 2], [3, 4]])
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
       )
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
@@ -379,7 +382,12 @@ Chaining examples
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   expectTypeOf(
-    math.chain([1, 2]).lusolve(math.matrix([ [1, 2], [3, 4], ]))
+    math.chain([1, 2]).lusolve(
+      math.matrix([
+        [1, 2],
+        [3, 4],
+      ])
+    )
   ).toMatchTypeOf<MathJsChain<MathArray>>()
 
   expectTypeOf(
@@ -390,7 +398,6 @@ Chaining examples
       ])
       .lusolve([1, 2])
   ).toMatchTypeOf<MathJsChain<MathArray>>()
-
 
   // qr
   expectTypeOf(
@@ -672,7 +679,9 @@ Chaining examples
 
   // gcd
   expectTypeOf(math.chain([1, 2]).gcd(3)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<
+    MathJsChain<number>
+  >()
   // TODO make gcd() work in the following cases
   // expectTypeOf(math.chain([1, 2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
   // expectTypeOf(math.chain([[1], [2]]).gcd()).toMatchTypeOf<

--- a/types/index.ts
+++ b/types/index.ts
@@ -355,14 +355,7 @@ Chaining examples
 
   // lusolve
   expectTypeOf(
-    math
-      .chain(
-        math.matrix([
-          [1, 2],
-          [3, 4],
-        ])
-      )
-      .lusolve(math.matrix([[1, 2]]))
+    math.chain( math.matrix([ [1, 2], [3, 4], ])).lusolve(math.matrix([1, 2]))
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   expectTypeOf(
@@ -382,7 +375,7 @@ Chaining examples
         [1, 2],
         [3, 4],
       ])
-      .lusolve(math.matrix([[1, 2]]))
+      .lusolve(math.matrix([1, 2]))
   ).toMatchTypeOf<MathJsChain<MathArray>>()
 
   expectTypeOf(

--- a/types/index.ts
+++ b/types/index.ts
@@ -243,6 +243,11 @@ Chaining examples
   expectTypeOf(math.chain('1 + 1').evaluate()).toMatchTypeOf<MathJsChain<any>>()
   expectTypeOf(math.chain('1 + 1').evaluate().done()).toMatchTypeOf<any>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).evaluate()).toMatchTypeOf<MathJsChain<any[]>>()
+
+  // parse
+  expectTypeOf(math.chain('1 + 1').parse()).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain('1 + 1').parse().done()).toMatchTypeOf<MathNode>()
+  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parse()).toMatchTypeOf<MathJsChain<MathNode[]>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -307,6 +307,18 @@ Chaining examples
   // cbrt
   expectTypeOf(math.chain(1).ceil()).toMatchTypeOf<MathJsChain<MathNumericType>>()
   expectTypeOf(math.chain([1]).ceil()).toMatchTypeOf<MathJsChain<MathCollection>>()
+
+  // fix
+  expectTypeOf(math.chain(1).fix()).toMatchTypeOf<MathJsChain<MathNumericType>>()
+  expectTypeOf(math.chain([1]).fix()).toMatchTypeOf<MathJsChain<MathCollection>>()
+
+  // floor
+  expectTypeOf(math.chain(1).floor()).toMatchTypeOf<MathJsChain<MathNumericType>>()
+  expectTypeOf(math.chain([1]).floor()).toMatchTypeOf<MathJsChain<MathCollection>>()
+
+  // round
+  expectTypeOf(math.chain(1).round()).toMatchTypeOf<MathJsChain<MathNumericType>>()
+  expectTypeOf(math.chain([1]).round()).toMatchTypeOf<MathJsChain<MathCollection>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -262,6 +262,11 @@ Chaining examples
   // derivative
   expectTypeOf(math.chain(math.parse('x^2')).derivative('x')).toMatchTypeOf<MathJsChain<MathNode>>()
   expectTypeOf(math.chain(math.parse('x^2')).derivative('x').done()).toMatchTypeOf<MathNode>()
+
+  // lsolve
+  expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2]).done()).toMatchTypeOf<MathArray>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lsolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -238,6 +238,11 @@ Chaining examples
   // compile
   expectTypeOf(math.chain('a + b').compile()).toMatchTypeOf<MathJsChain<EvalFunction>>()
   expectTypeOf(math.chain('a + b').compile().done()).toMatchTypeOf<EvalFunction>()
+
+  // evaluate
+  expectTypeOf(math.chain('1 + 1').evaluate()).toMatchTypeOf<MathJsChain<any>>()
+  expectTypeOf(math.chain('1 + 1').evaluate().done()).toMatchTypeOf<any>()
+  expectTypeOf(math.chain(['1 + 1', '2 + 2']).evaluate()).toMatchTypeOf<MathJsChain<any[]>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -258,6 +258,10 @@ Chaining examples
   expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<MathJsChain<MathNode>>()
   expectTypeOf(math.chain(math.parse('1 + 1')).resolve({}).done()).toMatchTypeOf<MathNode>()
   expectTypeOf(math.chain([math.parse('1 + 1'), math.parse('1 + 1')]).resolve({})).toMatchTypeOf<MathJsChain<MathNode[]>>()
+
+  // derivative
+  expectTypeOf(math.chain(math.parse('x^2')).derivative('x')).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain(math.parse('x^2')).derivative('x').done()).toMatchTypeOf<MathNode>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -489,9 +489,6 @@ Chaining examples
   expectTypeOf(math.chain(math.bignumber(1)).cbrt()).toMatchTypeOf<
     MathJsChain<BigNumber>
   >()
-  expectTypeOf(math.chain(math.fraction(1, 2)).cbrt()).toMatchTypeOf<
-    MathJsChain<Fraction>
-  >()
   expectTypeOf(math.chain(math.complex(1, 2)).cbrt()).toMatchTypeOf<
     MathJsChain<Complex>
   >()

--- a/types/index.ts
+++ b/types/index.ts
@@ -250,6 +250,10 @@ Chaining examples
   // lup
   expectTypeOf(math.chain([[1,2],[3,4]]).lup()).toMatchTypeOf<MathJsChain<LUDecomposition>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lup()).toMatchTypeOf<MathJsChain<LUDecomposition>>()
+
+  // lusolve
+  expectTypeOf(math.chain([[1,2],[3,4]]).lusolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lusolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -300,10 +300,6 @@ Chaining examples
     MathJsChain<MathNode[]>
   >()
 
-  // parser
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  expectTypeOf(math.chain().parser()).toMatchTypeOf<MathJsChain<any>>()
-
   // resolve
   expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<
     MathJsChain<MathNode>

--- a/types/index.ts
+++ b/types/index.ts
@@ -364,8 +364,7 @@ Chaining examples
       )
       .lusolve(
         math.matrix([
-          [1, 2],
-          [3, 4],
+          [1, 2]
         ])
       )
   ).toMatchTypeOf<MathJsChain<Matrix>>()
@@ -382,10 +381,9 @@ Chaining examples
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   expectTypeOf(
-    math.chain([1, 2]).lusolve(
+    math.chain([[1, 2], [3, 4]]).lusolve(
       math.matrix([
-        [1, 2],
-        [3, 4],
+        [1, 2]
       ])
     )
   ).toMatchTypeOf<MathJsChain<MathArray>>()

--- a/types/index.ts
+++ b/types/index.ts
@@ -253,6 +253,11 @@ Chaining examples
   expectTypeOf(math.chain('1 + 1').parser()).toMatchTypeOf<MathJsChain<any>>()
   expectTypeOf(math.chain('1 + 1').parser().done()).toMatchTypeOf<any>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<MathJsChain<any>>()
+
+  // resolve
+  expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain(math.parse('1 + 1')).resolve({}).done()).toMatchTypeOf<MathNode>()
+  expectTypeOf(math.chain([math.parse('1 + 1'), math.parse('1 + 1')]).resolve({})).toMatchTypeOf<MathJsChain<MathNode[]>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -356,12 +356,17 @@ Chaining examples
   // lusolve
   expectTypeOf(
     math
-      .chain([
-        [1, 2],
-        [3, 4],
-      ])
-      .lusolve([1, 2])
-  ).toMatchTypeOf<MathJsChain<MathArray>>()
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .lusolve(
+        math.matrix([[1, 2], [3, 4]])
+      )
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
+
   expectTypeOf(
     math
       .chain(
@@ -372,6 +377,20 @@ Chaining examples
       )
       .lusolve([1, 2])
   ).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  expectTypeOf(
+    math.chain([1, 2]).lusolve(math.matrix([ [1, 2], [3, 4], ]))
+  ).toMatchTypeOf<MathJsChain<MathArray>>()
+
+  expectTypeOf(
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
+      ])
+      .lusolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<MathArray>>()
+
 
   // qr
   expectTypeOf(
@@ -653,9 +672,7 @@ Chaining examples
 
   // gcd
   expectTypeOf(math.chain([1, 2]).gcd(3)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<
-    MathJsChain<number>
-  >()
+  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<MathJsChain<number>>()
   // TODO make gcd() work in the following cases
   // expectTypeOf(math.chain([1, 2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
   // expectTypeOf(math.chain([[1], [2]]).gcd()).toMatchTypeOf<

--- a/types/index.ts
+++ b/types/index.ts
@@ -505,7 +505,7 @@ Chaining examples
       )
       .cbrt()
   ).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain(math.unit('league')).cbrt()).toMatchTypeOf<
+  expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<
     MathJsChain<Unit>
   >()
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -346,6 +346,17 @@ Chaining examples
   // dotPow
   expectTypeOf(math.chain(1).dotPow(2)).toMatchTypeOf<MathJsChain<MathType>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotPow(2)).toMatchTypeOf<MathJsChain<MathType>>()
+
+  // exp
+  expectTypeOf(math.chain(1).exp()).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain([1,2]).exp()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).exp()).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // expm1
+  expectTypeOf(math.chain(1).expm1()).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain([1,2]).expm1()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).expm1()).toMatchTypeOf<MathJsChain<Matrix>>()
+
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -362,11 +362,7 @@ Chaining examples
           [3, 4],
         ])
       )
-      .lusolve(
-        math.matrix([
-          [1, 2]
-        ])
-      )
+      .lusolve(math.matrix([[1, 2]]))
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   expectTypeOf(
@@ -381,11 +377,12 @@ Chaining examples
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   expectTypeOf(
-    math.chain([[1, 2], [3, 4]]).lusolve(
-      math.matrix([
-        [1, 2]
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
       ])
-    )
+      .lusolve(math.matrix([[1, 2]]))
   ).toMatchTypeOf<MathJsChain<MathArray>>()
 
   expectTypeOf(

--- a/types/index.ts
+++ b/types/index.ts
@@ -211,9 +211,6 @@ Chaining examples
   expectTypeOf(math.chain([12, 13, 14]).complex()).toMatchTypeOf<
     MathJsChain<MathCollection>
   >()
-  expectTypeOf(math.chain([12, 13, 14]).complex(1)).toMatchTypeOf<
-    MathJsChain<MathCollection>
-  >()
 
   // createUnit
   expectTypeOf(math.chain(math.createUnit('furlong'))).toMatchTypeOf<

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,6 +18,7 @@ import {
   Index,
   Matrix,
   EvalFunction,
+  LUDecomposition,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -267,6 +268,10 @@ Chaining examples
   expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2]).done()).toMatchTypeOf<MathArray>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lsolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // lup
+  expectTypeOf(math.chain([[1,2],[3,4]]).lup()).toMatchTypeOf<MathJsChain<LUDecomposition>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lup()).toMatchTypeOf<MathJsChain<LUDecomposition>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,6 +20,7 @@ import {
   EvalFunction,
   LUDecomposition,
   QRDecomposition,
+  SLUDecomposition,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -267,6 +268,9 @@ Chaining examples
   // simplify
   expectTypeOf(math.chain('a + a + b').simplify()).toMatchTypeOf<MathJsChain<MathNode>>()
   expectTypeOf(math.chain(math.parse('a + a + b')).simplify()).toMatchTypeOf<MathJsChain<MathNode>>()
+
+  // slu
+  expectTypeOf(math.chain(math.sparse([[1,2],[3,4]])).slu(2, 0.5)).toMatchTypeOf<MathJsChain<SLUDecomposition>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -319,6 +319,15 @@ Chaining examples
   // round
   expectTypeOf(math.chain(1).round()).toMatchTypeOf<MathJsChain<MathNumericType>>()
   expectTypeOf(math.chain([1]).round()).toMatchTypeOf<MathJsChain<MathCollection>>()
+
+  // cube
+  expectTypeOf(math.chain(1).cube()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(math.bignumber(1)).cube()).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain(math.fraction(1,2)).cube()).toMatchTypeOf<MathJsChain<Fraction>>()
+  expectTypeOf(math.chain(math.complex(1,2)).cube()).toMatchTypeOf<MathJsChain<Complex>>()
+  expectTypeOf(math.chain([1,2]).cube()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).cube()).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain(math.unit('furlong')).cube()).toMatchTypeOf<MathJsChain<Unit>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -275,6 +275,15 @@ Chaining examples
   // usolve
   expectTypeOf(math.chain([[1,2],[3,4]]).usolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).usolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // abs
+  expectTypeOf(math.chain(1).abs()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(math.bignumber(1)).abs()).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain(math.fraction(1,2)).abs()).toMatchTypeOf<MathJsChain<Fraction>>()
+  expectTypeOf(math.chain(math.complex(1,2)).abs()).toMatchTypeOf<MathJsChain<Complex>>()
+  expectTypeOf(math.chain([1,2]).abs()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).abs()).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain(math.unit('furlong')).abs()).toMatchTypeOf<MathJsChain<Unit>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -653,7 +653,9 @@ Chaining examples
 
   // gcd
   expectTypeOf(math.chain([1, 2]).gcd(3)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<
+    MathJsChain<number>
+  >()
   // TODO make gcd() work in the following cases
   // expectTypeOf(math.chain([1, 2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
   // expectTypeOf(math.chain([[1], [2]]).gcd()).toMatchTypeOf<

--- a/types/index.ts
+++ b/types/index.ts
@@ -363,6 +363,10 @@ Chaining examples
   expectTypeOf(math.chain([math.bignumber(1),math.bignumber(1)]).gcd()).toMatchTypeOf<MathJsChain<BigNumber>>()
   expectTypeOf(math.chain([math.complex(1, 2),math.complex(1, 2)]).gcd()).toMatchTypeOf<MathJsChain<Complex>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).expm1()).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // hypot
+  expectTypeOf(math.chain([1,2]).hypot()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([math.bignumber(1),math.bignumber(1)]).hypot()).toMatchTypeOf<MathJsChain<BigNumber>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -168,221 +168,580 @@ Chaining examples
   const r = math.chain(-0.483).round([0, 1, 2]).floor().add(0.52).fix(1).done()
   assert.deepStrictEqual(r, [0.5, -0.4, -0.4])
 
-  expectTypeOf(math.chain('x + y').parse().resolve({ x: 1 }).done()).toMatchTypeOf<MathNode>()
-  expectTypeOf(math.chain('x + y').parse().resolve().done()).toMatchTypeOf<MathNode>()
+  expectTypeOf(
+    math.chain('x + y').parse().resolve({ x: 1 }).done()
+  ).toMatchTypeOf<MathNode>()
+  expectTypeOf(
+    math.chain('x + y').parse().resolve().done()
+  ).toMatchTypeOf<MathNode>()
 
   // bignum
-  expectTypeOf(math.chain(math.bignumber(12))).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain(12).bignumber()).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain([12, 13, 14]).bignumber()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain(math.bignumber(12))).toMatchTypeOf<
+    MathJsChain<BigNumber>
+  >()
+  expectTypeOf(math.chain(12).bignumber()).toMatchTypeOf<
+    MathJsChain<BigNumber>
+  >()
+  expectTypeOf(math.chain([12, 13, 14]).bignumber()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // boolean
-  expectTypeOf(math.chain(math.boolean(true))).toMatchTypeOf<MathJsChain<boolean>>()
+  expectTypeOf(math.chain(math.boolean(true))).toMatchTypeOf<
+    MathJsChain<boolean>
+  >()
   expectTypeOf(math.chain(true).boolean()).toMatchTypeOf<MathJsChain<boolean>>()
-  expectTypeOf(math.chain([12, 13, 14]).boolean()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain([12, 13, 14]).boolean()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // complex
-  expectTypeOf(math.chain(math.complex('123'))).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain('123').complex()).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain('123').complex(1)).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain([12, 13, 14]).complex()).toMatchTypeOf<MathJsChain<MathCollection>>()
-  expectTypeOf(math.chain([12, 13, 14]).complex(1)).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain(math.complex('123'))).toMatchTypeOf<
+    MathJsChain<Complex>
+  >()
+  expectTypeOf(math.chain('123').complex()).toMatchTypeOf<
+    MathJsChain<Complex>
+  >()
+  expectTypeOf(math.chain('123').complex(1)).toMatchTypeOf<
+    MathJsChain<Complex>
+  >()
+  expectTypeOf(math.chain([12, 13, 14]).complex()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
+  expectTypeOf(math.chain([12, 13, 14]).complex(1)).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // createUnit
-  expectTypeOf(math.chain(math.createUnit('furlong'))).toMatchTypeOf<MathJsChain<Unit>>()
-  expectTypeOf(math.chain(math.createUnit({
-    furlong: '1234'
-  }))).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(math.chain(math.createUnit('furlong'))).toMatchTypeOf<
+    MathJsChain<Unit>
+  >()
+  expectTypeOf(
+    math.chain(
+      math.createUnit({
+        furlong: '1234',
+      })
+    )
+  ).toMatchTypeOf<MathJsChain<Unit>>()
 
-   // fraction
-  expectTypeOf(math.chain(math.fraction('123'))).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain('123').fraction()).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain('123').fraction(2)).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain([12, 13, 14]).fraction()).toMatchTypeOf<MathJsChain<MathCollection>>()
-  expectTypeOf(math.chain([12, 13, 14]).fraction(2)).toMatchTypeOf<MathJsChain<MathCollection>>()
+  // fraction
+  expectTypeOf(math.chain(math.fraction('123'))).toMatchTypeOf<
+    MathJsChain<Fraction>
+  >()
+  expectTypeOf(math.chain('123').fraction()).toMatchTypeOf<
+    MathJsChain<Fraction>
+  >()
+  expectTypeOf(math.chain('123').fraction(2)).toMatchTypeOf<
+    MathJsChain<Fraction>
+  >()
+  expectTypeOf(math.chain([12, 13, 14]).fraction()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
+  expectTypeOf(math.chain([12, 13, 14]).fraction(2)).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
-   // index
-  expectTypeOf(math.chain([12, 13, 14]).index()).toMatchTypeOf<MathJsChain<Index>>()
+  // index
+  expectTypeOf(math.chain([12, 13, 14]).index()).toMatchTypeOf<
+    MathJsChain<Index>
+  >()
 
-   // matrix
-  expectTypeOf(math.chain([12, 13, 14, 15]).matrix()).toMatchTypeOf<MathJsChain<Matrix>>()
+  // matrix
+  expectTypeOf(math.chain([12, 13, 14, 15]).matrix()).toMatchTypeOf<
+    MathJsChain<Matrix>
+  >()
 
-   // number
+  // number
   expectTypeOf(math.chain('12').number()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([12, 13, 14]).number()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain([12, 13, 14]).number()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
-   // sparse
-  expectTypeOf(math.chain([12, 13, 14, 15]).sparse()).toMatchTypeOf<MathJsChain<Matrix>>()
+  // sparse
+  expectTypeOf(math.chain([12, 13, 14, 15]).sparse()).toMatchTypeOf<
+    MathJsChain<Matrix>
+  >()
 
   // split unit
-  expectTypeOf(math.chain(math.unit('furlong')).splitUnit([])).toMatchTypeOf<MathJsChain<Unit[]>>()
+  expectTypeOf(math.chain(math.unit('furlong')).splitUnit([])).toMatchTypeOf<
+    MathJsChain<Unit[]>
+  >()
 
   // string
   expectTypeOf(math.chain('test').string()).toMatchTypeOf<MathJsChain<string>>()
-  expectTypeOf(math.chain([1,2,3]).string()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain([1, 2, 3]).string()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // unit
   expectTypeOf(math.chain(12).unit()).toMatchTypeOf<MathJsChain<Unit>>()
-  expectTypeOf(math.chain([1,2,3]).unit()).toMatchTypeOf<MathJsChain<Unit[]>>()
+  expectTypeOf(math.chain([1, 2, 3]).unit()).toMatchTypeOf<
+    MathJsChain<Unit[]>
+  >()
 
   // compile
-  expectTypeOf(math.chain('a + b').compile()).toMatchTypeOf<MathJsChain<EvalFunction>>()
+  expectTypeOf(math.chain('a + b').compile()).toMatchTypeOf<
+    MathJsChain<EvalFunction>
+  >()
 
   // evaluate
   expectTypeOf(math.chain('1 + 1').evaluate()).toMatchTypeOf<MathJsChain<any>>()
-  expectTypeOf(math.chain(['1 + 1', '2 + 2']).evaluate()).toMatchTypeOf<MathJsChain<any[]>>()
+  expectTypeOf(math.chain(['1 + 1', '2 + 2']).evaluate()).toMatchTypeOf<
+    MathJsChain<any[]>
+  >()
 
   // parse
-  expectTypeOf(math.chain('1 + 1').parse()).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parse()).toMatchTypeOf<MathJsChain<MathNode[]>>()
+  expectTypeOf(math.chain('1 + 1').parse()).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
+  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parse()).toMatchTypeOf<
+    MathJsChain<MathNode[]>
+  >()
 
   // parser
   expectTypeOf(math.chain('1 + 1').parser()).toMatchTypeOf<MathJsChain<any>>()
-  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<MathJsChain<any>>()
+  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<
+    MathJsChain<any>
+  >()
 
   // resolve
-  expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain([math.parse('1 + 1'), math.parse('1 + 1')]).resolve({})).toMatchTypeOf<MathJsChain<MathNode[]>>()
+  expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
+  expectTypeOf(
+    math.chain([math.parse('1 + 1'), math.parse('1 + 1')]).resolve({})
+  ).toMatchTypeOf<MathJsChain<MathNode[]>>()
 
   // derivative
-  expectTypeOf(math.chain(math.parse('x^2')).derivative('x')).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain(math.parse('x^2')).derivative('x')).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
 
   // lsolve
-  expectTypeOf(math.chain([[1,2],[3,4]]).lsolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lsolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
+      ])
+      .lsolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .lsolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // lup
-  expectTypeOf(math.chain([[1,2],[3,4]]).lup()).toMatchTypeOf<MathJsChain<LUDecomposition>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lup()).toMatchTypeOf<MathJsChain<LUDecomposition>>()
+  expectTypeOf(
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
+      ])
+      .lup()
+  ).toMatchTypeOf<MathJsChain<LUDecomposition>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .lup()
+  ).toMatchTypeOf<MathJsChain<LUDecomposition>>()
 
   // lusolve
-  expectTypeOf(math.chain([[1,2],[3,4]]).lusolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lusolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
+      ])
+      .lusolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .lusolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // qr
-  expectTypeOf(math.chain([[1,2],[3,4]]).qr()).toMatchTypeOf<MathJsChain<QRDecomposition>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).qr()).toMatchTypeOf<MathJsChain<QRDecomposition>>()
+  expectTypeOf(
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
+      ])
+      .qr()
+  ).toMatchTypeOf<MathJsChain<QRDecomposition>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .qr()
+  ).toMatchTypeOf<MathJsChain<QRDecomposition>>()
 
   // rationalize
-  expectTypeOf(math.chain('1.23').rationalize()).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain(math.parse('1.23')).rationalize()).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain('1.23').rationalize()).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
+  expectTypeOf(math.chain(math.parse('1.23')).rationalize()).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
 
   // simplify
-  expectTypeOf(math.chain('a + a + b').simplify()).toMatchTypeOf<MathJsChain<MathNode>>()
-  expectTypeOf(math.chain(math.parse('a + a + b')).simplify()).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain('a + a + b').simplify()).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
+  expectTypeOf(math.chain(math.parse('a + a + b')).simplify()).toMatchTypeOf<
+    MathJsChain<MathNode>
+  >()
 
   // slu
-  expectTypeOf(math.chain(math.sparse([[1,2],[3,4]])).slu(2, 0.5)).toMatchTypeOf<MathJsChain<SLUDecomposition>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.sparse([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .slu(2, 0.5)
+  ).toMatchTypeOf<MathJsChain<SLUDecomposition>>()
 
   // usolve
-  expectTypeOf(math.chain([[1,2],[3,4]]).usolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).usolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(
+    math
+      .chain([
+        [1, 2],
+        [3, 4],
+      ])
+      .usolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .usolve([1, 2])
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // abs
   expectTypeOf(math.chain(1).abs()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain(math.bignumber(1)).abs()).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain(math.fraction(1,2)).abs()).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain(math.complex(1,2)).abs()).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain([1,2]).abs()).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).abs()).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain(math.unit('furlong')).abs()).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(math.chain(math.bignumber(1)).abs()).toMatchTypeOf<
+    MathJsChain<BigNumber>
+  >()
+  expectTypeOf(math.chain(math.fraction(1, 2)).abs()).toMatchTypeOf<
+    MathJsChain<Fraction>
+  >()
+  expectTypeOf(math.chain(math.complex(1, 2)).abs()).toMatchTypeOf<
+    MathJsChain<Complex>
+  >()
+  expectTypeOf(math.chain([1, 2]).abs()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .abs()
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain(math.unit('furlong')).abs()).toMatchTypeOf<
+    MathJsChain<Unit>
+  >()
 
   // add
   expectTypeOf(math.chain(1).add(2)).toMatchTypeOf<MathJsChain<MathType>>()
   expectTypeOf(math.chain([1]).add(2)).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(
+    math.chain(
+      math.matrix([
+        [1, 2],
+        [3, 4],
+      ])
+    )
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // apply
-  expectTypeOf(math.chain([1,2,3]).apply(1, () => 1)).toMatchTypeOf<MathJsChain<number[]>>()
+  expectTypeOf(math.chain([1, 2, 3]).apply(1, () => 1)).toMatchTypeOf<
+    MathJsChain<number[]>
+  >()
 
   // cbrt
   expectTypeOf(math.chain(1).cbrt()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain(math.bignumber(1)).cbrt()).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain(math.fraction(1,2)).cbrt()).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain(math.complex(1,2)).cbrt()).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain([1,2]).cbrt()).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).cbrt()).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(math.chain(math.bignumber(1)).cbrt()).toMatchTypeOf<
+    MathJsChain<BigNumber>
+  >()
+  expectTypeOf(math.chain(math.fraction(1, 2)).cbrt()).toMatchTypeOf<
+    MathJsChain<Fraction>
+  >()
+  expectTypeOf(math.chain(math.complex(1, 2)).cbrt()).toMatchTypeOf<
+    MathJsChain<Complex>
+  >()
+  expectTypeOf(math.chain([1, 2]).cbrt()).toMatchTypeOf<
+    MathJsChain<MathArray>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .cbrt()
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<
+    MathJsChain<Unit>
+  >()
 
   // cbrt
-  expectTypeOf(math.chain(1).ceil()).toMatchTypeOf<MathJsChain<MathNumericType>>()
-  expectTypeOf(math.chain([1]).ceil()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain(1).ceil()).toMatchTypeOf<
+    MathJsChain<MathNumericType>
+  >()
+  expectTypeOf(math.chain([1]).ceil()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // fix
-  expectTypeOf(math.chain(1).fix()).toMatchTypeOf<MathJsChain<MathNumericType>>()
-  expectTypeOf(math.chain([1]).fix()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain(1).fix()).toMatchTypeOf<
+    MathJsChain<MathNumericType>
+  >()
+  expectTypeOf(math.chain([1]).fix()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // floor
-  expectTypeOf(math.chain(1).floor()).toMatchTypeOf<MathJsChain<MathNumericType>>()
-  expectTypeOf(math.chain([1]).floor()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain(1).floor()).toMatchTypeOf<
+    MathJsChain<MathNumericType>
+  >()
+  expectTypeOf(math.chain([1]).floor()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // round
-  expectTypeOf(math.chain(1).round()).toMatchTypeOf<MathJsChain<MathNumericType>>()
-  expectTypeOf(math.chain([1]).round()).toMatchTypeOf<MathJsChain<MathCollection>>()
+  expectTypeOf(math.chain(1).round()).toMatchTypeOf<
+    MathJsChain<MathNumericType>
+  >()
+  expectTypeOf(math.chain([1]).round()).toMatchTypeOf<
+    MathJsChain<MathCollection>
+  >()
 
   // cube
   expectTypeOf(math.chain(1).cube()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain(math.bignumber(1)).cube()).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain(math.fraction(1,2)).cube()).toMatchTypeOf<MathJsChain<Fraction>>()
-  expectTypeOf(math.chain(math.complex(1,2)).cube()).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain([1,2]).cube()).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).cube()).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain(math.unit('furlong')).cube()).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(math.chain(math.bignumber(1)).cube()).toMatchTypeOf<
+    MathJsChain<BigNumber>
+  >()
+  expectTypeOf(math.chain(math.fraction(1, 2)).cube()).toMatchTypeOf<
+    MathJsChain<Fraction>
+  >()
+  expectTypeOf(math.chain(math.complex(1, 2)).cube()).toMatchTypeOf<
+    MathJsChain<Complex>
+  >()
+  expectTypeOf(math.chain([1, 2]).cube()).toMatchTypeOf<
+    MathJsChain<MathArray>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .cube()
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain(math.unit('furlong')).cube()).toMatchTypeOf<
+    MathJsChain<Unit>
+  >()
 
   // divide
-  expectTypeOf(math.chain(math.unit('furlong')).divide(math.unit('furlong'))).toMatchTypeOf<MathJsChain<number | Unit>>()
-  expectTypeOf(math.chain(math.unit('furlong')).divide(6)).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(
+    math.chain(math.unit('furlong')).divide(math.unit('furlong'))
+  ).toMatchTypeOf<MathJsChain<number | Unit>>()
+  expectTypeOf(math.chain(math.unit('furlong')).divide(6)).toMatchTypeOf<
+    MathJsChain<Unit>
+  >()
   expectTypeOf(math.chain(2).divide(6)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([1,2,3]).divide(6)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain([1, 2, 3]).divide(6)).toMatchTypeOf<
+    MathJsChain<MathType>
+  >()
 
   // dotDivide
-  expectTypeOf(math.chain(1).dotDivide(2)).toMatchTypeOf<MathJsChain<MathType>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotDivide(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain(1).dotDivide(2)).toMatchTypeOf<
+    MathJsChain<MathType>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .dotDivide(2)
+  ).toMatchTypeOf<MathJsChain<MathType>>()
 
   // dotMultiply
-  expectTypeOf(math.chain(1).dotMultiply(2)).toMatchTypeOf<MathJsChain<MathType>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotMultiply(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain(1).dotMultiply(2)).toMatchTypeOf<
+    MathJsChain<MathType>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .dotMultiply(2)
+  ).toMatchTypeOf<MathJsChain<MathType>>()
 
   // dotPow
   expectTypeOf(math.chain(1).dotPow(2)).toMatchTypeOf<MathJsChain<MathType>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotPow(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .dotPow(2)
+  ).toMatchTypeOf<MathJsChain<MathType>>()
 
   // exp
   expectTypeOf(math.chain(1).exp()).toMatchTypeOf<MathJsChain<MathType>>()
-  expectTypeOf(math.chain([1,2]).exp()).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).exp()).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain([1, 2]).exp()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .exp()
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // expm1
   expectTypeOf(math.chain(1).expm1()).toMatchTypeOf<MathJsChain<MathType>>()
-  expectTypeOf(math.chain([1,2]).expm1()).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).expm1()).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain([1, 2]).expm1()).toMatchTypeOf<
+    MathJsChain<MathArray>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .expm1()
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // gcd
-  expectTypeOf(math.chain([1,2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([[1],[2]]).gcd()).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain([math.bignumber(1),math.bignumber(1)]).gcd()).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain([math.complex(1, 2),math.complex(1, 2)]).gcd()).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).expm1()).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain([1, 2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([[1], [2]]).gcd()).toMatchTypeOf<
+    MathJsChain<MathArray>
+  >()
+  expectTypeOf(
+    math.chain([math.bignumber(1), math.bignumber(1)]).gcd()
+  ).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(
+    math.chain([math.complex(1, 2), math.complex(1, 2)]).gcd()
+  ).toMatchTypeOf<MathJsChain<Complex>>()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .expm1()
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // hypot
-  expectTypeOf(math.chain([1,2]).hypot()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([math.bignumber(1),math.bignumber(1)]).hypot()).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain([1, 2]).hypot()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(
+    math.chain([math.bignumber(1), math.bignumber(1)]).hypot()
+  ).toMatchTypeOf<MathJsChain<BigNumber>>()
 
   // lcm
   expectTypeOf(math.chain(1).lcm(2)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain(math.bignumber(1)).lcm(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain([1,2]).lcm([3,4])).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lcm(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(
+    math.chain(math.bignumber(1)).lcm(math.bignumber(2))
+  ).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain([1, 2]).lcm([3, 4])).toMatchTypeOf<
+    MathJsChain<MathArray>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .lcm(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // log
   expectTypeOf(math.chain(1).log(2)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain(math.bignumber(1)).log(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(
+    math.chain(math.bignumber(1)).log(math.bignumber(2))
+  ).toMatchTypeOf<MathJsChain<BigNumber>>()
 
   // log10
   expectTypeOf(math.chain(1).log10(2)).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain(math.bignumber(1)).log10(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain([1,2]).log10([3,4])).toMatchTypeOf<MathJsChain<MathArray>>()
-  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).log10(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(
+    math.chain(math.bignumber(1)).log10(math.bignumber(2))
+  ).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain([1, 2]).log10([3, 4])).toMatchTypeOf<
+    MathJsChain<MathArray>
+  >()
+  expectTypeOf(
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .log10(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+  ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // TODO complete the rest of these...
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -357,6 +357,12 @@ Chaining examples
   expectTypeOf(math.chain([1,2]).expm1()).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).expm1()).toMatchTypeOf<MathJsChain<Matrix>>()
 
+  // gcd
+  expectTypeOf(math.chain([1,2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([[1],[2]]).gcd()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain([math.bignumber(1),math.bignumber(1)]).gcd()).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain([math.complex(1, 2),math.complex(1, 2)]).gcd()).toMatchTypeOf<MathJsChain<Complex>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).expm1()).toMatchTypeOf<MathJsChain<Matrix>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -480,7 +480,7 @@ Chaining examples
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // apply
-  expectTypeOf(math.chain([1, 2, 3]).apply(1, () => 1)).toMatchTypeOf<
+  expectTypeOf(math.chain([1, 2, 3]).apply(0, () => 1)).toMatchTypeOf<
     MathJsChain<number[]>
   >()
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -334,6 +334,18 @@ Chaining examples
   expectTypeOf(math.chain(math.unit('furlong')).divide(6)).toMatchTypeOf<MathJsChain<Unit>>()
   expectTypeOf(math.chain(2).divide(6)).toMatchTypeOf<MathJsChain<number>>()
   expectTypeOf(math.chain([1,2,3]).divide(6)).toMatchTypeOf<MathJsChain<MathType>>()
+
+  // dotDivide
+  expectTypeOf(math.chain(1).dotDivide(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotDivide(2)).toMatchTypeOf<MathJsChain<MathType>>()
+
+  // dotMultiply
+  expectTypeOf(math.chain(1).dotMultiply(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotMultiply(2)).toMatchTypeOf<MathJsChain<MathType>>()
+
+  // dotPow
+  expectTypeOf(math.chain(1).dotPow(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).dotPow(2)).toMatchTypeOf<MathJsChain<MathType>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,6 +17,7 @@ import {
   MathArray,
   Index,
   Matrix,
+  EvalFunction,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -233,6 +234,10 @@ Chaining examples
   expectTypeOf(math.chain(12).unit()).toMatchTypeOf<MathJsChain<Unit>>()
   expectTypeOf(math.chain(12).unit().done()).toMatchTypeOf<Unit>()
   expectTypeOf(math.chain([1,2,3]).unit()).toMatchTypeOf<MathJsChain<Unit[]>>()
+
+  // compile
+  expectTypeOf(math.chain('a + b').compile()).toMatchTypeOf<MathJsChain<EvalFunction>>()
+  expectTypeOf(math.chain('a + b').compile().done()).toMatchTypeOf<EvalFunction>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -228,6 +228,11 @@ Chaining examples
   expectTypeOf(math.chain('test').string()).toMatchTypeOf<MathJsChain<string>>()
   expectTypeOf(math.chain('test').string().done()).toMatchTypeOf<string>()
   expectTypeOf(math.chain([1,2,3]).string()).toMatchTypeOf<MathJsChain<MathCollection>>()
+
+  // unit
+  expectTypeOf(math.chain(12).unit()).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(math.chain(12).unit().done()).toMatchTypeOf<Unit>()
+  expectTypeOf(math.chain([1,2,3]).unit()).toMatchTypeOf<MathJsChain<Unit[]>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -355,7 +355,14 @@ Chaining examples
 
   // lusolve
   expectTypeOf(
-    math.chain( math.matrix([ [1, 2], [3, 4], ])).lusolve(math.matrix([1, 2]))
+    math
+      .chain(
+        math.matrix([
+          [1, 2],
+          [3, 4],
+        ])
+      )
+      .lusolve(math.matrix([1, 2]))
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   expectTypeOf(

--- a/types/index.ts
+++ b/types/index.ts
@@ -248,6 +248,11 @@ Chaining examples
   expectTypeOf(math.chain('1 + 1').parse()).toMatchTypeOf<MathJsChain<MathNode>>()
   expectTypeOf(math.chain('1 + 1').parse().done()).toMatchTypeOf<MathNode>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).parse()).toMatchTypeOf<MathJsChain<MathNode[]>>()
+
+  // parser
+  expectTypeOf(math.chain('1 + 1').parser()).toMatchTypeOf<MathJsChain<any>>()
+  expectTypeOf(math.chain('1 + 1').parser().done()).toMatchTypeOf<any>()
+  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<MathJsChain<any>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,6 +19,7 @@ import {
   Matrix,
   EvalFunction,
   LUDecomposition,
+  QRDecomposition,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -254,6 +255,10 @@ Chaining examples
   // lusolve
   expectTypeOf(math.chain([[1,2],[3,4]]).lusolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lusolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // qr
+  expectTypeOf(math.chain([[1,2],[3,4]]).qr()).toMatchTypeOf<MathJsChain<QRDecomposition>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).qr()).toMatchTypeOf<MathJsChain<QRDecomposition>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -219,7 +219,7 @@ Chaining examples
   expectTypeOf(
     math.chain(
       math.createUnit({
-        furlong: '1234',
+        fresnel: '1234',
       })
     )
   ).toMatchTypeOf<MathJsChain<Unit>>()
@@ -516,7 +516,7 @@ Chaining examples
       )
       .cbrt()
   ).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<
+  expectTypeOf(math.chain(math.unit('league')).cbrt()).toMatchTypeOf<
     MathJsChain<Unit>
   >()
 
@@ -582,9 +582,9 @@ Chaining examples
 
   // divide
   expectTypeOf(
-    math.chain(math.unit('furlong')).divide(math.unit('furlong'))
+    math.chain(math.unit('femtosecond')).divide(math.unit('femtosecond'))
   ).toMatchTypeOf<MathJsChain<number | Unit>>()
-  expectTypeOf(math.chain(math.unit('furlong')).divide(6)).toMatchTypeOf<
+  expectTypeOf(math.chain(math.unit('steradian')).divide(6)).toMatchTypeOf<
     MathJsChain<Unit>
   >()
   expectTypeOf(math.chain(2).divide(6)).toMatchTypeOf<MathJsChain<number>>()

--- a/types/index.ts
+++ b/types/index.ts
@@ -237,7 +237,7 @@ Chaining examples
   expectTypeOf(math.chain([12, 13, 14]).fraction()).toMatchTypeOf<
     MathJsChain<MathCollection>
   >()
-  expectTypeOf(math.chain([12, 13, 14]).fraction(2)).toMatchTypeOf<
+  expectTypeOf(math.chain([12, 13, 14]).fraction()).toMatchTypeOf<
     MathJsChain<MathCollection>
   >()
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -505,9 +505,6 @@ Chaining examples
       )
       .cbrt()
   ).toMatchTypeOf<MathJsChain<Matrix>>()
-  expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<
-    MathJsChain<Unit>
-  >()
 
   // cbrt
   expectTypeOf(math.chain(1).ceil()).toMatchTypeOf<

--- a/types/index.ts
+++ b/types/index.ts
@@ -568,9 +568,9 @@ Chaining examples
 
   // divide
   expectTypeOf(
-    math.chain(math.unit('femtosecond')).divide(math.unit('femtosecond'))
+    math.chain(math.unit('furlong')).divide(math.unit('femtosecond'))
   ).toMatchTypeOf<MathJsChain<number | Unit>>()
-  expectTypeOf(math.chain(math.unit('steradian')).divide(6)).toMatchTypeOf<
+  expectTypeOf(math.chain(math.unit('furlong')).divide(6)).toMatchTypeOf<
     MathJsChain<Unit>
   >()
   expectTypeOf(math.chain(2).divide(6)).toMatchTypeOf<MathJsChain<number>>()

--- a/types/index.ts
+++ b/types/index.ts
@@ -373,6 +373,18 @@ Chaining examples
   expectTypeOf(math.chain(math.bignumber(1)).lcm(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
   expectTypeOf(math.chain([1,2]).lcm([3,4])).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lcm(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // log
+  expectTypeOf(math.chain(1).log(2)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(math.bignumber(1)).log(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
+
+  // log10
+  expectTypeOf(math.chain(1).log10(2)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(math.bignumber(1)).log10(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain([1,2]).log10([3,4])).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).log10(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
+
+  // TODO complete the rest of these...
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -271,6 +271,10 @@ Chaining examples
 
   // slu
   expectTypeOf(math.chain(math.sparse([[1,2],[3,4]])).slu(2, 0.5)).toMatchTypeOf<MathJsChain<SLUDecomposition>>()
+
+  // usolve
+  expectTypeOf(math.chain([[1,2],[3,4]]).usolve([1,2])).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).usolve([1,2])).toMatchTypeOf<MathJsChain<Matrix>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -21,6 +21,7 @@ import {
   LUDecomposition,
   QRDecomposition,
   SLUDecomposition,
+  MathType,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -284,6 +285,11 @@ Chaining examples
   expectTypeOf(math.chain([1,2]).abs()).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).abs()).toMatchTypeOf<MathJsChain<Matrix>>()
   expectTypeOf(math.chain(math.unit('furlong')).abs()).toMatchTypeOf<MathJsChain<Unit>>()
+
+  // add
+  expectTypeOf(math.chain(1).add(2)).toMatchTypeOf<MathJsChain<MathType>>()
+  expectTypeOf(math.chain([1]).add(2)).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -302,11 +302,7 @@ Chaining examples
 
   // parser
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  expectTypeOf(math.chain('1 + 1').parser()).toMatchTypeOf<MathJsChain<any>>()
-  expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    MathJsChain<any>
-  >()
+  expectTypeOf(math.chain().parser()).toMatchTypeOf<MathJsChain<any>>()
 
   // resolve
   expectTypeOf(math.chain(math.parse('1 + 1')).resolve({})).toMatchTypeOf<

--- a/types/index.ts
+++ b/types/index.ts
@@ -263,6 +263,10 @@ Chaining examples
   // rationalize
   expectTypeOf(math.chain('1.23').rationalize()).toMatchTypeOf<MathJsChain<MathNode>>()
   expectTypeOf(math.chain(math.parse('1.23')).rationalize()).toMatchTypeOf<MathJsChain<MathNode>>()
+
+  // simplify
+  expectTypeOf(math.chain('a + a + b').simplify()).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain(math.parse('a + a + b')).simplify()).toMatchTypeOf<MathJsChain<MathNode>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -80,6 +80,8 @@ Basic usage examples
   math.chain(m2by3).variance(0, 'biased')
   math.chain(m2by3).variance(1, 'uncorrected').variance('unbiased')
 
+  math.variance(math.variance(m2by3, 'uncorrected'))
+
   // expressions
   math.evaluate('1.2 * (2 + 4.5)')
 
@@ -166,6 +168,7 @@ Chaining examples
   )
 
   const r = math.chain(-0.483).round([0, 1, 2]).floor().add(0.52).fix(1).done()
+
   assert.deepStrictEqual(r, [0.5, -0.4, -0.4])
 
   expectTypeOf(
@@ -720,11 +723,11 @@ Chaining examples
   ).toMatchTypeOf<MathJsChain<BigNumber>>()
 
   // log10
-  expectTypeOf(math.chain(1).log10(2)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(1).log10()).toMatchTypeOf<MathJsChain<number>>()
   expectTypeOf(
-    math.chain(math.bignumber(1)).log10(math.bignumber(2))
+    math.chain(math.bignumber(1)).log10()
   ).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(math.chain([1, 2]).log10([3, 4])).toMatchTypeOf<
+  expectTypeOf(math.chain([1, 2]).log10()).toMatchTypeOf<
     MathJsChain<MathArray>
   >()
   expectTypeOf(
@@ -735,12 +738,7 @@ Chaining examples
           [3, 4],
         ])
       )
-      .log10(
-        math.matrix([
-          [1, 2],
-          [3, 4],
-        ])
-      )
+      .log10()
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // TODO complete the rest of these...

--- a/types/index.ts
+++ b/types/index.ts
@@ -652,26 +652,29 @@ Chaining examples
   ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // gcd
-  expectTypeOf(math.chain([1, 2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(math.chain([[1], [2]]).gcd()).toMatchTypeOf<
-    MathJsChain<MathArray>
-  >()
-  expectTypeOf(
-    math.chain([math.bignumber(1), math.bignumber(1)]).gcd()
-  ).toMatchTypeOf<MathJsChain<BigNumber>>()
-  expectTypeOf(
-    math.chain([math.complex(1, 2), math.complex(1, 2)]).gcd()
-  ).toMatchTypeOf<MathJsChain<Complex>>()
-  expectTypeOf(
-    math
-      .chain(
-        math.matrix([
-          [1, 2],
-          [3, 4],
-        ])
-      )
-      .expm1()
-  ).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain([1, 2]).gcd(3)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([1, 2]).gcd(3, 4)).toMatchTypeOf<MathJsChain<number>>()
+  // TODO make gcd() work in the following cases
+  // expectTypeOf(math.chain([1, 2]).gcd()).toMatchTypeOf<MathJsChain<number>>()
+  // expectTypeOf(math.chain([[1], [2]]).gcd()).toMatchTypeOf<
+  //   MathJsChain<MathArray>
+  // >()
+  // expectTypeOf(
+  //   math.chain([math.bignumber(1), math.bignumber(1)]).gcd()
+  // ).toMatchTypeOf<MathJsChain<BigNumber>>()
+  // expectTypeOf(
+  //   math.chain([math.complex(1, 2), math.complex(1, 2)]).gcd()
+  // ).toMatchTypeOf<MathJsChain<Complex>>()
+  // expectTypeOf(
+  //   math
+  //     .chain(
+  //       math.matrix([
+  //         [1, 2],
+  //         [3, 4],
+  //       ])
+  //     )
+  //     .expm1()
+  // ).toMatchTypeOf<MathJsChain<Matrix>>()
 
   // hypot
   expectTypeOf(math.chain([1, 2]).hypot()).toMatchTypeOf<MathJsChain<number>>()

--- a/types/index.ts
+++ b/types/index.ts
@@ -223,6 +223,11 @@ Chaining examples
   // split unit
   expectTypeOf(math.chain(math.unit('furlong')).splitUnit([])).toMatchTypeOf<MathJsChain<Unit[]>>()
   expectTypeOf(math.chain(math.unit('furlong')).splitUnit([]).done()).toMatchTypeOf<Unit[]>()
+
+  // string
+  expectTypeOf(math.chain('test').string()).toMatchTypeOf<MathJsChain<string>>()
+  expectTypeOf(math.chain('test').string().done()).toMatchTypeOf<string>()
+  expectTypeOf(math.chain([1,2,3]).string()).toMatchTypeOf<MathJsChain<MathCollection>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -293,6 +293,15 @@ Chaining examples
 
   // apply
   expectTypeOf(math.chain([1,2,3]).apply(1, () => 1)).toMatchTypeOf<MathJsChain<number[]>>()
+
+  // cbrt
+  expectTypeOf(math.chain(1).cbrt()).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(math.bignumber(1)).cbrt()).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain(math.fraction(1,2)).cbrt()).toMatchTypeOf<MathJsChain<Fraction>>()
+  expectTypeOf(math.chain(math.complex(1,2)).cbrt()).toMatchTypeOf<MathJsChain<Complex>>()
+  expectTypeOf(math.chain([1,2]).cbrt()).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).cbrt()).toMatchTypeOf<MathJsChain<Matrix>>()
+  expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<MathJsChain<Unit>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -259,6 +259,10 @@ Chaining examples
   // qr
   expectTypeOf(math.chain([[1,2],[3,4]]).qr()).toMatchTypeOf<MathJsChain<QRDecomposition>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).qr()).toMatchTypeOf<MathJsChain<QRDecomposition>>()
+
+  // rationalize
+  expectTypeOf(math.chain('1.23').rationalize()).toMatchTypeOf<MathJsChain<MathNode>>()
+  expectTypeOf(math.chain(math.parse('1.23')).rationalize()).toMatchTypeOf<MathJsChain<MathNode>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -328,6 +328,12 @@ Chaining examples
   expectTypeOf(math.chain([1,2]).cube()).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).cube()).toMatchTypeOf<MathJsChain<Matrix>>()
   expectTypeOf(math.chain(math.unit('furlong')).cube()).toMatchTypeOf<MathJsChain<Unit>>()
+
+  // divide
+  expectTypeOf(math.chain(math.unit('furlong')).divide(math.unit('furlong'))).toMatchTypeOf<MathJsChain<number | Unit>>()
+  expectTypeOf(math.chain(math.unit('furlong')).divide(6)).toMatchTypeOf<MathJsChain<Unit>>()
+  expectTypeOf(math.chain(2).divide(6)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain([1,2,3]).divide(6)).toMatchTypeOf<MathJsChain<MathType>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -367,6 +367,12 @@ Chaining examples
   // hypot
   expectTypeOf(math.chain([1,2]).hypot()).toMatchTypeOf<MathJsChain<number>>()
   expectTypeOf(math.chain([math.bignumber(1),math.bignumber(1)]).hypot()).toMatchTypeOf<MathJsChain<BigNumber>>()
+
+  // lcm
+  expectTypeOf(math.chain(1).lcm(2)).toMatchTypeOf<MathJsChain<number>>()
+  expectTypeOf(math.chain(math.bignumber(1)).lcm(math.bignumber(2))).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain([1,2]).lcm([3,4])).toMatchTypeOf<MathJsChain<MathArray>>()
+  expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).lcm(math.matrix([[1,2],[3,4]]))).toMatchTypeOf<MathJsChain<Matrix>>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -288,8 +288,10 @@ Chaining examples
   >()
 
   // evaluate
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expectTypeOf(math.chain('1 + 1').evaluate()).toMatchTypeOf<MathJsChain<any>>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).evaluate()).toMatchTypeOf<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     MathJsChain<any[]>
   >()
 
@@ -302,8 +304,10 @@ Chaining examples
   >()
 
   // parser
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expectTypeOf(math.chain('1 + 1').parser()).toMatchTypeOf<MathJsChain<any>>()
   expectTypeOf(math.chain(['1 + 1', '2 + 2']).parser()).toMatchTypeOf<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     MathJsChain<any>
   >()
 
@@ -724,9 +728,9 @@ Chaining examples
 
   // log10
   expectTypeOf(math.chain(1).log10()).toMatchTypeOf<MathJsChain<number>>()
-  expectTypeOf(
-    math.chain(math.bignumber(1)).log10()
-  ).toMatchTypeOf<MathJsChain<BigNumber>>()
+  expectTypeOf(math.chain(math.bignumber(1)).log10()).toMatchTypeOf<
+    MathJsChain<BigNumber>
+  >()
   expectTypeOf(math.chain([1, 2]).log10()).toMatchTypeOf<
     MathJsChain<MathArray>
   >()
@@ -1808,6 +1812,7 @@ Factory Test
     expectTypeOf(x).toMatchTypeOf<math.SymbolNode>()
   }
   if (math.isChain(x)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expectTypeOf(x).toMatchTypeOf<math.MathJsChain<any>>()
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -219,6 +219,10 @@ Chaining examples
    // sparse
   expectTypeOf(math.chain([12, 13, 14, 15]).sparse()).toMatchTypeOf<MathJsChain<Matrix>>()
   expectTypeOf(math.chain([12, 13, 14, 15]).sparse().done()).toMatchTypeOf<Matrix>()
+
+  // split unit
+  expectTypeOf(math.chain(math.unit('furlong')).splitUnit([])).toMatchTypeOf<MathJsChain<Unit[]>>()
+  expectTypeOf(math.chain(math.unit('furlong')).splitUnit([]).done()).toMatchTypeOf<Unit[]>()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -22,6 +22,7 @@ import {
   QRDecomposition,
   SLUDecomposition,
   MathType,
+  MathNumericType,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -302,6 +303,10 @@ Chaining examples
   expectTypeOf(math.chain([1,2]).cbrt()).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(math.chain(math.matrix([[1,2],[3,4]])).cbrt()).toMatchTypeOf<MathJsChain<Matrix>>()
   expectTypeOf(math.chain(math.unit('furlong')).cbrt()).toMatchTypeOf<MathJsChain<Unit>>()
+
+  // cbrt
+  expectTypeOf(math.chain(1).ceil()).toMatchTypeOf<MathJsChain<MathNumericType>>()
+  expectTypeOf(math.chain([1]).ceil()).toMatchTypeOf<MathJsChain<MathCollection>>()
 }
 
 /*


### PR DESCRIPTION
Adds TReturn generic to MathJsChain and populates it with the return type of whatever chain function returns it

**Example:**

`.done()` now returns correct node type for `complex()`
<img width="616" alt="image" src="https://user-images.githubusercontent.com/64985/164341964-aacc2291-d96e-4af4-b24d-d72dac203fb8.png">
<img width="495" alt="image" src="https://user-images.githubusercontent.com/64985/164342203-fc0d9182-312c-4d04-9579-0823af46f73a.png">

**Note:** @josdejong   this is just a proof of concept for now to see wha you think. It's obviously not perfect, but I think it's better than the current `any` type that is returned by `done()`. In any case, if the type turns out to be wrong that's always fixable by passing a generic.

Also: I think it maybe be possible to typecheck that each chain function is called on a preceding function returning a valid value, but would have to play around

Also also: I think it may also be possible to not have to duplicate the param types for each chain function as you have now using the [`Parameters` generic util](https://www.typescriptlang.org/docs/handbook/utility-types.html#parameterstype)