### PR TITLE
Fix/remove examples and docs from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,10 @@
     "HISTORY.md",
     "CONTRIBUTING.md"
   ],
+  "directories": {
+    "bin": "./bin",
+    "lib": "./lib"
+  },
   "scripts": {
     "build": "gulp --gulpfile gulpfile.cjs && npm run update-authors",
     "build-and-test": "npm run build && npm run test:all && npm run lint",

--- a/package.json
+++ b/package.json
@@ -127,9 +127,7 @@
   "files": [
     "bin",
     "dist",
-    "docs",
     "lib",
-    "examples",
     "main",
     "types",
     "number.cjs",
@@ -170,13 +168,6 @@
   },
   "bugs": {
     "url": "https://github.com/josdejong/mathjs/issues"
-  },
-  "directories": {
-    "doc": "./docs",
-    "example": "./examples",
-    "lib": "./lib",
-    "src": "./src",
-    "test": "./test"
   },
   "browserslist": [
     "IE 11"


### PR DESCRIPTION
This PR fixes #2337 by removing the folders `examples` and `docs` from the npm package of `mathjs`.

For my own reference, here some explanation on the `files` and `directories` properties in package.json: https://stackoverflow.com/questions/40795836/how-do-you-use-the-files-and-directories-properties-in-package-json

Must be merged after merging #2555, else it is not possible to generate the website anymore.