### PR TITLE
extended simplify function rules to include fractions with coefficients

### DIFF
--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -495,8 +495,17 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       assuming: { multiply: { associative: true } }
     },
 
-    { l: 'n1/(-n2)', r: '-n1/n2' }
+    { l: 'n1/(-n2)', r: '-n1/n2' },
 
+    {
+      s: '(c1*v+c2)/c3 -> ((c1*v)/c3)+c2/c3',
+      assuming: { multiply: { associative: true } }
+    },
+
+    {
+      s: '(-(c1*v)-c2)/c3 -> (-c1/c3)*v+-(c2/c3)',
+      assuming: { multiply: { associative: true } }
+    }
   ]
 
   /**


### PR DESCRIPTION
Added a couple of new rules for expression parsing in case of fractions with coefficients. The expression mentioned in #2594 simplifies correctly now. Multi variable functional expressions with coefficients don't simplify yet. Don't know yet if there is a way to parse both single and multi variable (for instance 'w/5-(2w+3 + **2z**)/2-3w/5') using a single rule. Probably not.