### PR TITLE
Improve types for factory function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -161,6 +161,10 @@ declare namespace math {
     isHexDigit(c: string): boolean
   }
 
+  interface NodeCtor {
+    new(): Node
+  }
+
   interface AccessorNode extends MathNodeCommon {
     type: 'AccessorNode'
     isAccessorNode: true
@@ -434,6 +438,7 @@ declare namespace math {
     tau: number
 
     // Class-like constructors
+    Node: NodeCtor
     AccessorNode: AccessorNodeCtor
     ArrayNode: ArrayNodeCtor
     AssignmentNode: AssignmentNodeCtor

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3288,10 +3288,10 @@ declare namespace math {
       factories: FactoryFunctionMap,
       config?: ConfigOptions
     ) => MathJsStatic
-    factory: <T>(
+    factory: <T, TDeps extends readonly MathJsFunctionName[]>(
       name: string,
-      dependencies: MathJsFunctionName[],
-      create: (injected: Partial<MathJsStatic>) => T,
+      dependencies: TDeps,
+      create: (injected: Pick<MathJsStatic, Extract<MathJsFunctionName, TDeps[number]>>) => T,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       meta?: any
     ) => FactoryFunction<T>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -162,7 +162,7 @@ declare namespace math {
   }
 
   interface NodeCtor {
-    new(): Node
+    new (): Node
   }
 
   interface AccessorNode extends MathNodeCommon {
@@ -3296,7 +3296,9 @@ declare namespace math {
     factory: <T, TDeps extends readonly MathJsFunctionName[]>(
       name: string,
       dependencies: TDeps,
-      create: (injected: Pick<MathJsStatic, Extract<MathJsFunctionName, TDeps[number]>>) => T,
+      create: (
+        injected: Pick<MathJsStatic, Extract<MathJsFunctionName, TDeps[number]>>
+      ) => T,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       meta?: any
     ) => FactoryFunction<T>


### PR DESCRIPTION
Dependencies available in factory callback are now dependent on list of dependencies which are passed in

e.g.

<img width="824" alt="image" src="https://user-images.githubusercontent.com/64985/172893928-34ced9b2-5622-4bdb-82d5-e1ac791ff840.png">

# Note
One annoying thing is that you do have to write `const dependencies = ['ArrayNode'] as const` instead of `const dependencies = ['ArrayNode']` so that the type is `readonly ["ArrayNode"]` not `string[]` but that's not so bad I guess?