### PR TITLE
Fix #2793: `math.flatten()` clones object values too

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,12 +3,12 @@
 # not yet published, 11.3.0
 
 - Allow creating new subclasses of `Node` in TypeScript. @mattvague.
+- Fix flatten() cloning entries of array/Matrix (#2799).
 
 
 # 2022-09-13, 11.2.1
 
 - Fix doc generator being broken, not generating a function reference.
-
 
 # 2022-09-12, 11.2.0
 

--- a/src/function/matrix/flatten.js
+++ b/src/function/matrix/flatten.js
@@ -1,4 +1,3 @@
-import { clone } from '../../utils/object.js'
 import { flatten as flattenArray } from '../../utils/array.js'
 import { factory } from '../../utils/factory.js'
 
@@ -7,8 +6,8 @@ const dependencies = ['typed', 'matrix']
 
 export const createFlatten = /* #__PURE__ */ factory(name, dependencies, ({ typed, matrix }) => {
   /**
-   * Flatten a multi dimensional matrix into a single dimensional matrix.
-   * It is guaranteed to always return a clone of the argument.
+   * Flatten a multidimensional matrix into a single dimensional matrix.
+   * A new matrix is returned, the original matrix is left untouched.
    *
    * Syntax:
    *
@@ -27,12 +26,12 @@ export const createFlatten = /* #__PURE__ */ factory(name, dependencies, ({ type
    */
   return typed(name, {
     Array: function (x) {
-      return flattenArray(clone(x))
+      return flattenArray(x)
     },
 
     Matrix: function (x) {
-      const flat = flattenArray(clone(x.toArray()))
-      // TODO: return the same matrix type as x
+      const flat = flattenArray(x.toArray())
+      // TODO: return the same matrix type as x (Dense or Sparse Matrix)
       return matrix(flat)
     }
   })

--- a/test/unit-tests/function/matrix/flatten.test.js
+++ b/test/unit-tests/function/matrix/flatten.test.js
@@ -8,11 +8,11 @@ describe('flatten', function () {
     assert.deepStrictEqual(flatten([]), [])
   })
 
-  it('should clone the flattened array', function () {
+  it('should not clone the flattened array', function () {
     const c = math.complex()
     const flat = flatten([c])
     assert.deepStrictEqual(flat, [c])
-    assert(c !== flat[0])
+    assert(c === flat[0])
   })
 
   it('should flatten a 1 dimensional array', function () {


### PR DESCRIPTION
Resolves #2793.