### PR TITLE
lint ts files in test directory

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,7 +33,7 @@ module.exports = {
       }
     },
     {
-      files: ['types/*.ts'],
+      files: ['*.ts'],
       extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:prettier/recommended' // this should come last


### PR DESCRIPTION
When the TS type tests go moved to `tests/` directory, the associated linting rule did not get updated.  Rather than specifically linting TS files in `types/` and `tests/`, I think it's better to just lint all TS files using the TS rules.

### How should this be manually tested?
Add a linting error in both ts files (index.d.ts and testTypes.ts), run `npm run lint` and check that both errors are caught.