### PR TITLE
Use the master github branch of mathjs to generate docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ To update the website with the latest version of math.js:
 
       npm install
 
+  > Note that the installation takes a long time, because the git source 
+  > of mathjs is installed and a fresh build is created.
+
 - Update the docs, examples, and version number via the build tool:
 
       npm run build

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,13 +10,15 @@ var rename = require('gulp-rename');
 var header = require('gulp-header');
 var handlebars = require('handlebars');
 
-var LIB_SRC           = './node_modules/mathjs/lib/browser/*';
+var DEP_MATHJS        = './node_modules/mathjs'
+var DEP_MATHJS_SRC    = './node_modules/mathjs-src'
+var LIB_SRC           = DEP_MATHJS_SRC + '/lib/browser/*';
 var LIB_DEST          = './js/lib';
-var DOCS_SRC          = './node_modules/mathjs/docs/**/*.md';
+var DOCS_SRC          = DEP_MATHJS_SRC + '/docs/**/*.md';
 var DOCS_DEST         = './docs';
-var EXAMPLES_SRC      = './node_modules/mathjs/examples/**/*';
+var EXAMPLES_SRC      = DEP_MATHJS_SRC + '/examples/**/*';
 var EXAMPLES_DEST     = './examples';
-var HISTORY_SRC       = './node_modules/mathjs/HISTORY.md';
+var HISTORY_SRC       = DEP_MATHJS_SRC + '/HISTORY.md';
 var HISTORY_DEST      = '.';
 var MATHJS            = LIB_DEST + '/math.js';
 var DOWNLOAD          = './download.md';
@@ -93,6 +95,25 @@ var injectClickableIssueTags = replace(/[ (](#(\d+))/mg, function (match, tag, n
 });
 var injectClickableUserTags = replace(/ (@([0-9a-zA-Z_-]+))/mg, function (match, tag, username) {
   return ' <a href="https://github.com/' + username + '">' + tag + '</a>'
+});
+
+/**
+ * Verify whether we have the same version numbers in both mathjs and mathjs-src
+ *
+ * The mathjs library itself is purely used to validate whether the library
+ * is published and whether we've an up-to-date version of the master branch
+ * with the source code.
+ */
+gulp.task('verify', function (cb) {
+  const mathjsVersion = require(DEP_MATHJS + '/package.json').version;
+  const mathjsSrcVersion = require(DEP_MATHJS_SRC + '/package.json').version;
+
+  if (mathjsVersion !== mathjsSrcVersion) {
+    throw new Error('Version numbers of mathjs and mathjs-src do not correspond'+
+      `(mathjs: ${mathjsVersion}, mathjs-src: ${mathjsSrcVersion})`);
+  }
+
+  cb();
 });
 
 /**
@@ -302,6 +323,7 @@ gulp.task('version', function (cb) {
 });
 
 gulp.task('default', gulp.series(
+    'verify',
     'clean',
     'copy',
     'docs',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "mathjs-website",
       "version": "1.0.0",
       "dependencies": {
-        "mathjs": "10.5.2"
+        "mathjs": "10.5.2",
+        "mathjs-src": "josdejong/mathjs#master"
       },
       "devDependencies": {
         "fancy-log": "2.0.0",
@@ -2992,6 +2993,29 @@
       "version": "10.5.2",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.5.2.tgz",
       "integrity": "sha512-yLl2yA597A+07+xsOgy1+pq/m4ZokQceWQbB9OsIkK2guCpA2Px9k11zul93eJAA0WUFZiMK6VcruY9ZBbSKjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.3.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.2.0",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.1.0"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mathjs-src": {
+      "name": "mathjs",
+      "version": "10.5.2",
+      "resolved": "git+ssh://git@github.com/josdejong/mathjs.git#d278675849114ebf34359c3678a6d03c8c7edf87",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
         "complex.js": "^2.1.1",
@@ -7149,6 +7173,21 @@
       "version": "10.5.2",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.5.2.tgz",
       "integrity": "sha512-yLl2yA597A+07+xsOgy1+pq/m4ZokQceWQbB9OsIkK2guCpA2Px9k11zul93eJAA0WUFZiMK6VcruY9ZBbSKjA==",
+      "requires": {
+        "@babel/runtime": "^7.17.9",
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.3.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.2.0",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.1.0"
+      }
+    },
+    "mathjs-src": {
+      "version": "git+ssh://git@github.com/josdejong/mathjs.git#d278675849114ebf34359c3678a6d03c8c7edf87",
+      "from": "mathjs-src@josdejong/mathjs#master",
       "requires": {
         "@babel/runtime": "^7.17.9",
         "complex.js": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "url": "https://github.com/josdejong/mathjs.git"
   },
   "dependencies": {
-    "mathjs": "10.5.2"
+    "mathjs": "10.5.2",
+    "mathjs-src": "josdejong/mathjs#master"
   },
   "devDependencies": {
     "fancy-log": "2.0.0",


### PR DESCRIPTION
This is the first step in order to address #2337: making the gh-pages scripts independent of the `examples` and `docs` folder of the publish package on npm.

I'm not sure yet on whether an `npm install` will automatically refresh the installed git source code of the `master` branch, we'll see after the first next release (and if it doesn't work, the `verify` script will fail).