### PR TITLE
Call `toTex` on expression arg of derivative if it is a node

### DIFF
--- a/src/function/algebra/derivative.js
+++ b/src/function/algebra/derivative.js
@@ -129,7 +129,7 @@ export const createDerivative = /* #__PURE__ */ factory(name, dependencies, ({
       if (isConstantNode(expr) && typeOf(expr.value) === 'string') {
         return _derivTex(parse(expr.value).toString(), x.toString(), 1)
       } else {
-        return _derivTex(expr.toString(), x.toString(), 1)
+        return _derivTex(expr.toTex(), x.toString(), 1)
       }
     },
     'Node, ConstantNode': function (expr, x) {

--- a/test/unit-tests/function/algebra/derivative.test.js
+++ b/test/unit-tests/function/algebra/derivative.test.js
@@ -276,9 +276,9 @@ describe('derivative', function () {
   })
 
   it('should LaTeX expressions involving derivative', function () {
-    compareString(math.parse('derivative(x*y,x)').toTex(), '{d\\over dx}\\left[x * y\\right]')
+    compareString(math.parse('derivative(x*y,x)').toTex(), '{d\\over dx}\\left[ x\\cdot y\\right]')
     compareString(math.parse('derivative("x*y",x)').toTex(), '{d\\over dx}\\left[x * y\\right]')
-    compareString(math.parse('derivative(x*y,"x")').toTex(), '{d\\over dx}\\left[x * y\\right]')
+    compareString(math.parse('derivative(x*y,"x")').toTex(), '{d\\over dx}\\left[ x\\cdot y\\right]')
     compareString(math.parse('derivative("x*y","x")').toTex(), '{d\\over dx}\\left[x * y\\right]')
 
     // FIXME: handle toTex of derivative with options as third argument


### PR DESCRIPTION
## The Problem

Not sure if there's a good reason for this, but currently the expression argument of `derivative(expr,x)`  is not TeX-ified when calling `toTex()` on the derivative node. This is a bit suprising since other functions seems to do this.

Compare the behaviour of `derivative(expr, var)` to `add(x, y)`:

<img width="484" alt="image" src="https://user-images.githubusercontent.com/64985/169444845-97e14a3f-e267-4abc-8cf8-53d5bfb99558.png">

Looks like we're just calling `toString()` when the expression is a `Node`: https://github.com/josdejong/mathjs/blob/develop/src/function/algebra/derivative.js#L132

## The solution

This PR simply calls toTex on the expression arg if it's a Node