### PR TITLE
[Proposal] Refactor `resolve` fn to be more flexible and extensible

### DIFF
--- a/src/expression/node/FunctionNode.js
+++ b/src/expression/node/FunctionNode.js
@@ -279,6 +279,16 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
     }
 
     /**
+     * TODO
+     * @param {*} scope 
+     * @param {*} within 
+     * @returns 
+     */
+    resolve (scope, within = new Set()) {
+      return new FunctionNode(this.name, this.args.map((a) => a.resolve(scope, within)))
+    }
+
+    /**
      * Execute a callback for each of the child nodes of this node
      * @param {function(child: Node, path: string, parent: Node)} callback
      */

--- a/src/expression/node/Node.js
+++ b/src/expression/node/Node.js
@@ -60,6 +60,13 @@ export const createNode = /* #__PURE__ */ factory(name, dependencies, ({ mathWit
     }
 
     /**
+     * TODO
+     */
+    resolve (scope, within = new Set()) {
+      return this.map(child => child.resolve(scope, within))
+    }
+
+    /**
      * Compile a node into a JavaScript function.
      * This basically pre-calculates as much as possible and only leaves open
      * calculations which depend on a dynamic scope with variables.

--- a/src/expression/node/OperatorNode.js
+++ b/src/expression/node/OperatorNode.js
@@ -327,6 +327,16 @@ export const createOperatorNode = /* #__PURE__ */ factory(name, dependencies, ({
     }
 
     /**
+     * TODO
+     * @param {*} scope 
+     * @param {*} within 
+     * @returns 
+     */
+    resolve (scope, within = new Set()) {
+      return new OperatorNode(this.op, this.fn, this.args.map(a => a.resolve(scope, within)), this.implicit)
+    }
+
+    /**
      * Execute a callback for each of the child nodes of this node
      * @param {function(child: Node, path: string, parent: Node)} callback
      */

--- a/src/expression/node/ParenthesisNode.js
+++ b/src/expression/node/ParenthesisNode.js
@@ -47,6 +47,16 @@ export const createParenthesisNode = /* #__PURE__ */ factory(name, dependencies,
     }
 
     /**
+     * TODO
+     * @param {*} scope 
+     * @param {*} within 
+     * @returns 
+     */
+    resolve (scope, within = new Set()) {
+      return new ParenthesisNode(this.content.resolve(scope, within))
+    }
+
+    /**
      * Get the content of the current Node.
      * @return {Node} content
      * @override

--- a/src/expression/node/SymbolNode.js
+++ b/src/expression/node/SymbolNode.js
@@ -1,5 +1,6 @@
 import { escape } from '../../utils/string.js'
 import { getSafeProperty } from '../../utils/customs.js'
+import { isNode } from '../../utils/is.js'
 import { factory } from '../../utils/factory.js'
 import { toSymbol } from '../../utils/latex.js'
 
@@ -7,10 +8,11 @@ const name = 'SymbolNode'
 const dependencies = [
   'math',
   '?Unit',
-  'Node'
+  'Node',
+  'ConstantNode'
 ]
 
-export const createSymbolNode = /* #__PURE__ */ factory(name, dependencies, ({ math, Unit, Node }) => {
+export const createSymbolNode = /* #__PURE__ */ factory(name, dependencies, ({ math, Unit, Node, ConstantNode, parse }) => {
   /**
    * Check whether some name is a valueless unit like "inch".
    * @param {string} name
@@ -40,6 +42,35 @@ export const createSymbolNode = /* #__PURE__ */ factory(name, dependencies, ({ m
 
     get type () { return 'SymbolNode' }
     get isSymbolNode () { return true }
+
+    /**
+     * TODO
+     * @param {*} scope 
+     * @param {*} within 
+     * @returns 
+     */
+    resolve (scope, within = new Set()) {
+      if (within.has(this.name)) {
+        const variables = Array.from(within).join(', ')
+        throw new ReferenceError(
+          `recursive loop of variable definitions among {${variables}}`
+        )
+      }
+
+      const value = scope.get(this.name)
+
+      if (isNode(value)) {
+        const nextWithin = new Set(within)
+        nextWithin.add(this.name)
+        return value.resolve(scope, nextWithin)
+      } else if (typeof value === 'number') {
+        return math.parse(String(value))
+      } else if (value !== undefined) {
+        return new ConstantNode(value)
+      } else {
+        return this
+      }
+    }
 
     /**
      * Compile a node into a JavaScript function.

--- a/src/function/algebra/resolve.js
+++ b/src/function/algebra/resolve.js
@@ -52,42 +52,8 @@ export const createResolve = /* #__PURE__ */ factory(name, dependencies, ({
     if (!scope) {
       return node
     }
-    if (isSymbolNode(node)) {
-      if (within.has(node.name)) {
-        const variables = Array.from(within).join(', ')
-        throw new ReferenceError(
-          `recursive loop of variable definitions among {${variables}}`
-        )
-      }
-      const value = scope.get(node.name)
-      if (isNode(value)) {
-        const nextWithin = new Set(within)
-        nextWithin.add(node.name)
-        return _resolve(value, scope, nextWithin)
-      } else if (typeof value === 'number') {
-        return parse(String(value))
-      } else if (value !== undefined) {
-        return new ConstantNode(value)
-      } else {
-        return node
-      }
-    } else if (isOperatorNode(node)) {
-      const args = node.args.map(function (arg) {
-        return _resolve(arg, scope, within)
-      })
-      return new OperatorNode(node.op, node.fn, args, node.implicit)
-    } else if (isParenthesisNode(node)) {
-      return new ParenthesisNode(_resolve(node.content, scope, within))
-    } else if (isFunctionNode(node)) {
-      const args = node.args.map(function (arg) {
-        return _resolve(arg, scope, within)
-      })
-      return new FunctionNode(node.name, args)
-    }
 
-    // Otherwise just recursively resolve any children (might also work
-    // for some of the above special cases)
-    return node.map(child => _resolve(child, scope, within))
+    return node.resolve(scope, within)
   }
 
   return typed('resolve', {

--- a/test/unit-tests/expression/node/OperatorNode.test.js
+++ b/test/unit-tests/expression/node/OperatorNode.test.js
@@ -45,6 +45,10 @@ describe('OperatorNode', function () {
     assert.strictEqual(add23.compile().evaluate(), 5)
   })
 
+  it('should resolve an OperatorNode', function () {
+    // TODO
+  })
+
   it('should test whether a unary or binary operator', function () {
     const n1 = new OperatorNode('-', 'unaryMinus', [two])
     assert.strictEqual(n1.isUnary(), true)

--- a/test/unit-tests/expression/node/ParenthesisNode.test.js
+++ b/test/unit-tests/expression/node/ParenthesisNode.test.js
@@ -33,6 +33,10 @@ describe('ParenthesisNode', function () {
     assert.strictEqual(n.compile().evaluate.toString(), a.compile().evaluate.toString())
   })
 
+  it('should resolve a ParenthesisNode', function () {
+    // TODO
+  })
+
   it('should filter a ParenthesisNode', function () {
     const a = new ConstantNode(1)
     const n = new ParenthesisNode(a)

--- a/test/unit-tests/expression/node/SymbolNode.test.js
+++ b/test/unit-tests/expression/node/SymbolNode.test.js
@@ -50,6 +50,10 @@ describe('SymbolNode', function () {
     assert.strictEqual(expr2.evaluate(scope2), math.sqrt)
   })
 
+  it('should resolve a SymbolNode', function () {
+    // TODO
+  })
+
   it('should filter a SymbolNode', function () {
     const n = new SymbolNode('x')
     assert.deepStrictEqual(n.filter(function (node) { return node instanceof SymbolNode }), [n])


### PR DESCRIPTION
## Problem

Currently, all of the logic for deciding how resolution works lives in the global `resolve` function. This means that it's impossible to change the resolution behaviour on custom Node subclasses.

## Solution

Move node-specific resolution logic from `resolve` function to each node type class to allow extending / changing the behaviour in custom types, as well as cleaning up the code a bit, and makes things easier to test.

## Motivation

In my app, I'd like to implement a custom node type called `RandomValueNode` that replaces itself with a `ConstantNode` with a random value when it's tree is resolved, however the current implementation of resolve makes that impossible.