### PR TITLE
fix: Type declarations for rounding functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -179,7 +179,6 @@ Alfonso Valenciana <valencianaad@hotmail.com>
 David <dvd.cnt@gmail.com>
 Glen Whitney <glen@studioinfinity.org>
 Divya Yeruva <divyareddy.y019@gmail.com>
-Yeruva <Divya.Yeruva@pepsico.com>
 Eternal-Rise <my_dawn@ukr.net>
 yifanwww <yifanw1101@gmail.com>
 NattapongSiri <38780353+NattapongSiri@users.noreply.github.com>

--- a/docs/datatypes/matrices.md
+++ b/docs/datatypes/matrices.md
@@ -342,6 +342,23 @@ const m1 = math.matrix([[0, 1], [0, 0]], 'sparse')
 const m2 = math.identity(1000, 1000, 'sparse')
 ```
 
+You can also coerce an array or matrix into sparse storage format with the
+`sparse` function.
+```js
+const md = math.matrix([[0, 1], [0,0]])  // dense
+const ms = math.sparse(md)               // sparse
+```
+
+Caution: `sparse` called on a JavaScript array of _n_ plain numbers produces
+a matrix with one column and _n_ rows -- in contrast to `matrix`, which
+produces a 1-dimensional matrix object with _n_ entries, i.e., a vector
+(_not_ a 1 by _n_ "row vector" nor an _n_ by 1 "column vector", but just a plain
+vector of length _n_).
+```js
+const mv = math.matrix([0, 0, 1])  // Has size [3]
+const mc = math.sparse([0, 0, 1])  // A "column vector," has size [3, 1]
+```
+
 ## API
 
 All relevant functions in math.js support Matrices and Arrays. Functions like `math.add` and `math.subtract`, `math.sqrt` handle matrices element wise. There is a set of functions specifically for creating or manipulating matrices, such as:

--- a/src/factoriesNumber.js
+++ b/src/factoriesNumber.js
@@ -20,7 +20,6 @@ import {
   bitOrNumber,
   bitXorNumber,
   cbrtNumber,
-  ceilNumber,
   combinationsNumber,
   coshNumber,
   cosNumber,
@@ -32,8 +31,6 @@ import {
   divideNumber,
   expm1Number,
   expNumber,
-  fixNumber,
-  floorNumber,
   gammaNumber,
   gcdNumber,
   isIntegerNumber,
@@ -52,10 +49,12 @@ import {
   multiplyNumber,
   normNumber,
   notNumber,
+  nthRootNumber,
   orNumber,
   powNumber,
   rightArithShiftNumber,
   rightLogShiftNumber,
+  roundNumber,
   sechNumber,
   secNumber,
   signNumber,
@@ -102,12 +101,12 @@ export const createUnaryPlus = /* #__PURE__ */ createNumberFactory('unaryPlus', 
 export const createAbs = /* #__PURE__ */ createNumberFactory('abs', absNumber)
 export const createAddScalar = /* #__PURE__ */ createNumberFactory('addScalar', addNumber)
 export const createCbrt = /* #__PURE__ */ createNumberFactory('cbrt', cbrtNumber)
-export const createCeil = /* #__PURE__ */ createNumberFactory('ceil', ceilNumber)
+export { createCeilNumber as createCeil } from './function/arithmetic/ceil.js'
 export const createCube = /* #__PURE__ */ createNumberFactory('cube', cubeNumber)
 export const createExp = /* #__PURE__ */ createNumberFactory('exp', expNumber)
 export const createExpm1 = /* #__PURE__ */ createNumberFactory('expm1', expm1Number)
-export const createFix = /* #__PURE__ */ createNumberFactory('fix', fixNumber)
-export const createFloor = /* #__PURE__ */ createNumberFactory('floor', floorNumber)
+export { createFixNumber as createFix } from './function/arithmetic/fix.js'
+export { createFloorNumber as createFloor } from './function/arithmetic/floor.js'
 export const createGcd = /* #__PURE__ */ createNumberFactory('gcd', gcdNumber)
 export const createLcm = /* #__PURE__ */ createNumberFactory('lcm', lcmNumber)
 export const createLog10 = /* #__PURE__ */ createNumberFactory('log10', log10Number)
@@ -115,7 +114,8 @@ export const createLog2 = /* #__PURE__ */ createNumberFactory('log2', log2Number
 export const createMod = /* #__PURE__ */ createNumberFactory('mod', modNumber)
 export const createMultiplyScalar = /* #__PURE__ */ createNumberFactory('multiplyScalar', multiplyNumber)
 export const createMultiply = /* #__PURE__ */ createNumberFactory('multiply', multiplyNumber)
-export { createNthRootNumber as createNthRoot } from './function/arithmetic/nthRoot.js'
+export const createNthRoot = /* #__PURE__ */
+  createNumberOptionalSecondArgFactory('nthRoot', nthRootNumber)
 export const createSign = /* #__PURE__ */ createNumberFactory('sign', signNumber)
 export const createSqrt = /* #__PURE__ */ createNumberFactory('sqrt', sqrtNumber)
 export const createSquare = /* #__PURE__ */ createNumberFactory('square', squareNumber)
@@ -123,7 +123,8 @@ export const createSubtract = /* #__PURE__ */ createNumberFactory('subtract', su
 export const createXgcd = /* #__PURE__ */ createNumberFactory('xgcd', xgcdNumber)
 export const createDivideScalar = /* #__PURE__ */ createNumberFactory('divideScalar', divideNumber)
 export const createPow = /* #__PURE__ */ createNumberFactory('pow', powNumber)
-export { createRoundNumber as createRound } from './function/arithmetic/round.js'
+export const createRound = /* #__PURE__ */
+  createNumberOptionalSecondArgFactory('round', roundNumber)
 export const createLog = /* #__PURE__ */
   createNumberOptionalSecondArgFactory('log', logNumber)
 export const createLog1p = /* #__PURE__ */ createNumberFactory('log1p', log1pNumber)

--- a/src/function/arithmetic/nthRoot.js
+++ b/src/function/arithmetic/nthRoot.js
@@ -58,10 +58,7 @@ export const createNthRoot = /* #__PURE__ */ factory(name, dependencies, ({ type
   )
   return typed(name, {
 
-    number: function (x) {
-      return nthRootNumber(x, 2)
-    },
-
+    number: nthRootNumber,
     'number, number': nthRootNumber,
 
     BigNumber: function (x) {

--- a/src/plain/number/arithmetic.js
+++ b/src/plain/number/arithmetic.js
@@ -1,4 +1,4 @@
-import { isInteger, log2, log10, cbrt, expm1, sign, toFixed, log1p } from '../../utils/number.js'
+import { cbrt, expm1, isInteger, log10, log1p, log2, sign, toFixed } from '../../utils/number.js'
 
 const n1 = 'number'
 const n2 = 'number, number'
@@ -43,11 +43,6 @@ export function cbrtNumber (x) {
 }
 cbrtNumber.signature = n1
 
-export function ceilNumber (x) {
-  return Math.ceil(x)
-}
-ceilNumber.signature = n1
-
 export function cubeNumber (x) {
   return x * x * x
 }
@@ -62,16 +57,6 @@ export function expm1Number (x) {
   return expm1(x)
 }
 expm1Number.signature = n1
-
-export function fixNumber (x) {
-  return (x > 0) ? Math.floor(x) : Math.ceil(x)
-}
-fixNumber.signature = n1
-
-export function floorNumber (x) {
-  return Math.floor(x)
-}
-floorNumber.signature = n1
 
 /**
  * Calculate gcd for numbers
@@ -190,10 +175,10 @@ modNumber.signature = n2
  * Calculate the nth root of a, solve x^root == a
  * http://rosettacode.org/wiki/Nth_root#JavaScript
  * @param {number} a
- * @param {number} root
+ * @param {number} [2] root
  * @private
  */
-export function nthRootNumber (a, root) {
+export function nthRootNumber (a, root = 2) {
   const inv = root < 0
   if (inv) {
     root = -root
@@ -243,7 +228,6 @@ export function nthRootNumber (a, root) {
   return inv ? 1 / x : x
   */
 }
-nthRootNumber.signature = n2
 
 export function signNumber (x) {
   return sign(x)
@@ -333,9 +317,11 @@ powNumber.signature = n2
  * @return {number} roundedValue
  */
 export function roundNumber (value, decimals = 0) {
+  if (!isInteger(decimals) || decimals < 0 || decimals > 15) {
+    throw new Error('Number of decimals in function round must be an integer from 0 to 15 inclusive')
+  }
   return parseFloat(toFixed(value, decimals))
 }
-roundNumber.signature = n2
 
 /**
  * Calculate the norm of a number, the absolute value.

--- a/src/type/matrix/function/sparse.js
+++ b/src/type/matrix/function/sparse.js
@@ -8,6 +8,9 @@ export const createSparse = /* #__PURE__ */ factory(name, dependencies, ({ typed
    * Create a Sparse Matrix. The function creates a new `math.Matrix` object from
    * an `Array`. A Matrix has utility functions to manipulate the data in the
    * matrix, like getting the size and getting or setting values in the matrix.
+   * Note that a Sparse Matrix is always 2-dimensional, so for example if
+   * you create one from a plain array of _n_ numbers, you get an _n_ by 1
+   * Sparse "column vector".
    *
    * Syntax:
    *
@@ -22,6 +25,9 @@ export const createSparse = /* #__PURE__ */ factory(name, dependencies, ({ typed
    *    m.resize([3, 2], 5)
    *    m.valueOf()                     // Array [[1, 2], [3, 4], [5, 5]]
    *    m.get([1, 0])                    // number 3
+   *    let v = math.sparse([0, 0, 1])
+   *    v.size()                        // Array [3, 1]
+   *    v.get([2, 0])                   // number 1
    *
    * See also:
    *

--- a/test/node-tests/commonjs.test.js
+++ b/test/node-tests/commonjs.test.js
@@ -16,7 +16,7 @@ describe('lib/cjs', function () {
     const filename = path.join(__dirname, 'commonjsAppNumberOnly.cjs')
     cp.exec('node ' + filename, function (error, result) {
       assert.strictEqual(error, null)
-      assert.strictEqual(result, '2\nNaN\n2\n4\n')
+      assert.strictEqual(result, '2\nNaN\n2\n4\n7\n')
       done()
     })
   })

--- a/test/node-tests/commonjsAppNumberOnly.cjs
+++ b/test/node-tests/commonjsAppNumberOnly.cjs
@@ -1,6 +1,7 @@
-const { e, sqrt, format, log } = require('../../lib/cjs/number.js')
+const { e, floor, format, log, sqrt } = require('../../lib/cjs/number.js')
 
 console.log(format(sqrt(4)))
 console.log(format(sqrt(-4)))
 console.log(format(log(e * e)))
 console.log(format(log(625, 5)))
+console.log(format(floor(7 - 1e-13)))

--- a/test/node-tests/esm.test.js
+++ b/test/node-tests/esm.test.js
@@ -17,7 +17,7 @@ describe('lib/esm', function () {
     const filename = path.join(__dirname, 'esmAppNumberOnly.mjs')
     cp.exec('node ' + filename, function (error, result) {
       assert.strictEqual(error, null)
-      assert.strictEqual(result, '2\nNaN\n2\n4\n')
+      assert.strictEqual(result, '2\nNaN\n2\n4\n7\n')
       done()
     })
   })

--- a/test/node-tests/esmAppNumberOnly.mjs
+++ b/test/node-tests/esmAppNumberOnly.mjs
@@ -1,7 +1,8 @@
 // TODO: would be nice to call '../../' so we know for sure ESM is correctly exported
-import { e, sqrt, format, log } from '../../lib/esm/number.js'
+import { e, floor, format, log, sqrt } from '../../lib/esm/number.js'
 
 console.log(format(sqrt(4)))
 console.log(format(sqrt(-4)))
 console.log(format(log(e * e)))
 console.log(format(log(625, 5)))
+console.log(format(floor(7 - 1e-13)))

--- a/test/unit-tests/function/arithmetic/ceil.test.js
+++ b/test/unit-tests/function/arithmetic/ceil.test.js
@@ -59,6 +59,7 @@ describe('ceil', function () {
     assert.deepStrictEqual(ceil(bignumber(-1.3), 4), bignumber(-1.3))
     assert.deepStrictEqual(ceil(bignumber(-1.8), 0), bignumber(-1))
     assert.deepStrictEqual(ceil(bignumber(-1.315), 2), bignumber(-1.31))
+    assert.deepStrictEqual(ceil(bignumber(-1.315), bignumber(2)), bignumber(-1.31))
     assert.deepStrictEqual(ceil(bignumber(-2), 0), bignumber(-2))
     assert.deepStrictEqual(ceil(bignumber(-2.1), 0), bignumber(-2))
   })
@@ -75,6 +76,7 @@ describe('ceil', function () {
     approx.deepEqual(ceil(complex(1.3, 1.8), 0), complex(2, 2))
     approx.deepEqual(ceil(complex(1.3, 1.8), 1), complex(1.3, 1.8))
     approx.deepEqual(ceil(complex(1.315, 1.878), 2), complex(1.32, 1.88))
+    approx.deepEqual(ceil(complex(1.315, 1.878), bignumber(2)), complex(1.32, 1.88))
     approx.deepEqual(ceil(i, 0), complex(0, 1))
     approx.deepEqual(ceil(i, 4), complex(0, 1))
     approx.deepEqual(ceil(complex(-1.3, -1.8), 0), complex(-1, -1))
@@ -110,6 +112,7 @@ describe('ceil', function () {
     assert.strictEqual(ceil(fraction(0), 3).toString(), '0')
     assert.strictEqual(ceil(fraction(1), 4).toString(), '1')
     assert.strictEqual(ceil(fraction(1.315), 2).toString(), '1.32')
+    assert.strictEqual(ceil(fraction(1.315), bignumber(2)).toString(), '1.32')
     assert.strictEqual(ceil(fraction(-1), 0).toString(), '-1')
     assert.strictEqual(ceil(fraction(-1.315), 2).toString(), '-1.31')
   })
@@ -150,7 +153,7 @@ describe('ceil', function () {
   })
 
   it('should throw an error if requested number of decimals is incorrect', function () {
-    assert.throws(function () { ceil(2.5, 1.5) }, TypeError, 'Number of decimals in function round must be an integer')
+    assert.throws(function () { ceil(2.5, 1.5) }, Error, 'Number of decimals in function round must be an integer')
     assert.throws(function () { ceil(2.5, -2) }, Error, ' Number of decimals in function round must be in the range of 0-15')
     assert.throws(function () { ceil(2.5, Infinity) }, Error, ' Number of decimals in function round must be in the range of 0-15')
   })
@@ -170,10 +173,17 @@ describe('ceil', function () {
   it('should ceil each element in a matrix with a given number of decimals', function () {
     approx.deepEqual(ceil([1.282, 3.415, -5.121, -10.128], 2), [1.29, 3.42, -5.12, -10.12])
     approx.deepEqual(ceil(matrix([1.282, 3.415, -5.121, -10.128]), 2), matrix([1.29, 3.42, -5.12, -10.12]))
+    approx.deepEqual(ceil(matrix([1.282, 3.415, -5.121, -10.128]), bignumber(2)), matrix(bignumber([1.29, 3.42, -5.12, -10.12])))
   })
 
   it('should ceil when number of decimals is provided in an array', function () {
     assert.deepStrictEqual(ceil(3.12385, [2, 3]), [3.13, 3.124])
+  })
+
+  it('should ceil when number of decimals is provided in a matrix', function () {
+    assert.deepStrictEqual(ceil(3.12385, matrix([2, 3])), matrix([3.13, 3.124]))
+    assert.deepStrictEqual(ceil(0, matrix([2, 9, 12])), matrix([0, 0, 0]))
+    assert.deepStrictEqual(ceil(3.12385, sparse([0, 4])), matrix([[4], [3.1239]]))
   })
 
   it('should ceil dense matrix', function () {

--- a/test/unit-tests/function/arithmetic/fix.test.js
+++ b/test/unit-tests/function/arithmetic/fix.test.js
@@ -1,12 +1,12 @@
 // test fix
 import assert from 'assert'
 
-import approx from '../../../../tools/approx.js'
 import math from '../../../../src/defaultInstance.js'
 const bignumber = math.bignumber
 const complex = math.complex
 const fraction = math.fraction
 const matrix = math.matrix
+const sparse = math.sparse
 const unit = math.unit
 const fix = math.fix
 
@@ -17,37 +17,37 @@ describe('fix', function () {
   })
 
   it('should round numbers correctly', function () {
-    approx.equal(fix(0), 0)
-    approx.equal(fix(1), 1)
-    approx.equal(fix(1.3), 1)
-    approx.equal(fix(1.8), 1)
-    approx.equal(fix(2), 2)
-    approx.equal(fix(-1), -1)
-    approx.equal(fix(-1.3), -1)
-    approx.equal(fix(-1.8), -1)
-    approx.equal(fix(-2), -2)
-    approx.equal(fix(-2.1), -2)
-    approx.equal(fix(math.pi), 3)
+    assert.strictEqual(fix(0), 0)
+    assert.strictEqual(fix(1), 1)
+    assert.strictEqual(fix(1.3), 1)
+    assert.strictEqual(fix(1.8), 1)
+    assert.strictEqual(fix(2), 2)
+    assert.strictEqual(fix(-1), -1)
+    assert.strictEqual(fix(-1.3), -1)
+    assert.strictEqual(fix(-1.8), -1)
+    assert.strictEqual(fix(-2), -2)
+    assert.strictEqual(fix(-2.1), -2)
+    assert.strictEqual(fix(math.pi), 3)
   })
 
   it('should round numbers with a given number of decimals', function () {
-    approx.equal(fix(0, 5), 0)
-    approx.equal(fix(1, 5), 1)
-    approx.equal(fix(1.3, 5), 1.3)
-    approx.equal(fix(1.313, 2), 1.31)
-    approx.equal(fix(1.383, 2), 1.38)
-    approx.equal(fix(2.22, 2), 2.22)
-    approx.equal(fix(-1, 5), -1)
-    approx.equal(fix(-1.3, 5), -1.3)
-    approx.equal(fix(-1.883, 2), -1.88)
-    approx.equal(fix(-1.888, 2), -1.88)
-    approx.equal(fix(-2.22, 2), -2.22)
-    approx.equal(fix(math.pi, 6), 3.141592)
+    assert.strictEqual(fix(0, 5), 0)
+    assert.strictEqual(fix(1, 5), 1)
+    assert.strictEqual(fix(1.3, 5), 1.3)
+    assert.strictEqual(fix(1.313, 2), 1.31)
+    assert.strictEqual(fix(1.383, 2), 1.38)
+    assert.strictEqual(fix(2.22, 2), 2.22)
+    assert.strictEqual(fix(-1, 5), -1)
+    assert.strictEqual(fix(-1.3, 5), -1.3)
+    assert.strictEqual(fix(-1.883, 2), -1.88)
+    assert.strictEqual(fix(-1.888, 2), -1.88)
+    assert.strictEqual(fix(-2.22, 2), -2.22)
+    assert.strictEqual(fix(math.pi, 6), 3.141592)
 
-    approx.equal(fix(1.313, bignumber(2)), 1.31)
-    approx.equal(fix(1.383, bignumber(2)), 1.38)
-    approx.equal(fix(-1.883, bignumber(2)), -1.88)
-    approx.equal(fix(-1.888, bignumber(2)), -1.88)
+    assert.deepStrictEqual(fix(1.313, bignumber(2)), bignumber(1.31))
+    assert.deepStrictEqual(fix(1.383, bignumber(2)), bignumber(1.38))
+    assert.deepStrictEqual(fix(-1.883, bignumber(2)), bignumber(-1.88))
+    assert.deepStrictEqual(fix(-1.888, bignumber(2)), bignumber(-1.88))
   })
 
   it('should round big numbers correctly', function () {
@@ -83,22 +83,22 @@ describe('fix', function () {
 
   it('should round complex numbers correctly', function () {
     // complex
-    approx.deepEqual(fix(complex(0, 0)), complex(0, 0))
-    approx.deepEqual(fix(complex(1.3, 1.8)), complex(1, 1))
-    approx.deepEqual(fix(math.i), complex(0, 1))
-    approx.deepEqual(fix(complex(-1.3, -1.8)), complex(-1, -1))
+    assert.deepStrictEqual(fix(complex(0, 0)), complex(0, 0))
+    assert.deepStrictEqual(fix(complex(1.3, 1.8)), complex(1, 1))
+    assert.deepStrictEqual(fix(math.i), complex(0, 1))
+    assert.deepStrictEqual(fix(complex(-1.3, -1.8)), complex(-1, -1))
   })
 
   it('should round complex numbers with a given number of decimals', function () {
-    approx.deepEqual(fix(complex(0, 0), 5), complex(0, 0))
-    approx.deepEqual(fix(complex(1.335, 2.835), 2), complex(1.33, 2.83))
-    approx.deepEqual(fix(math.i, 5), complex(0, 1))
-    approx.deepEqual(fix(complex(-1.335, -1.835), 2), complex(-1.33, -1.83))
+    assert.deepStrictEqual(fix(complex(0, 0), 5), complex(0, 0))
+    assert.deepStrictEqual(fix(complex(1.335, 2.835), 2), complex(1.33, 2.83))
+    assert.deepStrictEqual(fix(math.i, 5), complex(0, 1))
+    assert.deepStrictEqual(fix(complex(-1.335, -1.835), 2), complex(-1.33, -1.83))
 
-    approx.deepEqual(fix(complex(0, 0), bignumber(5)), complex(0, 0))
-    approx.deepEqual(fix(complex(1.335, 2.835), bignumber(2)), complex(1.33, 2.83))
-    approx.deepEqual(fix(math.i, bignumber(5)), complex(0, 1))
-    approx.deepEqual(fix(complex(-1.335, -1.835), bignumber(2)), complex(-1.33, -1.83))
+    assert.deepStrictEqual(fix(complex(0, 0), bignumber(5)), complex(0, 0))
+    assert.deepStrictEqual(fix(complex(1.335, 2.835), bignumber(2)), complex(1.33, 2.83))
+    assert.deepStrictEqual(fix(math.i, bignumber(5)), complex(0, 1))
+    assert.deepStrictEqual(fix(complex(-1.335, -1.835), bignumber(2)), complex(-1.33, -1.83))
   })
 
   it('should round fractions correctly', function () {
@@ -187,22 +187,29 @@ describe('fix', function () {
 
   it('should correctly round all values of a matrix element-wise', function () {
     // matrix, array, range
-    approx.deepEqual(fix([1.2, 3.4, 5.6, 7.8, 10.0]), [1, 3, 5, 7, 10])
-    approx.deepEqual(fix(matrix([1.2, 3.4, 5.6, 7.8, 10.0])), matrix([1, 3, 5, 7, 10]))
+    assert.deepStrictEqual(fix([1.2, 3.4, 5.6, 7.8, 10.0]), [1, 3, 5, 7, 10])
+    assert.deepStrictEqual(fix(matrix([1.2, 3.4, 5.6, 7.8, 10.0])), matrix([1, 3, 5, 7, 10]))
   })
 
   it('should round all values of a matrix element-wise with a given number of decimals', function () {
-    approx.deepEqual(fix([1.234, 3.456, 5.678, 7.891, 10.01], 2), [1.23, 3.45, 5.67, 7.89, 10.01])
-    approx.deepEqual(fix(matrix([1.234, 3.456, 5.678, 7.891, 10.01]), 2), matrix([1.23, 3.45, 5.67, 7.89, 10.01]))
+    assert.deepStrictEqual(fix([1.234, 3.456, 5.678, 7.891, 10.01], 2), [1.23, 3.45, 5.67, 7.89, 10.01])
+    assert.deepStrictEqual(fix(matrix([1.234, 3.456, 5.678, 7.891, 10.01]), 2), matrix([1.23, 3.45, 5.67, 7.89, 10.01]))
 
-    approx.deepEqual(fix([1.234, 3.456, 5.678, 7.891, 10.01], bignumber(2)), [1.23, 3.45, 5.67, 7.89, 10.01])
-    approx.deepEqual(fix(matrix([1.234, 3.456, 5.678, 7.891, 10.01]), bignumber(2)), matrix([1.23, 3.45, 5.67, 7.89, 10.01]))
+    assert.deepStrictEqual(fix([1.234, 3.456, 5.678, 7.891, 10.01], bignumber(2)), bignumber([1.23, 3.45, 5.67, 7.89, 10.01]))
+    assert.deepStrictEqual(fix(matrix([1.234, 3.456, 5.678, 7.891, 10.01]), bignumber(2)), matrix(bignumber([1.23, 3.45, 5.67, 7.89, 10.01])))
   })
 
   it('should round correctly with decimals provided in an array', function () {
-    approx.deepEqual(fix(1.234567, [0, 1, 2, 3, 4]), [1, 1.2, 1.23, 1.234, 1.2345])
-    approx.deepEqual(fix(bignumber(math.pi), [0, 1, 2, 3, 4]), [3, 3.1, 3.14, 3.141, 3.1415])
-    approx.deepEqual(fix(complex(1.335, 2.835), [1, 2]), [complex(1.3, 2.8), complex(1.33, 2.83)])
+    assert.deepStrictEqual(fix(1.234567, [0, 1, 2, 3, 4]), [1, 1.2, 1.23, 1.234, 1.2345])
+    assert.deepStrictEqual(fix(bignumber(math.pi), [0, 1, 2, 3, 4]), bignumber([3, 3.1, 3.14, 3.141, 3.1415]))
+    assert.deepStrictEqual(fix(complex(1.335, 2.835), [1, 2]), [complex(1.3, 2.8), complex(1.33, 2.83)])
+  })
+
+  it('should round correctly with decimals provided in a matrix', function () {
+    assert.deepStrictEqual(fix(1.234567, matrix([0, 1, 2, 3, 4])), matrix([1, 1.2, 1.23, 1.234, 1.2345]))
+    assert.deepStrictEqual(fix(0, matrix([0, 2, 4])), matrix([0, 0, 0]))
+    assert.deepStrictEqual(fix(bignumber(math.pi), sparse([0, 1, 2, 3, 4])), matrix(bignumber([[3], [3.1], [3.14], [3.141], [3.1415]])))
+    assert.deepStrictEqual(fix(complex(1.335, 2.835), matrix([1, 2])), matrix([complex(1.3, 2.8), complex(1.33, 2.83)]))
   })
 
   it('should throw an error in case of invalid number of arguments', function () {

--- a/test/unit-tests/function/arithmetic/floor.test.js
+++ b/test/unit-tests/function/arithmetic/floor.test.js
@@ -1,7 +1,6 @@
 // test floor
 import assert from 'assert'
 
-import approx from '../../../../tools/approx.js'
 import math from '../../../../src/defaultInstance.js'
 const bignumber = math.bignumber
 const complex = math.complex
@@ -19,30 +18,31 @@ describe('floor', function () {
   })
 
   it('should floor numbers correctly', function () {
-    approx.equal(floor(0), 0)
-    approx.equal(floor(1), 1)
-    approx.equal(floor(1.3), 1)
-    approx.equal(floor(1.8), 1)
-    approx.equal(floor(2), 2)
-    approx.equal(floor(-1), -1)
-    approx.equal(floor(-1.3), -2)
-    approx.equal(floor(-1.8), -2)
-    approx.equal(floor(-2), -2)
-    approx.equal(floor(-2.1), -3)
-    approx.equal(floor(math.pi), 3)
+    assert.strictEqual(floor(0), 0)
+    assert.strictEqual(floor(1), 1)
+    assert.strictEqual(floor(1.3), 1)
+    assert.strictEqual(floor(1.8), 1)
+    assert.strictEqual(floor(2), 2)
+    assert.strictEqual(floor(-1), -1)
+    assert.strictEqual(floor(-1.3), -2)
+    assert.strictEqual(floor(-1.8), -2)
+    assert.strictEqual(floor(-2), -2)
+    assert.strictEqual(floor(-2.1), -3)
+    assert.strictEqual(floor(math.pi), 3)
   })
 
   it('should return the floor of a number with a given number of decimals', function () {
-    approx.equal(floor(0, 5), 0)
-    approx.equal(floor(2, 3), 2)
-    approx.equal(floor(1.3216, 2), 1.32)
-    approx.equal(floor(math.pi, 3), 3.141)
-    approx.equal(floor(math.pi, 6), 3.141593)
-    approx.equal(floor(1234.5678, 2), 1234.56)
-    approx.equal(floor(2.135, 2), 2.13)
-    approx.equal(floor(-1.8, 0), -2)
-    approx.equal(floor(-1.8, 1), -1.8)
-    approx.equal(floor(-2.178, 2), -2.18)
+    assert.strictEqual(floor(0, 5), 0)
+    assert.strictEqual(floor(2, 3), 2)
+    assert.strictEqual(floor(1.3216, 2), 1.32)
+    assert.strictEqual(floor(math.pi, 3), 3.141)
+    assert.strictEqual(floor(math.pi, 6), 3.141592)
+    assert.strictEqual(floor(1234.5678, 2), 1234.56)
+    assert.strictEqual(floor(2.135, 2), 2.13)
+    assert.deepStrictEqual(floor(2.135, bignumber(2)), bignumber(2.13))
+    assert.strictEqual(floor(-1.8, 0), -2)
+    assert.strictEqual(floor(-1.8, 1), -1.8)
+    assert.strictEqual(floor(-2.178, 2), -2.18)
   })
 
   it('should floor big numbers correctly', function () {
@@ -63,6 +63,7 @@ describe('floor', function () {
     assert.deepStrictEqual(floor(bignumber(1), 3), bignumber(1))
     assert.deepStrictEqual(floor(bignumber(1.315), 2), bignumber(1.31))
     assert.deepStrictEqual(floor(bignumber(1.8), 1), bignumber(1.8))
+    assert.deepStrictEqual(floor(bignumber(2.135), bignumber(2)), bignumber(2.13))
     assert.deepStrictEqual(floor(bignumber(-1), 4), bignumber(-1))
     assert.deepStrictEqual(floor(bignumber(-1.3), 4), bignumber(-1.3))
     assert.deepStrictEqual(floor(bignumber(-1.8), 0), bignumber(-2))
@@ -72,22 +73,23 @@ describe('floor', function () {
   })
 
   it('should floor complex numbers correctly', function () {
-    approx.deepEqual(floor(complex(0, 0)), complex(0, 0))
-    approx.deepEqual(floor(complex(1.3, 1.8)), complex(1, 1))
-    approx.deepEqual(floor(i), complex(0, 1))
-    approx.deepEqual(floor(complex(-1.3, -1.8)), complex(-2, -2))
+    assert.deepStrictEqual(floor(complex(0, 0)), complex(0, 0))
+    assert.deepStrictEqual(floor(complex(1.3, 1.8)), complex(1, 1))
+    assert.deepStrictEqual(floor(i), complex(0, 1))
+    assert.deepStrictEqual(floor(complex(-1.3, -1.8)), complex(-2, -2))
   })
 
   it('should return the floor of real and imag part of a complex with a given number of decimals', function () {
-    approx.deepEqual(floor(complex(0, 0), 3), complex(0, 0))
-    approx.deepEqual(floor(complex(1.3, 1.8), 0), complex(1, 1))
-    approx.deepEqual(floor(complex(1.3, 1.8), 1), complex(1.3, 1.8))
-    approx.deepEqual(floor(complex(1.315, 1.878), 2), complex(1.31, 1.87))
-    approx.deepEqual(floor(i, 0), complex(0, 1))
-    approx.deepEqual(floor(i, 4), complex(0, 1))
-    approx.deepEqual(floor(complex(-1.3, -1.8), 0), complex(-2, -2))
-    approx.deepEqual(floor(complex(-1.3, -1.8), 1), complex(-1.3, -1.8))
-    approx.deepEqual(floor(complex(-1.315, -1.878), 2), complex(-1.32, -1.88))
+    assert.deepStrictEqual(floor(complex(0, 0), 3), complex(0, 0))
+    assert.deepStrictEqual(floor(complex(1.3, 1.8), 0), complex(1, 1))
+    assert.deepStrictEqual(floor(complex(1.3, 1.8), 1), complex(1.3, 1.8))
+    assert.deepStrictEqual(floor(complex(1.315, 1.878), 2), complex(1.31, 1.87))
+    assert.deepStrictEqual(floor(complex(1.315, 1.878), bignumber(2)), complex(1.31, 1.87))
+    assert.deepStrictEqual(floor(i, 0), complex(0, 1))
+    assert.deepStrictEqual(floor(i, 4), complex(0, 1))
+    assert.deepStrictEqual(floor(complex(-1.3, -1.8), 0), complex(-2, -2))
+    assert.deepStrictEqual(floor(complex(-1.3, -1.8), 1), complex(-1.3, -1.8))
+    assert.deepStrictEqual(floor(complex(-1.315, -1.878), 2), complex(-1.32, -1.88))
   })
 
   it('should floor fractions correctly', function () {
@@ -112,6 +114,8 @@ describe('floor', function () {
     assert.strictEqual(floor(fraction(0), 3).toString(), '0')
     assert.strictEqual(floor(fraction(1), 4).toString(), '1')
     assert.strictEqual(floor(fraction(1.315), 2).toString(), '1.31')
+    assert.strictEqual(floor(fraction(1.315), bignumber(2)).toString(), '1.31')
+    assert.deepStrictEqual(floor(fraction(44, 7), bignumber(2)), fraction(628, 100))
     assert.strictEqual(floor(fraction(-1), 0).toString(), '-1')
     assert.strictEqual(floor(fraction(-1.315), 2).toString(), '-1.32')
   })
@@ -156,17 +160,30 @@ describe('floor', function () {
   })
 
   it('should floor all elements in a matrix', function () {
-    approx.deepEqual(floor([1.2, 3.4, 5.6, 7.8, 10.0]), [1, 3, 5, 7, 10])
-    approx.deepEqual(floor(matrix([1.2, 3.4, 5.6, 7.8, 10.0])), matrix([1, 3, 5, 7, 10]))
+    assert.deepStrictEqual(floor([1.2, 3.4, 5.6, 7.8, 10.0]), [1, 3, 5, 7, 10])
+    assert.deepStrictEqual(floor(matrix([1.2, 3.4, 5.6, 7.8, 10.0])), matrix([1, 3, 5, 7, 10]))
   })
 
   it('should floor each element in a matrix with a given number of decimals', function () {
-    approx.deepEqual(floor([1.282, 3.415, -5.121, -10.128], 2), [1.28, 3.41, -5.13, -10.13])
-    approx.deepEqual(floor(matrix([1.282, 3.415, -5.121, -10.128]), 2), matrix([1.28, 3.41, -5.13, -10.13]))
+    assert.deepStrictEqual(floor([1.282, 3.415, -5.121, -10.128], 2), [1.28, 3.41, -5.13, -10.13])
+    assert.deepStrictEqual(floor([1.282, 3.415, -5.121, -10.128], bignumber(2)), [bignumber(1.28), bignumber(3.41), bignumber(-5.13), bignumber(-10.13)])
+    assert.deepStrictEqual(floor(matrix([1.282, 3.415, -5.121, -10.128]), 2), matrix([1.28, 3.41, -5.13, -10.13]))
+    assert.deepStrictEqual(floor(matrix([1.282, 3.415, -5.121, -10.128]), bignumber(2)), matrix([bignumber(1.28), bignumber(3.41), bignumber(-5.13), bignumber(-10.13)]))
   })
 
   it('should floor when number of decimals is provided in an array', function () {
     assert.deepStrictEqual(floor(3.12385, [2, 3]), [3.12, 3.123])
+    assert.deepStrictEqual(floor(bignumber(3.12385), [2, 3]), bignumber([3.12, 3.123]))
+    assert.deepStrictEqual(floor(complex(3.12385, -1.6789), [2, 3]), [complex(3.12, -1.68), complex(3.123, -1.679)])
+    assert.deepStrictEqual(floor(fraction(44, 7), [2, 3]), [fraction(628, 100), fraction(6285, 1000)])
+  })
+
+  it('should floor when number of decimals is provided in a matrix', function () {
+    assert.deepStrictEqual(floor(3.12385, matrix([2, 3])), matrix([3.12, 3.123]))
+    assert.deepStrictEqual(floor(0, matrix([2, 3])), matrix([0, 0]))
+    assert.deepStrictEqual(floor(bignumber(3.12385), sparse([2, 3])), bignumber(matrix([[3.12], [3.123]])))
+    assert.deepStrictEqual(floor(complex(3.12385, -1.6789), matrix([2, 3])), matrix([complex(3.12, -1.68), complex(3.123, -1.679)]))
+    assert.deepStrictEqual(floor(fraction(44, 7), sparse([2, 3])), matrix([[fraction(628, 100)], [fraction(6285, 1000)]]))
   })
 
   it('should floor dense matrix', function () {
@@ -180,7 +197,7 @@ describe('floor', function () {
   it('should floor dense matrix with given bignumber decimals', function () {
     const expected = bignumber(matrix([[1.777, 2.345], [-90.828, 0]]))
     const decimals = bignumber(3)
-    approx.deepEqual(floor(matrix([[1.7777, 2.3456], [-90.8272, 0]]), decimals), expected)
+    assert.deepStrictEqual(floor(matrix([[1.7777, 2.3456], [-90.8272, 0]]), decimals), expected)
   })
 
   it('should floor sparse matrix', function () {
@@ -205,10 +222,11 @@ describe('floor', function () {
   it('should throw an in case of wrong type of arguments', function () {
     assert.throws(function () { floor(null) }, /TypeError: Unexpected type of argument/)
     assert.throws(function () { floor(42, null) }, /TypeError: Unexpected type of argument/)
+    assert.throws(function () { floor([3.82, 3.15], [1, 2]) }, /TypeError: Unexpected type of argument/)
   })
 
   it('should throw an error if requested number of decimals is incorrect', function () {
-    assert.throws(function () { floor(2.5, 1.5) }, TypeError, 'Number of decimals in function round must be an integer')
+    assert.throws(function () { floor(2.5, 1.5) }, Error, 'Number of decimals in function round must be an integer')
     assert.throws(function () { floor(2.5, -2) }, Error, ' Number of decimals in function round must be in the range of 0-15')
     assert.throws(function () { floor(2.5, Infinity) }, Error, ' Number of decimals in function round must be in the range of 0-15')
   })

--- a/test/unit-tests/function/arithmetic/round.test.js
+++ b/test/unit-tests/function/arithmetic/round.test.js
@@ -4,6 +4,7 @@ import assert from 'assert'
 import approx from '../../../../tools/approx.js'
 import math from '../../../../src/defaultInstance.js'
 const bignumber = math.bignumber
+const complex = math.complex
 const fraction = math.fraction
 const matrix = math.matrix
 const sparse = math.sparse
@@ -42,15 +43,15 @@ describe('round', function () {
   })
 
   it('should throw an error on invalid value of n', function () {
-    assert.throws(function () { round(math.pi, -2) }, /Number of decimals in function round must be in the range of 0-15/)
-    assert.throws(function () { round(math.pi, 20) }, /Number of decimals in function round must be in the range of 0-15/)
+    assert.throws(function () { round(math.pi, -2) }, /Number of decimals in function round must be .* 0 .* 15/)
+    assert.throws(function () { round(math.pi, 20) }, /Number of decimals in function round must be .* 0 .* 15/)
     assert.throws(function () { round(math.pi, 2.5) }, /Number of decimals in function round must be an integer/)
-    assert.throws(function () { round(1, 1.2) }, /TypeError: Number of decimals in function round must be an integer/)
-    assert.throws(function () { round(1, bignumber(1.2)) }, /TypeError: Number of decimals in function round must be an integer/)
-    assert.throws(function () { round(math.complex(1, 1), 1.2) }, /TypeError: Number of decimals in function round must be an integer/)
-    assert.throws(function () { round(math.complex(1, 1), bignumber(1.2)) }, /TypeError: Number of decimals in function round must be an integer/)
-    assert.throws(function () { round(bignumber(1.2), bignumber(1.2)) }, /TypeError: Number of decimals in function round must be an integer/)
-    assert.throws(function () { round(round(fraction('1/2'), 1.2)) }, /TypeError: Number of decimals in function round must be an integer/)
+    assert.throws(function () { round(1, 1.2) }, /Error: Number of decimals in function round must be an integer/)
+    assert.throws(function () { round(1, bignumber(1.2)) }, /Error: Number of decimals in function round must be an integer/)
+    assert.throws(function () { round(complex(1, 1), 1.2) }, /Error: Number of decimals in function round must be an integer/)
+    assert.throws(function () { round(complex(1, 1), bignumber(1.2)) }, /Error: Number of decimals in function round must be an integer/)
+    assert.throws(function () { round(bignumber(1.2), bignumber(1.2)) }, /Error: Number of decimals in function round must be an integer/)
+    assert.throws(function () { round(round(fraction('1/2'), 1.2)) }, /Error: Number of decimals in function round must be an integer/)
   })
 
   it('should throw an error if used with wrong number of arguments', function () {
@@ -86,6 +87,7 @@ describe('round', function () {
     assert.strictEqual(round(fraction('1/2')).toString(), '1')
 
     assert.strictEqual(round(fraction('1/2'), 1).toString(), '0.5')
+    assert.deepStrictEqual(round(fraction(2, 3), bignumber(2)), fraction(67, 100))
   })
 
   it('should gracefully handle round-off errors', function () {
@@ -109,11 +111,11 @@ describe('round', function () {
   })
 
   it('should round real and imag part of a complex number', function () {
-    assert.deepStrictEqual(round(math.complex(2.2, math.pi)), math.complex(2, 3))
+    assert.deepStrictEqual(round(complex(2.2, math.pi)), complex(2, 3))
   })
 
   it('should round a complex number with a bignumber as number of decimals', function () {
-    assert.deepStrictEqual(round(math.complex(2.157, math.pi), bignumber(2)), math.complex(2.16, 3.14))
+    assert.deepStrictEqual(round(complex(2.157, math.pi), bignumber(2)), complex(2.16, 3.14))
   })
 
   it('should throw an error if used with a unit', function () {
@@ -143,6 +145,8 @@ describe('round', function () {
     it('should round array and scalar', function () {
       assert.deepStrictEqual(round([1.7777, 2.3456], 3), [1.778, 2.346])
       assert.deepStrictEqual(round(3.12385, [2, 3]), [3.12, 3.124])
+      assert.deepStrictEqual(round(fraction(44, 7), [2, 3]),
+        [fraction(629, 100), fraction(6286, 1000)])
     })
   })
 
@@ -155,6 +159,8 @@ describe('round', function () {
       assert.deepStrictEqual(round(matrix([[1.7777, 2.3456], [-90.8272, 0]]), 3), matrix([[1.778, 2.346], [-90.827, 0]]))
       assert.deepStrictEqual(round(3.12385, matrix([[2, 3], [0, 2]])), matrix([[3.12, 3.124], [3, 3.12]]))
       assert.deepStrictEqual(round(0.0, matrix([2, 3])), matrix([0, 0]))
+      assert.deepStrictEqual(round(complex(2.7182, 6.2831), matrix([2, 3])),
+        matrix([complex(2.72, 6.28), complex(2.718, 6.283)]))
     })
   })
 
@@ -167,6 +173,8 @@ describe('round', function () {
       assert.deepStrictEqual(round(sparse([[1.7777, 2.3456], [-90.8272, 0]]), 3), sparse([[1.778, 2.346], [-90.827, 0]]))
       assert.deepStrictEqual(round(3.12385, sparse([[2, 3], [0, 2]])), matrix([[3.12, 3.124], [3, 3.12]]))
       assert.deepStrictEqual(round(0.0, sparse([2, 3])), sparse([0, 0]))
+      assert.deepStrictEqual(round(bignumber(6.28318), sparse([0, 4])),
+        matrix([[bignumber(6)], [bignumber(6.2832)]]))
     })
   })
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -126,6 +126,9 @@ Chaining examples
       .done(),
     [2, 3]
   );
+
+  const r = math.chain(-0.483).round([0,1,2]).floor().add(0.52).fix(1).done();
+  assert.deepStrictEqual(r, [0.5, -0.4, -0.4]);
 }
 
 /*
@@ -503,6 +506,110 @@ Expression tree examples
 }
 
 /*
+Function ceil examples
+*/
+{
+  const math = create(all, {});
+
+  // number input
+  assert.strictEqual(math.ceil(3.2), 4);
+  assert.strictEqual(math.ceil(-4.2), -4);
+
+  // number input
+  // roundoff result to 2 decimals
+  assert.strictEqual(math.ceil(3.212, 2), 3.22);
+  assert.deepStrictEqual(math.ceil(3.212, math.bignumber(2)), math.bignumber(3.22));
+  assert.strictEqual(math.ceil(-4.212, 2), -4.21);
+
+  // bignumber input
+  assert.deepStrictEqual(math.ceil(math.bignumber(3.212)), math.bignumber(4))
+  assert.deepStrictEqual(math.ceil(math.bignumber(3.212), 2), math.bignumber(3.22))
+  assert.deepStrictEqual(math.ceil(math.bignumber(3.212), math.bignumber(2)), math.bignumber(3.22))
+
+  // fraction input
+  assert.deepStrictEqual(math.ceil(math.fraction(44,7)), math.fraction(7))
+  assert.deepStrictEqual(math.ceil(math.fraction(-44,7)), math.fraction(-6))
+  assert.deepStrictEqual(math.ceil(math.fraction(44,7), 2), math.fraction(629,100))
+  assert.deepStrictEqual(math.ceil(math.fraction(44,7), math.bignumber(2)), math.fraction(629,100))
+
+  // Complex input
+  const c = math.complex(3.24, -2.71);
+  assert.deepStrictEqual(math.ceil(c), math.complex(4, -2));
+  assert.deepStrictEqual(math.ceil(c, 1), math.complex(3.3, -2.7));
+  assert.deepStrictEqual(math.ceil(c, math.bignumber(1)), math.complex(3.3, -2.7));
+
+  // array input
+  assert.deepStrictEqual(math.ceil([3.2, 3.8, -4.7]), [4, 4, -4]);
+  assert.deepStrictEqual(math.ceil([3.21, 3.82, -4.71], 1), [3.3, 3.9, -4.7]);
+  assert.deepStrictEqual(math.ceil([3.21, 3.82, -4.71], math.bignumber(1)),
+    math.bignumber([3.3, 3.9, -4.7]));
+
+  // numeric input, array or matrix of decimals
+  let numCeiled: math.MathArray = math.ceil(math.tau, [2, 3])
+  assert.deepStrictEqual(numCeiled, [6.29, 6.284]);
+  let bigCeiled: math.Matrix = math.ceil(math.bignumber(6.28318), math.matrix([2, 3]));
+  assert.deepStrictEqual(bigCeiled, math.matrix(math.bignumber([6.29, 6.284])));
+  assert.deepStrictEqual(math.ceil(math.fraction(44, 7), [2, 3]),
+    [math.fraction(629, 100), math.fraction(6286, 1000)]);
+
+  // array - array is (currently) undefined
+  //@ts-expect-error
+  assert.throws(() => math.ceil([3.21, 3.82], [1, 2]), TypeError);
+}
+
+/*
+Function fix examples
+*/
+{
+  const math = create(all, {});
+
+  // number input
+  assert.strictEqual(math.fix(3.2), 3);
+  assert.strictEqual(math.fix(-4.2), -4);
+
+  // number input
+  // roundoff result to 2 decimals
+  assert.strictEqual(math.fix(3.212, 2), 3.21);
+  assert.deepStrictEqual(math.fix(3.212, math.bignumber(2)), math.bignumber(3.21));
+  assert.strictEqual(math.fix(-4.212, 2), -4.21);
+
+  // bignumber input
+  assert.deepStrictEqual(math.fix(math.bignumber(3.212)), math.bignumber(3))
+  assert.deepStrictEqual(math.fix(math.bignumber(3.212), 2), math.bignumber(3.21))
+  assert.deepStrictEqual(math.fix(math.bignumber(3.212), math.bignumber(2)), math.bignumber(3.21))
+
+  // fraction input
+  assert.deepStrictEqual(math.fix(math.fraction(44,7)), math.fraction(6))
+  assert.deepStrictEqual(math.fix(math.fraction(-44,7)), math.fraction(-6))
+  assert.deepStrictEqual(math.fix(math.fraction(44,7), 2), math.fraction(628,100))
+  assert.deepStrictEqual(math.fix(math.fraction(44,7), math.bignumber(2)), math.fraction(628,100))
+
+  // Complex input
+  const c = math.complex(3.24, -2.71);
+  assert.deepStrictEqual(math.fix(c), math.complex(3, -2));
+  assert.deepStrictEqual(math.fix(c, 1), math.complex(3.2, -2.7));
+  assert.deepStrictEqual(math.fix(c, math.bignumber(1)), math.complex(3.2, -2.7));
+
+  // array input
+  assert.deepStrictEqual(math.fix([3.2, 3.8, -4.7]), [3, 3, -4]);
+  assert.deepStrictEqual(math.fix([3.21, 3.82, -4.71], 1), [3.2, 3.8, -4.7]);
+  assert.deepStrictEqual(math.fix([3.21, 3.82, -4.71], math.bignumber(1)),
+    math.bignumber([3.2, 3.8, -4.7]));
+
+  // numeric input, array or matrix of decimals
+  let numFixed: math.MathArray = math.fix(math.tau, [2, 3])
+  assert.deepStrictEqual(numFixed, [6.28, 6.283]);
+  let bigFixed: math.Matrix = math.fix(math.bignumber(6.28318), math.matrix([2, 3]));
+  assert.deepStrictEqual(bigFixed, math.matrix(math.bignumber([6.28, 6.283])));
+  assert.deepStrictEqual(math.fix(math.fraction(44, 7), [2, 3]),
+    [math.fraction(628, 100), math.fraction(6285, 1000)]);
+
+  // array - array is (currently) undefined
+  //@ts-expect-error
+  assert.throws(() => math.fix([3.21, 3.82], [1, 2]), TypeError);
+}
+
+/*
 Function floor examples
 */
 {
@@ -515,16 +622,95 @@ Function floor examples
   // number input
   // roundoff result to 2 decimals
   assert.strictEqual(math.floor(3.212, 2), 3.21);
+  assert.deepStrictEqual(math.floor(3.212, math.bignumber(2)), math.bignumber(3.21));
   assert.strictEqual(math.floor(-4.212, 2), -4.22);
+
+  // bignumber input
+  assert.deepStrictEqual(math.floor(math.bignumber(3.212)), math.bignumber(3))
+  assert.deepStrictEqual(math.floor(math.bignumber(3.212), 2), math.bignumber(3.21))
+  assert.deepStrictEqual(math.floor(math.bignumber(3.212), math.bignumber(2)), math.bignumber(3.21))
+
+  // fraction input
+  assert.deepStrictEqual(math.floor(math.fraction(44,7)), math.fraction(6))
+  assert.deepStrictEqual(math.floor(math.fraction(-44,7)), math.fraction(-7))
+  assert.deepStrictEqual(math.floor(math.fraction(44,7), 2), math.fraction(628,100))
+  assert.deepStrictEqual(math.floor(math.fraction(44,7), math.bignumber(2)), math.fraction(628,100))
 
   // Complex input
   const c = math.complex(3.24, -2.71);
   assert.deepStrictEqual(math.floor(c), math.complex(3, -3));
   assert.deepStrictEqual(math.floor(c, 1), math.complex(3.2, -2.8));
+  assert.deepStrictEqual(math.floor(c, math.bignumber(1)), math.complex(3.2, -2.8));
 
-  //array input
+  // array input
   assert.deepStrictEqual(math.floor([3.2, 3.8, -4.7]), [3, 3, -5]);
   assert.deepStrictEqual(math.floor([3.21, 3.82, -4.71], 1), [3.2, 3.8, -4.8]);
+  assert.deepStrictEqual(math.floor([3.21, 3.82, -4.71], math.bignumber(1)),
+    math.bignumber([3.2, 3.8, -4.8]));
+
+  // numeric input, array or matrix of decimals
+  let numFloored: math.MathArray = math.floor(math.tau, [2, 3])
+  assert.deepStrictEqual(numFloored, [6.28, 6.283]);
+  let bigFloored: math.Matrix = math.floor(math.bignumber(6.28318), math.matrix([2, 3]));
+  assert.deepStrictEqual(bigFloored, math.matrix(math.bignumber([6.28, 6.283])));
+  assert.deepStrictEqual(math.floor(math.fraction(44, 7), [2, 3]),
+    [math.fraction(628, 100), math.fraction(6285, 1000)]);
+
+  // array - array is (currently) undefined
+  //@ts-expect-error
+  assert.throws(() => math.floor([3.21, 3.82], [1, 2]), TypeError);
+}
+
+/*
+Function round examples
+*/
+{
+  const math = create(all, {});
+
+  // number input
+  assert.strictEqual(math.round(3.2), 3);
+  assert.strictEqual(math.round(-4.2), -4);
+
+  // number input
+  // roundoff result to 2 decimals
+  assert.strictEqual(math.round(3.212, 2), 3.21);
+  assert.deepStrictEqual(math.round(3.212, math.bignumber(2)), math.bignumber(3.21));
+  assert.strictEqual(math.round(-4.212, 2), -4.21);
+
+  // bignumber input
+  assert.deepStrictEqual(math.round(math.bignumber(3.212)), math.bignumber(3))
+  assert.deepStrictEqual(math.round(math.bignumber(3.212), 2), math.bignumber(3.21))
+  assert.deepStrictEqual(math.round(math.bignumber(3.212), math.bignumber(2)), math.bignumber(3.21))
+
+  // fraction input
+  assert.deepStrictEqual(math.round(math.fraction(44,7)), math.fraction(6))
+  assert.deepStrictEqual(math.round(math.fraction(-44,7)), math.fraction(-6))
+  assert.deepStrictEqual(math.round(math.fraction(44,7), 2), math.fraction(629,100))
+  assert.deepStrictEqual(math.round(math.fraction(44,7), math.bignumber(2)), math.fraction(629,100))
+
+  // Complex input
+  const c = math.complex(3.24, -2.71);
+  assert.deepStrictEqual(math.round(c), math.complex(3, -3));
+  assert.deepStrictEqual(math.round(c, 1), math.complex(3.2, -2.7));
+  assert.deepStrictEqual(math.round(c, math.bignumber(1)), math.complex(3.2, -2.7));
+
+  // array input
+  assert.deepStrictEqual(math.round([3.2, 3.8, -4.7]), [3, 4, -5]);
+  assert.deepStrictEqual(math.round([3.21, 3.82, -4.71], 1), [3.2, 3.8, -4.7]);
+  assert.deepStrictEqual(math.round([3.21, 3.82, -4.71], math.bignumber(1)),
+    math.bignumber([3.2, 3.8, -4.7]));
+
+  // numeric input, array or matrix of decimals
+  let numRounded: math.MathArray = math.round(math.tau, [2, 3])
+  assert.deepStrictEqual(numRounded, [6.28, 6.283]);
+  let bigRounded: math.Matrix = math.round(math.bignumber(6.28318), math.matrix([2, 3]));
+  assert.deepStrictEqual(bigRounded, math.matrix(math.bignumber([6.28, 6.283])));
+  assert.deepStrictEqual(math.round(math.fraction(44, 7), [2, 3]),
+    [math.fraction(629, 100), math.fraction(6286, 1000)]);
+
+  // array - array is (currently) undefined
+  //@ts-expect-error
+  assert.throws(() => math.round([3.21, 3.82], [1, 2]), TypeError);
 }
 
 


### PR DESCRIPTION
  This is a sequel to #2531. Uniformizes the signatures of ceil, fix, floor,
  and round, and updates the TypeScript declarations to match. Adds the
  optional "number of places" argument to the chain versions of ceil, fix,
  and floor. Adds TypeScript tests for all rounding functions.

  Also corrects the TypeScript declaration for `bignumber()` and introduces
  a couple more common abbreviations for TypeScript types.

  Fixes the number-only implementations of floor, ceil, fix, and nthRoot
  to match the full implementation behavior on numbers, and tests this for
  floor.

  Includes some minor documentation updates and additional unit tests for
  the rounding functions.

  Reverts inclusion in AUTHORS of incorrect email for one contributor,
  that occurred in #2531.

  Resolves #2526.
  Resolves #2529.