### PR TITLE
fix: move @types/mocha to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@types/mocha": "^9.1.1",
     "complex.js": "^2.1.1",
     "decimal.js": "^10.3.1",
     "escape-latex": "^1.2.0",
@@ -43,6 +42,7 @@
     "@babel/preset-env": "7.17.10",
     "@babel/register": "7.17.7",
     "@types/assert": "1.5.6",
+    "@types/mocha": "^9.1.1",
     "@typescript-eslint/eslint-plugin": "5.21.0",
     "@typescript-eslint/parser": "5.21.0",
     "assert": "2.0.0",


### PR DESCRIPTION
For issue #2553 

Currently I don't have time to test this, if anyone wants to test, please add following dependencies to a project then try to build, with current version of mathjs it should fail and show the error in issue #2553 , and after this fix it should build successfully.

Currently we have these packages in our dependencies:
    "@types/jest": "^27.4.1",
    "expect-more-jest": "^5.4.0",
    "jest": "^27.5.1",
    "jest-mock-extended": "^2.0.4",
    "jest-mock-server": "^0.0.5",
    "ts-jest": "^27.1.3",


which I think just adding jest and @types/jest would produce the error.

thanks in advance