### PR TITLE
Make it possible to create subclass of `Node` while keeping TS happy

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -385,22 +385,8 @@ declare namespace math {
     new (name: string): SymbolNode
   }
 
-  type MathNode =
-    | AccessorNode
-    | ArrayNode
-    | AssignmentNode
-    | BlockNode
-    | ConditionalNode
-    | ConstantNode
-    | FunctionAssignmentNode
-    | FunctionNode
-    | IndexNode
-    | ObjectNode
-    | OperatorNode<OperatorNodeOp, OperatorNodeFn>
-    | ParenthesisNode
-    | RangeNode
-    | RelationalNode
-    | SymbolNode
+  // NOTE this is as it is to avoid breaking changes, please don't change it
+  type MathNode = MathNodeCommon
 
   type MathJsFunctionName = keyof MathJsStatic
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -162,10 +162,10 @@ declare namespace math {
   }
 
   interface NodeCtor {
-    new (): MathNodeCommon
+    new (): MathNode
   }
 
-  interface AccessorNode extends MathNodeCommon {
+  interface AccessorNode extends MathNode {
     type: 'AccessorNode'
     isAccessorNode: true
     object: MathNode
@@ -176,7 +176,7 @@ declare namespace math {
     new (object: MathNode, index: IndexNode): AccessorNode
   }
 
-  interface ArrayNode extends MathNodeCommon {
+  interface ArrayNode extends MathNode {
     type: 'ArrayNode'
     isArrayNode: true
     items: MathNode[]
@@ -185,7 +185,7 @@ declare namespace math {
     new (items: MathNode[]): ArrayNode
   }
 
-  interface AssignmentNode extends MathNodeCommon {
+  interface AssignmentNode extends MathNode {
     type: 'AssignmentNode'
     isAssignmentNode: true
     object: SymbolNode | AccessorNode
@@ -202,7 +202,7 @@ declare namespace math {
     ): AssignmentNode
   }
 
-  interface BlockNode extends MathNodeCommon {
+  interface BlockNode extends MathNode {
     type: 'BlockNode'
     isBlockNode: true
     blocks: Array<{ node: MathNode; visible: boolean }>
@@ -213,7 +213,7 @@ declare namespace math {
     ): BlockNode
   }
 
-  interface ConditionalNode extends MathNodeCommon {
+  interface ConditionalNode extends MathNode {
     type: 'ConditionalNode'
     isConditionalNode: boolean
     condition: MathNode
@@ -228,7 +228,7 @@ declare namespace math {
     ): ConditionalNode
   }
 
-  interface ConstantNode extends MathNodeCommon {
+  interface ConstantNode extends MathNode {
     type: 'ConstantNode'
     isConstantNode: true
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -239,7 +239,7 @@ declare namespace math {
     new (constant: number): ConstantNode
   }
 
-  interface FunctionAssignmentNode extends MathNodeCommon {
+  interface FunctionAssignmentNode extends MathNode {
     type: 'FunctionAssignmentNode'
     isFunctionAssignmentNode: true
     name: string
@@ -250,7 +250,7 @@ declare namespace math {
     new (name: string, params: string[], expr: MathNode): FunctionAssignmentNode
   }
 
-  interface FunctionNode extends MathNodeCommon {
+  interface FunctionNode extends MathNode {
     type: 'FunctionNode'
     isFunctionNode: true
     fn: SymbolNode
@@ -260,7 +260,7 @@ declare namespace math {
     new (fn: MathNode | string, args: MathNode[]): FunctionNode
   }
 
-  interface IndexNode extends MathNodeCommon {
+  interface IndexNode extends MathNode {
     type: 'IndexNode'
     isIndexNode: true
     dimensions: MathNode[]
@@ -271,7 +271,7 @@ declare namespace math {
     new (dimensions: MathNode[], dotNotation: boolean): IndexNode
   }
 
-  interface ObjectNode extends MathNodeCommon {
+  interface ObjectNode extends MathNode {
     type: 'ObjectNode'
     isObjectNode: true
     properties: Record<string, MathNode>
@@ -320,7 +320,7 @@ declare namespace math {
     TOp extends OperatorNodeMap[TFn] = never,
     TFn extends OperatorNodeFn = never,
     TArgs extends MathNode[] = MathNode[]
-  > extends MathNodeCommon {
+  > extends MathNode {
     type: 'OperatorNode'
     isOperatorNode: true
     op: TOp
@@ -331,7 +331,7 @@ declare namespace math {
     isBinary(): boolean
   }
 
-  interface OperatorNodeCtor extends MathNodeCommon {
+  interface OperatorNodeCtor extends MathNode {
     new <
       TOp extends OperatorNodeMap[TFn],
       TFn extends OperatorNodeFn,
@@ -344,7 +344,7 @@ declare namespace math {
     ): OperatorNode<TOp, TFn, TArgs>
   }
   interface ParenthesisNode<TContent extends MathNode = MathNode>
-    extends MathNodeCommon {
+    extends MathNode {
     type: 'ParenthesisNode'
     isParenthesisNode: true
     content: TContent
@@ -355,7 +355,7 @@ declare namespace math {
     ): ParenthesisNode<TContent>
   }
 
-  interface RangeNode extends MathNodeCommon {
+  interface RangeNode extends MathNode {
     type: 'RangeNode'
     isRangeNode: true
     start: MathNode
@@ -366,7 +366,7 @@ declare namespace math {
     new (start: MathNode, end: MathNode, step?: MathNode): RangeNode
   }
 
-  interface RelationalNode extends MathNodeCommon {
+  interface RelationalNode extends MathNode {
     type: 'RelationalNode'
     isRelationalNode: true
     conditionals: string[]
@@ -376,7 +376,7 @@ declare namespace math {
     new (conditionals: string[], params: MathNode[]): RelationalNode
   }
 
-  interface SymbolNode extends MathNodeCommon {
+  interface SymbolNode extends MathNode {
     type: 'SymbolNode'
     isSymbolNode: true
     name: string
@@ -385,8 +385,10 @@ declare namespace math {
     new (name: string): SymbolNode
   }
 
-  // NOTE this is as it is to avoid breaking changes, please don't change it
-  type MathNode = MathNodeCommon
+  /**
+   * @deprecated since version 11.3. Prefer `MathNode` instead
+   */
+  type MathNodeCommon = MathNode
 
   type MathJsFunctionName = keyof MathJsStatic
 
@@ -3132,7 +3134,7 @@ declare namespace math {
 
     isIndexNode(x: unknown): x is IndexNode
 
-    isNode(x: unknown): x is MathNodeCommon
+    isNode(x: unknown): x is MathNode
 
     isObjectNode(x: unknown): x is ObjectNode
 
@@ -3841,7 +3843,7 @@ declare namespace math {
     evaluate(scope?: any): any
   }
 
-  interface MathNodeCommon {
+  interface MathNode {
     isNode: true
     comment: string
     type: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -44,6 +44,7 @@ import {
   MathNodeCommon,
   Unit,
   Node,
+  isSymbolNode,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -1005,7 +1006,6 @@ Expressions examples
     if (node.type !== 'ParenthesisNode') {
       throw Error(`expected ParenthesisNode, got ${node.type}`)
     }
-    const _innerNode = node.content
   }
 
   // scope can contain both variables and functions
@@ -1464,9 +1464,9 @@ Expression tree examples
   const math = create(all, {})
 
   // Filter an expression tree
-  const node: MathNode = math.parse('x^2 + x/4 + 3*y')
-  const filtered: MathNode[] = node.filter(
-    (node: MathNode) => node.type === 'SymbolNode' && node.name === 'x'
+  const node = math.parse('x^2 + x/4 + 3*y')
+  const filtered = node.filter(
+    (node) => isSymbolNode(node) && node.name === 'x'
   )
 
   const _arr: string[] = filtered.map((node: MathNode) => node.toString())

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,7 +27,6 @@ import {
   MathJsChain,
   MathJsFunctionName,
   MathNode,
-  MathNodeCommon,
   MathNumericType,
   MathType,
   Matrix,
@@ -42,7 +41,9 @@ import {
   SimplifyRule,
   SLUDecomposition,
   SymbolNode,
+  MathNodeCommon,
   Unit,
+  Node,
 } from 'mathjs'
 import * as assert from 'assert'
 import { expectTypeOf } from 'expect-type'
@@ -2171,10 +2172,10 @@ Factory Test
     expectTypeOf(x).toMatchTypeOf<IndexNode>()
   }
   if (math.isNode(x)) {
-    expectTypeOf(x).toMatchTypeOf<MathNodeCommon>()
+    expectTypeOf(x).toMatchTypeOf<MathNode>()
   }
   if (math.isNode(x)) {
-    expectTypeOf(x).toMatchTypeOf<MathNodeCommon>()
+    expectTypeOf(x).toMatchTypeOf<MathNode>()
   }
   if (math.isObjectNode(x)) {
     expectTypeOf(x).toMatchTypeOf<ObjectNode>()
@@ -2262,4 +2263,37 @@ Random examples
   expectTypeOf(math.chain([1, 2, 3]).pickRandom(2)).toMatchTypeOf<
     MathJsChain<number[]>
   >()
+}
+
+/*
+MathNode examples
+*/
+{
+  class CustomNode extends Node {
+    a: MathNode
+    constructor(a: MathNode) {
+      super()
+      this.a = a
+    }
+  }
+
+  // Basic node
+  const instance1 = new Node()
+
+  // Built-in subclass of Node
+  const instance2 = new ConstantNode(2)
+
+  // Custom subclass of node
+  const instance3 = new CustomNode(new ConstantNode(2))
+
+  expectTypeOf(instance1).toMatchTypeOf<MathNode>()
+  expectTypeOf(instance1).toMatchTypeOf<MathNodeCommon>()
+
+  expectTypeOf(instance2).toMatchTypeOf<MathNode>()
+  expectTypeOf(instance2).toMatchTypeOf<MathNodeCommon>()
+  expectTypeOf(instance2).toMatchTypeOf<ConstantNode>()
+
+  expectTypeOf(instance3).toMatchTypeOf<MathNode>()
+  expectTypeOf(instance3).toMatchTypeOf<MathNodeCommon>()
+  expectTypeOf(instance3).toMatchTypeOf<CustomNode>()
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "target": "ES6",
     "paths": {
       "mathjs": ["./index.d.ts"]
     },


### PR DESCRIPTION
## The Problem

Currently, `MathNode` is defined as a union of all of the existing subclasses of `Node` i.e. 

```ts
  type MathNode = MathNo
    | AccessorNode
    | ArrayNode
    | AssignmentNode
    | BlockNode
   ...
```

This has a few consequences:
1. Every time a node new type is added in MathJS you also have to remember to add that type to the `MathNode` union
2. It's impossible (or at least as far as I can tell) to add a custom subclass of `Node` when using mathjs while having that node conform to the `MathNode` type so that TS is happy

## The solution
By simply aliasing `MathNode` to `MathNodeCommon` (which all existing node types extend), typescript automatically infers that any subclasses of `Node` are valid `MathNode` types.

I did some digging and couldn't quite figure out why the `MathNodeCommon` type needed to exist in the first place and why it couldn't just be called `MathNode`, but it is what it is and I guess we can't change that now without a lot of breaking changes.