### PR TITLE
Fix min as short for minim not minute in documentation

### DIFF
--- a/docs/datatypes/units.md
+++ b/docs/datatypes/units.md
@@ -273,9 +273,9 @@ Base                | Unit
 Length              | meter (m), inch (in), foot (ft), yard (yd), mile (mi), link (li), rod (rd), chain (ch), angstrom, mil
 Surface area        | m2, sqin, sqft, sqyd, sqmi, sqrd, sqch, sqmil, acre, hectare
 Volume              | m3, litre (l, L, lt, liter), cc, cuin, cuft, cuyd, teaspoon, tablespoon
-Liquid volume       | minim (min), fluiddram (fldr), fluidounce (floz), gill (gi), cup (cp), pint (pt), quart (qt), gallon (gal), beerbarrel (bbl), oilbarrel (obl), hogshead, drop (gtt)
+Liquid volume       | minim, fluiddram (fldr), fluidounce (floz), gill (gi), cup (cp), pint (pt), quart (qt), gallon (gal), beerbarrel (bbl), oilbarrel (obl), hogshead, drop (gtt)
 Angles              | rad (radian), deg (degree), grad (gradian), cycle, arcsec (arcsecond), arcmin (arcminute)
-Time                | second (s, secs, seconds), minute (mins, minutes), hour (h, hr, hrs, hours), day (days), week (weeks), month (months), year (years), decade (decades), century (centuries), millennium (millennia)
+Time                | second (s, secs, seconds), minute (min, mins, minutes), hour (h, hr, hrs, hours), day (days), week (weeks), month (months), year (years), decade (decades), century (centuries), millennium (millennia)
 Frequency           | hertz (Hz)
 Mass                | gram(g), tonne, ton, grain (gr), dram (dr), ounce (oz), poundmass (lbm, lb, lbs), hundredweight (cwt), stick, stone
 Electric current    | ampere (A)


### PR DESCRIPTION
I noticed that in the documentation `min` is marked as short for the volume unit `minim`. This is not the case since it is used as the short form of `minute`. See:

Commented out minim definition:

https://github.com/josdejong/mathjs/blob/194725727a9af7a38a65a0980e4efd16142af8da/src/type/unit/Unit.js#L1896

and the actual minute definition:

https://github.com/josdejong/mathjs/blob/194725727a9af7a38a65a0980e4efd16142af8da/src/type/unit/Unit.js#L2094-L2100

This MR simply moves min to the correct row in the table.