### PR TITLE
Types/improve operator node types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -312,24 +312,30 @@ declare namespace math {
 
   interface OperatorNode<
     TOp extends OperatorNodeMap[TFn],
-    TFn extends OperatorNodeFn
+    TFn extends OperatorNodeFn,
+    TArgs extends MathNode[] = MathNode[]
   > extends MathNodeCommon {
     type: 'OperatorNode'
     isOperatorNode: true
     op: TOp
     fn: TFn
-    args: MathNode[]
+    args: TArgs
     implicit: boolean
     isUnary(): boolean
     isBinary(): boolean
   }
+
   interface OperatorNodeCtor extends MathNodeCommon {
-    new <TOp extends OperatorNodeMap[TFn], TFn extends OperatorNodeFn>(
+    new <
+      TOp extends OperatorNodeMap[TFn],
+      TFn extends OperatorNodeFn,
+      TArgs extends MathNode[]
+    >(
       op: TOp,
       fn: TFn,
-      args: MathNode[],
+      args: TArgs,
       implicit?: boolean
-    ): OperatorNode<TOp, TFn>
+    ): OperatorNode<TOp, TFn, TArgs>
   }
   interface ParenthesisNode extends MathNodeCommon {
     type: 'ParenthesisNode'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -276,25 +276,61 @@ declare namespace math {
     new (properties: Record<string, MathNode>): ObjectNode
   }
 
-  interface OperatorNode extends MathNodeCommon {
+  type OperatorNodeMap = {
+    xor: 'xor'
+    and: 'and'
+    bitOr: '|'
+    bitXor: '^|'
+    bitAnd: '&'
+    equal: '=='
+    unequal: '!='
+    smaller: '<'
+    larger: '>'
+    smallerEq: '<='
+    leftShift: '<<'
+    rightArithShift: '>>'
+    rightLogShift: '>>>'
+    to: 'to'
+    add: '+'
+    subtract: '-'
+    multiply: '*'
+    divide: '/'
+    dotMultiply: '.*'
+    dotDivide: './'
+    mod: 'mod'
+    unaryPlus: '+'
+    unaryMinus: '-'
+    bitNot: '~'
+    not: 'not'
+    pow: '^'
+    dotPow: '.^'
+    factorial: '!'
+  }
+
+  type OperatorNodeOp = OperatorNodeMap[keyof OperatorNodeMap]
+  type OperatorNodeFn = keyof OperatorNodeMap
+
+  interface OperatorNode<
+    TOp extends OperatorNodeMap[TFn],
+    TFn extends OperatorNodeFn
+  > extends MathNodeCommon {
     type: 'OperatorNode'
     isOperatorNode: true
-    op: string
-    fn: string
+    op: TOp
+    fn: TFn
     args: MathNode[]
     implicit: boolean
     isUnary(): boolean
     isBinary(): boolean
   }
-  interface OperatorNodeCtor {
-    new (
-      op: string,
-      fn: string,
+  interface OperatorNodeCtor extends MathNodeCommon {
+    new <TOp extends OperatorNodeMap[TFn], TFn extends OperatorNodeFn>(
+      op: TOp,
+      fn: TFn,
       args: MathNode[],
       implicit?: boolean
-    ): OperatorNode
+    ): OperatorNode<TOp, TFn>
   }
-
   interface ParenthesisNode extends MathNodeCommon {
     type: 'ParenthesisNode'
     isParenthesisNode: true
@@ -345,7 +381,7 @@ declare namespace math {
     | FunctionNode
     | IndexNode
     | ObjectNode
-    | OperatorNode
+    | OperatorNode<OperatorNodeOp, OperatorNodeFn>
     | ParenthesisNode
     | RangeNode
     | RelationalNode
@@ -3095,7 +3131,9 @@ declare namespace math {
 
     isObjectNode(x: unknown): x is ObjectNode
 
-    isOperatorNode(x: unknown): x is OperatorNode
+    isOperatorNode(
+      x: unknown
+    ): x is OperatorNode<OperatorNodeOp, OperatorNodeFn>
 
     isParenthesisNode(x: unknown): x is ParenthesisNode
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -311,8 +311,8 @@ declare namespace math {
   type OperatorNodeFn = keyof OperatorNodeMap
 
   interface OperatorNode<
-    TOp extends OperatorNodeMap[TFn],
-    TFn extends OperatorNodeFn,
+    TOp extends OperatorNodeMap[TFn] = never,
+    TFn extends OperatorNodeFn = never,
     TArgs extends MathNode[] = MathNode[]
   > extends MathNodeCommon {
     type: 'OperatorNode'

--- a/types/index.ts
+++ b/types/index.ts
@@ -25,9 +25,13 @@ import {
   MathNumericType,
   ConstantNode,
   OperatorNode,
+  OperatorNodeFn,
+  OperatorNodeOp,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
+
+const math = create(all)
 
 // This file serves a dual purpose:
 // 1) examples of how to use math.js in TypeScript
@@ -1527,23 +1531,30 @@ Function round examples
   */
 {
   const math = create(all, {})
+  expectTypeOf(
+    new math.OperatorNode('/', 'divide', [
+      new math.ConstantNode(3),
+      new math.SymbolNode('x'),
+    ])
+  ).toMatchTypeOf<OperatorNode<'/', 'divide'>>()
+
   expectTypeOf(new math.ConstantNode(1).clone()).toMatchTypeOf<ConstantNode>()
   expectTypeOf(
     new math.OperatorNode('*', 'multiply', [
       new math.ConstantNode(3),
       new math.SymbolNode('x'),
     ]).clone()
-  ).toMatchTypeOf<OperatorNode>()
+  ).toMatchTypeOf<OperatorNode<'*', 'multiply'>>()
 
   expectTypeOf(
     new math.ConstantNode(1).cloneDeep()
   ).toMatchTypeOf<ConstantNode>()
   expectTypeOf(
-    new math.OperatorNode('*', 'multiply', [
+    new math.OperatorNode('+', 'unaryPlus', [
       new math.ConstantNode(3),
       new math.SymbolNode('x'),
     ]).cloneDeep()
-  ).toMatchTypeOf<OperatorNode>()
+  ).toMatchTypeOf<OperatorNode<'+', 'unaryPlus'>>()
 
   expectTypeOf(
     math.clone(new math.ConstantNode(1))
@@ -1900,7 +1911,9 @@ Factory Test
     expectTypeOf(x).toMatchTypeOf<math.ObjectNode>()
   }
   if (math.isOperatorNode(x)) {
-    expectTypeOf(x).toMatchTypeOf<math.OperatorNode>()
+    expectTypeOf(x).toMatchTypeOf<
+      OperatorNode<OperatorNodeOp, OperatorNodeFn>
+    >()
   }
   if (math.isParenthesisNode(x)) {
     expectTypeOf(x).toMatchTypeOf<math.ParenthesisNode>()

--- a/types/index.ts
+++ b/types/index.ts
@@ -31,8 +31,6 @@ import {
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
 
-const math = create(all)
-
 // This file serves a dual purpose:
 // 1) examples of how to use math.js in TypeScript
 // 2) tests for the TypeScript declarations provided by math.js

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,6 +27,7 @@ import {
   OperatorNode,
   OperatorNodeFn,
   OperatorNodeOp,
+  SymbolNode,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -1534,7 +1535,7 @@ Function round examples
       new math.ConstantNode(3),
       new math.SymbolNode('x'),
     ])
-  ).toMatchTypeOf<OperatorNode<'/', 'divide'>>()
+  ).toMatchTypeOf<OperatorNode<'/', 'divide', (ConstantNode | SymbolNode)[]>>()
 
   expectTypeOf(new math.ConstantNode(1).clone()).toMatchTypeOf<ConstantNode>()
   expectTypeOf(
@@ -1542,7 +1543,9 @@ Function round examples
       new math.ConstantNode(3),
       new math.SymbolNode('x'),
     ]).clone()
-  ).toMatchTypeOf<OperatorNode<'*', 'multiply'>>()
+  ).toMatchTypeOf<
+    OperatorNode<'*', 'multiply', (ConstantNode | SymbolNode)[]>
+  >()
 
   expectTypeOf(
     new math.ConstantNode(1).cloneDeep()
@@ -1552,7 +1555,9 @@ Function round examples
       new math.ConstantNode(3),
       new math.SymbolNode('x'),
     ]).cloneDeep()
-  ).toMatchTypeOf<OperatorNode<'+', 'unaryPlus'>>()
+  ).toMatchTypeOf<
+    OperatorNode<'+', 'unaryPlus', (ConstantNode | SymbolNode)[]>
+  >()
 
   expectTypeOf(
     math.clone(new math.ConstantNode(1))
@@ -1910,7 +1915,7 @@ Factory Test
   }
   if (math.isOperatorNode(x)) {
     expectTypeOf(x).toMatchTypeOf<
-      OperatorNode<OperatorNodeOp, OperatorNodeFn>
+      OperatorNode<OperatorNodeOp, OperatorNodeFn, MathNode[]>
     >()
   }
   if (math.isParenthesisNode(x)) {


### PR DESCRIPTION
This PR adds generic `op` and `fn` args to `OperatorNode` type to solve the problems laid out [here](https://github.com/josdejong/mathjs/issues/2575)

Addresses https://github.com/josdejong/mathjs/issues/2575