### PR TITLE
Fix type import errors due to usage of "exports" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,14 +102,17 @@
   "jsdelivr": "./lib/browser/math.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
     },
     "./number": {
+      "types": "./types/index.d.ts",
       "import": "./lib/esm/number.js",
       "require": "./lib/cjs/number.js"
     },
     "./lib/esm/number": {
+      "types": "./types/index.d.ts",
       "import": "./lib/esm/number.js",
       "require": "./lib/cjs/number.js"
     },


### PR DESCRIPTION
# Summary

Add "types" field to "exports" to fix type imports

# Description

I was having trouble getting the mathjs typescript types working in my app:

<img width="637" alt="image" src="https://user-images.githubusercontent.com/64985/169666119-7c33e0bb-09ed-48ba-8a5d-eaad62c07617.png">

I previously worked around this by adding this to my tsconfig.json

<img width="434" alt="image" src="https://user-images.githubusercontent.com/64985/169666051-5efd6712-9e9e-4d0e-a802-aedbe423f21c.png">

But that was a bit hacky and started causing other problems, so I decided to figure out what was going on. Seems that the "types" field in package.json is not respected when using "exports". Luckily as of typescript 4.7, "exports" itself supports "types" fields for each declaration as well (see [here](https://github.com/microsoft/TypeScript/issues/33079#issuecomment-1129096299)).

<img width="401" alt="image" src="https://user-images.githubusercontent.com/64985/169666181-25bb1195-5154-4179-a34b-8a8b74f3dc5d.png">

Now, my app is using `type: "module"` so I'm not sure if this will work with the CJS import as well but I assume it will (if someone could check that would be great).

After adding this fix my types now work with no hacks 💥

<img width="737" alt="image" src="https://user-images.githubusercontent.com/64985/169666160-297a646b-9ddf-4e72-b470-87ba9584d065.png">
