### PR TITLE
Make MathNodeCommon['type'] property a string

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3806,22 +3806,7 @@ declare namespace math {
   interface MathNodeCommon {
     isNode: true
     comment: string
-    type:
-      | 'AccessorNode'
-      | 'ArrayNode'
-      | 'AssignmentNode'
-      | 'BlockNode'
-      | 'ConditionalNode'
-      | 'ConstantNode'
-      | 'FunctionAssignmentNode'
-      | 'FunctionNode'
-      | 'IndexNode'
-      | 'ObjectNode'
-      | 'OperatorNode'
-      | 'ParenthesisNode'
-      | 'RangeNode'
-      | 'RelationalNode'
-      | 'SymbolNode'
+    type: string
 
     isUpdateNode?: boolean
 


### PR DESCRIPTION
Make MathNodeCommon['type'] property a string. This makes it possible to add custom data types, whereas right now Typescript complains that your new node type is not in the built-in union of types.

Before:
<img width="816" alt="image" src="https://user-images.githubusercontent.com/64985/172902644-f33c616b-6e36-4c84-ba54-ba5bc4f3a44b.png">

After:
<img width="828" alt="image" src="https://user-images.githubusercontent.com/64985/172902678-f9c39a44-a4a0-4b2a-8909-e2191163685a.png">

I think it's ok to make MathNodeCommon['type'] less strict since each sub type's `type` field is strictly typed and will override `string` from MathNodeCommon