### PR TITLE
Improve symbol equality checking

### DIFF
--- a/src/expression/node/SymbolNode.js
+++ b/src/expression/node/SymbolNode.js
@@ -120,6 +120,17 @@ export const createSymbolNode = /* #__PURE__ */ factory(name, dependencies, ({ m
   }
 
   /**
+   * Check if this symbol equals another symbol
+   * @param {Object} options
+   * @return {string} str
+   * @override
+   */
+   SymbolNode.prototype.equals = function (other) {
+    if (!other || other.type !== 'SymbolNode') return false
+    return this.name === other.name
+  }
+
+  /**
    * Get string representation
    * @param {Object} options
    * @return {string} str

--- a/test/unit-tests/expression/node/SymbolNode.test.js
+++ b/test/unit-tests/expression/node/SymbolNode.test.js
@@ -105,6 +105,8 @@ describe('SymbolNode', function () {
     const a = new SymbolNode('a')
     const b = new SymbolNode('b')
     const aEqual = new SymbolNode('a')
+    const aEqual2 = new SymbolNode('a')
+    aEqual2.toTex = () => 'custom tex'
     const aFake = {
       name: 'a'
     }
@@ -112,6 +114,7 @@ describe('SymbolNode', function () {
     assert.strictEqual(a.equals(null), false)
     assert.strictEqual(a.equals(undefined), false)
     assert.strictEqual(a.equals(aEqual), true)
+    assert.strictEqual(a.equals(aEqual2), true)
     assert.strictEqual(a.equals(b), false)
     assert.strictEqual(a.equals(aFake), false)
     assert.strictEqual(a.equals(new ConstantNode(2)), false)


### PR DESCRIPTION
This PR adds a `Symbol.equals` function that checks only that two symbols have the same `name` rather than doing a strict equality check.

The problem this solves is that in some usages, you may want to add / change properties on a specific instance of `SymbolNode` in order to, say, change their `toTex` function but have them remain conceptually "equal". Right now we use a `deepStrictEqual` check which fails if _any_ property differs which causes this to fail:

```
const a1 = new SymbolNode('a')
const a2 = new SymbolNode('a')
a2.toTex = () => 'custom tex'

a1.equals(a2) // false
```

Another case I can think of is that someone may want to create an extension of the SymbolNode type to add some other behaviour but, as in this case, have them remain conceptually equal if their names are the same.