### PR TITLE
Hotfix: missing functions in docs

### DIFF
--- a/tools/docgenerator.js
+++ b/tools/docgenerator.js
@@ -9,7 +9,6 @@ const fs = require('fs')
 const glob = require('glob')
 const mkdirp = require('mkdirp')
 const del = require('del')
-const { relative: relativePath } = require('path')
 const log = require('fancy-log')
 
 // special cases for function syntax

--- a/tools/docgenerator.js
+++ b/tools/docgenerator.js
@@ -540,7 +540,7 @@ function cleanup (outputPath, outputRoot) {
  * @param {String} inputPath        Path to location of source files
  * @returns {object} docinfo
  *     Object whose keys are function names, and whose values are objects with
- *     keys name, category, fullpath, relativepath, doc, and issues
+ *     keys name, category, fullPath, doc, and issues
  *     giving the relevant information
  */
 function collectDocs (functionNames, inputPath) {
@@ -582,11 +582,14 @@ function collectDocs (functionNames, inputPath) {
 
     if (category) {
       functions[name] = {
-        name: name,
-        category: category,
-        fullPath: fullPath,
-        relativePath: fullPath.substring(inputPath.length)
+        name,
+        category,
+        fullPath
       }
+    } else {
+      // TODO: throw a warning that no category could be found (instead of silently ignoring it).
+      //  Right now, this matches too many functions, so to do that, we first must make the glob matching relevant
+      //  files more specific, and we need to extend the list with functions we want to ignore.
     }
   })
 

--- a/tools/docgenerator.js
+++ b/tools/docgenerator.js
@@ -9,6 +9,7 @@ const fs = require('fs')
 const glob = require('glob')
 const mkdirp = require('mkdirp')
 const del = require('del')
+const { relative: relativePath } = require('path')
 const log = require('fancy-log')
 
 // special cases for function syntax
@@ -560,9 +561,10 @@ function collectDocs (functionNames, inputPath) {
     if (path.indexOf('docs') === -1 && functionIndex !== -1) {
       if (path.indexOf('expression') !== -1) {
         category = 'expression'
-      } else if (/^.\/lib\/type\/[a-zA-Z0-9_]*\/function/.test(fullPath)) {
+      } else if (/\/lib\/cjs\/type\/[a-zA-Z0-9_]*\/function/.test(fullPath)) {
+        // for type/bignumber/function/bignumber.js, type/fraction/function/fraction.js, etc
         category = 'construction'
-      } else if (/^.\/lib\/core\/function/.test(fullPath)) {
+      } else if (/\/lib\/cjs\/core\/function/.test(fullPath)) {
         category = 'core'
       } else {
         category = path[functionIndex + 1]
@@ -570,7 +572,7 @@ function collectDocs (functionNames, inputPath) {
     } else if (fullPath === './lib/cjs/expression/parse.js') {
       // TODO: this is an ugly special case
       category = 'expression'
-    } else if (path.join('/') === './lib/cjs/type') {
+    } else if (path.join('/').endsWith('/lib/cjs/type')) {
       // for boolean.js, number.js, string.js
       category = 'construction'
     }

--- a/tools/docgenerator.js
+++ b/tools/docgenerator.js
@@ -568,7 +568,7 @@ function collectDocs (functionNames, inputPath) {
       } else {
         category = path[functionIndex + 1]
       }
-    } else if (fullPath === './lib/cjs/expression/parse.js') {
+    } else if (fullPath.endsWith('/lib/cjs/expression/parse.js')) {
       // TODO: this is an ugly special case
       category = 'expression'
     } else if (path.join('/').endsWith('/lib/cjs/type')) {


### PR DESCRIPTION
I noticed that in the generated function reference, the categories `core` and `construction` and function `parse` where missing. This is the case since `mathjs@8.0.0`. I think it occurs since I switched from Linux to Windows, which has different paths, not correctly resolving these function categories.

This PR fixes this in the docgenerator script with a minimal hotfix.

The docgenerator script could use some love: it would be neat to output a warning when no function category could be found (instead of silently ignoring it). Right now, the script matches too many source functions, so to do that (too many functions that need to be on an ignored list). we first must make the glob matching relevant files more specific, and we need to extend the list with functions we want to ignore.

@gwhitney can you have a brief look at this small PR?