### PR TITLE
Improve ParenthesisNode types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -337,13 +337,16 @@ declare namespace math {
       implicit?: boolean
     ): OperatorNode<TOp, TFn, TArgs>
   }
-  interface ParenthesisNode<TContent extends MathNode = MathNode> extends MathNodeCommon {
+  interface ParenthesisNode<TContent extends MathNode = MathNode>
+    extends MathNodeCommon {
     type: 'ParenthesisNode'
     isParenthesisNode: true
     content: TContent
   }
   interface ParenthesisNodeCtor {
-    new<TContent extends MathNode>(content: TContent): ParenthesisNode<TContent>
+    new <TContent extends MathNode>(
+      content: TContent
+    ): ParenthesisNode<TContent>
   }
 
   interface RangeNode extends MathNodeCommon {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -337,13 +337,13 @@ declare namespace math {
       implicit?: boolean
     ): OperatorNode<TOp, TFn, TArgs>
   }
-  interface ParenthesisNode extends MathNodeCommon {
+  interface ParenthesisNode<TContent extends MathNode = MathNode> extends MathNodeCommon {
     type: 'ParenthesisNode'
     isParenthesisNode: true
-    content: MathNode
+    content: TContent
   }
   interface ParenthesisNodeCtor {
-    new (content: MathNode): ParenthesisNode
+    new<TContent extends MathNode>(content: TContent): ParenthesisNode<TContent>
   }
 
   interface RangeNode extends MathNodeCommon {

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,6 +28,7 @@ import {
   OperatorNodeFn,
   OperatorNodeOp,
   SymbolNode,
+  ParenthesisNode,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -823,6 +824,22 @@ Complex numbers examples
   {
     const _p: math.PolarCoordinates = math.complex(3, 4).toPolar()
   }
+}
+
+
+/*
+Parenthesis examples
+*/
+{
+  const math = create(all, {})
+
+  expectTypeOf(
+    new math.ParenthesisNode(
+      new math.ConstantNode(3),
+    )
+  ).toMatchTypeOf<
+    ParenthesisNode<ConstantNode>
+  >()
 }
 
 /*

--- a/types/index.ts
+++ b/types/index.ts
@@ -826,7 +826,6 @@ Complex numbers examples
   }
 }
 
-
 /*
 Parenthesis examples
 */
@@ -834,12 +833,8 @@ Parenthesis examples
   const math = create(all, {})
 
   expectTypeOf(
-    new math.ParenthesisNode(
-      new math.ConstantNode(3),
-    )
-  ).toMatchTypeOf<
-    ParenthesisNode<ConstantNode>
-  >()
+    new math.ParenthesisNode(new math.ConstantNode(3))
+  ).toMatchTypeOf<ParenthesisNode<ConstantNode>>()
 }
 
 /*


### PR DESCRIPTION
Adds `TContent` generic arg to ParenthesisNode type so that the type of the content node can be kept track of