### PR TITLE
Fix types for pickRandom

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2204,7 +2204,6 @@ declare namespace math {
      * when number is > 1.
      */
     pickRandom<T>(array: T[]): T
-    pickRandom<T>(array: T[], number: 1, weights?: number[]): T
     pickRandom<T>(array: T[], number: number): T[]
     pickRandom<T>(array: T[], number: number, weights: number[]): T[]
 
@@ -5525,7 +5524,6 @@ declare namespace math {
      * @param weights An array of ints or floats
      */
     pickRandom<T>(array: T[]): MathJsChain<T>
-    pickRandom<T>(array: T[], number: 1, weights?: number[]): MathJsChain<T>
     pickRandom<T>(array: T[], number: number): MathJsChain<T[]>
     pickRandom<T>(array: T[], number: number, weights: number[]): MathJsChain<T[]>
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5524,11 +5524,10 @@ declare namespace math {
      * @param number An int or float
      * @param weights An array of ints or floats
      */
-    pickRandom(
-      array: MathJsChain<number[]>,
-      number?: number,
-      weights?: number[]
-    ): MathJsChain<number | number[]>
+    pickRandom<T>(array: T[]): MathJsChain<T>
+    pickRandom<T>(array: T[], number: 1, weights?: number[]): MathJsChain<T>
+    pickRandom<T>(array: T[], number: number): MathJsChain<T[]>
+    pickRandom<T>(array: T[], number: number, weights: number[]): MathJsChain<T[]>
 
     /**
      * Return a random number larger or equal to min and smaller than max

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2203,11 +2203,10 @@ declare namespace math {
      * undefined. Returns an array with the configured number of elements
      * when number is > 1.
      */
-    pickRandom(
-      array: number[],
-      number?: number,
-      weights?: number[]
-    ): number | number[]
+    pickRandom<T>(array: T[]): T
+    pickRandom<T>(array: T[], number: 1, weights?: number[]): T
+    pickRandom<T>(array: T[], number: number): T[]
+    pickRandom<T>(array: T[], number: number, weights: number[]): T[]
 
     /**
      * Return a random number larger or equal to min and smaller than max

--- a/types/index.ts
+++ b/types/index.ts
@@ -2246,3 +2246,16 @@ Resolve examples
   ).toMatchTypeOf<MathNode[]>()
   expectTypeOf(math.resolve(math.matrix(['x', 'y']))).toMatchTypeOf<Matrix>()
 }
+
+/*
+Random examples
+*/
+{
+  const math = create(all, {})
+  expectTypeOf(math.pickRandom([1, 2, 3])).toMatchTypeOf<number>()
+  expectTypeOf(math.pickRandom(['a', { b: 10 }, 42])).toMatchTypeOf<
+    string | number | { b: number }
+  >()
+  expectTypeOf(math.pickRandom([1, 2, 3], 1)).toMatchTypeOf<number>()
+  expectTypeOf(math.pickRandom([1, 2, 3], 2)).toMatchTypeOf<number[]>()
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -2256,7 +2256,7 @@ Random examples
   expectTypeOf(math.pickRandom(['a', { b: 10 }, 42])).toMatchTypeOf<
     string | number | { b: number }
   >()
-  expectTypeOf(math.pickRandom([1, 2, 3], 1)).toMatchTypeOf<number>()
+  expectTypeOf(math.pickRandom([1, 2, 3])).toMatchTypeOf<number>()
   expectTypeOf(math.pickRandom([1, 2, 3], 2)).toMatchTypeOf<number[]>()
 
   expectTypeOf(math.chain().pickRandom([1, 2, 3], 2)).toMatchTypeOf<MathJsChain<number[]>>()

--- a/types/index.ts
+++ b/types/index.ts
@@ -2258,4 +2258,6 @@ Random examples
   >()
   expectTypeOf(math.pickRandom([1, 2, 3], 1)).toMatchTypeOf<number>()
   expectTypeOf(math.pickRandom([1, 2, 3], 2)).toMatchTypeOf<number[]>()
+
+  expectTypeOf(math.chain().pickRandom([1, 2, 3], 2)).toMatchTypeOf<MathJsChain<number[]>>()
 }


### PR DESCRIPTION
The TS type for pickRandom currently restricts the given array to numbers, however (AFAIK) it doesn't actually care what the array given to it contains.

This PR:
- Uses a generic to type the given array
- Varies the return type (T or T[]) depending on the given args