### PR TITLE
fix #2607: improve type definition for createUnit

### DIFF
--- a/src/type/unit/function/createUnit.js
+++ b/src/type/unit/function/createUnit.js
@@ -31,9 +31,10 @@ export const createCreateUnit = /* #__PURE__ */ factory(name, dependencies, ({ t
    *     math.createUnit('foo')
    *     math.createUnit('knot', {definition: '0.514444444 m/s', aliases: ['knots', 'kt', 'kts']})
    *     math.createUnit('mph', '1 mile/hour')
+   *     math.createUnit('km', math.unit(1000, 'm'))
    *
    * @param {string} name      The name of the new unit. Must be unique. Example: 'knot'
-   * @param {string, Unit} definition      Definition of the unit in terms of existing units. For example, '0.514444444 m / s'.
+   * @param {string, UnitDefinition, Unit} definition      Definition of the unit in terms of existing units. For example, '0.514444444 m / s'.
    * @param {Object} options   (optional) An object containing any of the following properties:
    *     - `prefixes {string}` "none", "short", "long", "binary_short", or "binary_long". The default is "none".
    *     - `aliases {Array}` Array of strings. Example: ['knots', 'kt', 'kts']

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -589,7 +589,7 @@ declare namespace math {
      */
     createUnit(
       name: string,
-      definition?: string | UnitDefinition,
+      definition?: string | UnitDefinition | Unit,
       options?: CreateUnitOptions
     ): Unit
     /**
@@ -599,7 +599,7 @@ declare namespace math {
      * @returns The new unit
      */
     createUnit(
-      units: Record<string, string | UnitDefinition>,
+      units: Record<string, string | UnitDefinition | Unit>,
       options?: CreateUnitOptions
     ): Unit
 
@@ -4111,7 +4111,7 @@ declare namespace math {
      */
     createUnit(
       this: MathJsChain<string>,
-      definition?: string | UnitDefinition,
+      definition?: string | UnitDefinition | Unit,
       options?: CreateUnitOptions
     ): MathJsChain<Unit>
     /**
@@ -4125,7 +4125,7 @@ declare namespace math {
      * 0.
      */
     createUnit(
-      this: MathJsChain<Record<string, string | UnitDefinition>>,
+      this: MathJsChain<Record<string, string | UnitDefinition | Unit>>,
       options?: CreateUnitOptions
     ): MathJsChain<Unit>
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -1285,6 +1285,7 @@ Units examples
   // use Unit as definition
   math.createUnit('c', { definition: b })
   math.createUnit('c', { definition: b }, { override: true })
+  math.createUnit('customUnit', math.unit(0.5, 'm'))
 
   // units can be added, subtracted, and multiplied or divided by numbers and by other units
   math.add(a, b)


### PR DESCRIPTION
Resolves issue #2607

This improves the type definition for `createUnit` function 
I also added an example using `Unit` as definition