### PR TITLE
Types/improve transform types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3945,9 +3945,9 @@ declare namespace math {
      * transformed.toString(); // returns '(3 ^ 2) + (5 * 3)'
      * ```
      */
-    transform(
-      callback: (node: MathNode, path: string, parent: MathNode) => MathNode
-    ): MathNode
+    transform<TResult>(
+      callback: (node: this, path: string, parent: MathNode) => TResult
+    ): TResult
 
     /**
      * `traverse(callback)`

--- a/types/index.ts
+++ b/types/index.ts
@@ -959,7 +959,7 @@ Transform examples
         .transform(myTransform1)
         .transform(myTransform2)
         .toString(),
-        'sqrt(3 ^ 2 + 4 ^ 2) + 1 - 5'
+      'sqrt(3 ^ 2 + 4 ^ 2) + 1 - 5'
     )
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -32,6 +32,8 @@ import {
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
 
+const math = create(all)
+
 // This file serves a dual purpose:
 // 1) examples of how to use math.js in TypeScript
 // 2) tests for the TypeScript declarations provided by math.js

--- a/types/index.ts
+++ b/types/index.ts
@@ -32,8 +32,6 @@ import {
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
 
-const math = create(all)
-
 // This file serves a dual purpose:
 // 1) examples of how to use math.js in TypeScript
 // 2) tests for the TypeScript declarations provided by math.js

--- a/types/index.ts
+++ b/types/index.ts
@@ -925,6 +925,46 @@ Fractions examples
 }
 
 /*
+Transform examples
+*/
+{
+  const math = create(all, {})
+  {
+    const myTransform1 = (node: MathNode): OperatorNode<'+', 'add'> =>
+      new OperatorNode('+', 'add', [node, new ConstantNode(1)])
+    const myTransform2 = (
+      node: OperatorNode<'+', 'add'>
+    ): OperatorNode<'-', 'subtract'> =>
+      new OperatorNode('-', 'subtract', [node, new ConstantNode(5)])
+
+    expectTypeOf(
+      math.parse('sqrt(3^2 + 4^2)').transform(myTransform1)
+    ).toMatchTypeOf<OperatorNode<'+', 'add', MathNode[]>>()
+
+    assert.deepStrictEqual(
+      math.parse('sqrt(3^2 + 4^2)').transform(myTransform1).toString(),
+      'sqrt(3 ^ 2 + 4 ^ 2) + 1'
+    )
+
+    expectTypeOf(
+      math
+        .parse('sqrt(3^2 + 4^2)')
+        .transform(myTransform1)
+        .transform(myTransform2)
+    ).toMatchTypeOf<OperatorNode<'-', 'subtract', MathNode[]>>()
+
+    assert.deepStrictEqual(
+      math
+        .parse('sqrt(3^2 + 4^2)')
+        .transform(myTransform1)
+        .transform(myTransform2)
+        .toString(),
+        'sqrt(3 ^ 2 + 4 ^ 2) + 1 - 5'
+    )
+  }
+}
+
+/*
 Matrices examples
 */
 {


### PR DESCRIPTION
**Addresses** https://github.com/josdejong/mathjs/issues/2579

This PR changes `Node.transform()` to return the type of node its callback returned, as well passing the type of the node being acted upon as the `node` argument of the callback function.

This allows for the following type validation:

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/64985/170537799-7f2a8177-ff2e-477a-8c51-f991e95230b2.png">