### PR TITLE
Improve standard simplify rule matches in non-commutative contexts

### DIFF
--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -447,6 +447,11 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     }
 
     if (isAssociative(newRule.l, context)) {
+      const nonCommutative = !isCommutative(newRule.l, context)
+      let leftExpandsym
+      // Gen. the LHS placeholder used in this NC-context specific expansion rules
+      if (nonCommutative) leftExpandsym = _getExpandPlaceholderSymbol()
+
       const makeNode = createMakeNodeFunction(newRule.l)
       const expandsym = _getExpandPlaceholderSymbol()
       newRule.expanded = {}
@@ -456,6 +461,20 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       flatten(newRule.expanded.l, context)
       unflattenr(newRule.expanded.l, context)
       newRule.expanded.r = makeNode([newRule.r, expandsym])
+
+      // In and for a non-commutative context, attempting with yet additional expansion rules makes
+      // way for more matches cases of multi-arg expressions; such that associative rules (such as
+      // 'n*n -> n^2') can be applied to exprs. such as 'a * b * b' and 'a * b * b * a'.
+      if (nonCommutative) {
+        // 'Non-commutative' 1: LHS (placeholder) only
+        newRule.expandedNC1 = {}
+        newRule.expandedNC1.l = makeNode([leftExpandsym, newRule.l.clone()])
+        newRule.expandedNC1.r = makeNode([leftExpandsym, newRule.r])
+        // 'Non-commutative' 2: farmost LHS and RHS placeholders
+        newRule.expandedNC2 = {}
+        newRule.expandedNC2.l = makeNode([leftExpandsym, newRule.expanded.l.clone()])
+        newRule.expandedNC2.r = makeNode([leftExpandsym, newRule.expanded.r])
+      }
     }
 
     return newRule
@@ -656,6 +675,16 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     if (!matches && rule.expanded) {
       repl = rule.expanded.r
       matches = _ruleMatch(rule.expanded.l, res, mergedContext)[0]
+      // Additional expansion-rules may be present for canonicalized rules in non-commutative
+      // contexts; making way for more potential matches for multi-operand/flattened exprs.
+      if (!matches && rule.expandedNC1) {
+        repl = rule.expandedNC1.r
+        matches = _ruleMatch(rule.expandedNC1.l, res, mergedContext)[0]
+      }
+      if (!matches && rule.expandedNC2) {
+        repl = rule.expandedNC2.r
+        matches = _ruleMatch(rule.expandedNC2.l, res, mergedContext)[0]
+      }
     }
 
     if (matches) {
@@ -880,8 +909,8 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
         }
         res = mergeChildMatches(childMatches)
       } else if (node.args.length >= 2 && rule.args.length === 2) { // node is flattened, rule is not
-        // Associative operators/functions can be split in different ways so we check if the rule matches each
-        // them and return their union.
+        // Associative operators/functions can be split in different ways so we check if the rule
+        // matches for each of them and return their union.
         const splits = getSplits(node, context)
         let splitMatches = []
         for (let i = 0; i < splits.length; i++) {

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -675,13 +675,12 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     if (!matches && rule.expanded) {
       repl = rule.expanded.r
       matches = _ruleMatch(rule.expanded.l, res, mergedContext)[0]
-      // Additional expansion-rules may be present for canonicalized rules in non-commutative
-      // contexts; making way for more potential matches for multi-operand/flattened exprs.
-      if (!matches && rule.expandedNC1) {
-        repl = rule.expandedNC1.r
-        matches = _ruleMatch(rule.expandedNC1.l, res, mergedContext)[0]
-      }
-      if (!matches && rule.expandedNC2) {
+    }
+    // Additional, non-commutative context expansion-rules
+    if (!matches && rule.expandedNC1) {
+      repl = rule.expandedNC1.r
+      matches = _ruleMatch(rule.expandedNC1.l, res, mergedContext)[0]
+      if (!matches) { // Existence of NC1 implies NC2
         repl = rule.expandedNC2.r
         matches = _ruleMatch(rule.expandedNC2.l, res, mergedContext)[0]
       }

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -455,7 +455,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       const makeNode = createMakeNodeFunction(newRule.l)
       const expandsym = _getExpandPlaceholderSymbol()
       newRule.expanded = {}
-      newRule.expanded.l = makeNode([newRule.l.clone(), expandsym])
+      newRule.expanded.l = makeNode([newRule.l, expandsym])
       // Push the expandsym into the deepest possible branch.
       // This helps to match the newRule against nodes returned from getSplits() later on.
       flatten(newRule.expanded.l, context)
@@ -468,11 +468,11 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       if (nonCommutative) {
         // 'Non-commutative' 1: LHS (placeholder) only
         newRule.expandedNC1 = {}
-        newRule.expandedNC1.l = makeNode([leftExpandsym, newRule.l.clone()])
+        newRule.expandedNC1.l = makeNode([leftExpandsym, newRule.l])
         newRule.expandedNC1.r = makeNode([leftExpandsym, newRule.r])
         // 'Non-commutative' 2: farmost LHS and RHS placeholders
         newRule.expandedNC2 = {}
-        newRule.expandedNC2.l = makeNode([leftExpandsym, newRule.expanded.l.clone()])
+        newRule.expandedNC2.l = makeNode([leftExpandsym, newRule.expanded.l])
         newRule.expandedNC2.r = makeNode([leftExpandsym, newRule.expanded.r])
       }
     }

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -440,12 +440,32 @@ describe('simplify', function () {
 
   it('should respect context changes to operator properties', function () {
     const optsNCM = { context: { multiply: { commutative: false } } }
+    const optsNCA = { context: { add: { commutative: false } } }
+
     simplifyAndCompare('x*y+y*x', 'x*y+y*x', {}, optsNCM)
     simplifyAndCompare('x*y-y*x', 'x*y-y*x', {}, optsNCM)
     simplifyAndCompare('x*5', 'x*5', {}, optsNCM)
     simplifyAndCompare('x*y*x^(-1)', 'x*y*x^(-1)', {}, optsNCM)
     simplifyAndCompare('x*y/x', 'x*y*x^(-1)', {}, optsNCM)
     simplifyAndCompare('x*y*(1/x)', 'x*y*x^(-1)', {}, optsNCM)
+
+    // Rules apply to *segments* of operands in NC multi-arg. exprs.
+    // ('n*n->n^2')
+    simplifyAndCompare('n*n*3', 'n^2*3', {}, optsNCM)
+    simplifyAndCompare('3*n*n', '3*n^2', {}, optsNCM)
+    simplifyAndCompare('3*n*n*3', '3*n^2*3', {}, optsNCM)
+    simplifyAndCompare('3*n*n*n*3', '3*n^2*n*3', {}, optsNCM)
+    simplifyAndCompare('3*3*n*n*n*3', '9*n^2*n*3', {}, optsNCM)
+    simplifyAndCompare('(w*z)*n*n*3', 'w*z*n^2*3', {}, optsNCM)
+    // ('v*(v*n1+n2) ->  v^2*n1+v*n2')
+    simplifyAndCompare('w*x*(x*y+z)', 'w*(x^2*y+x*z)', {}, optsNCM)
+    simplifyAndCompare('w*x*(x*y+z)*w', 'w*(x^2*y+x*z)*w', {}, optsNCM)
+    //  'n+n -> 2*n'
+    simplifyAndCompare('x+x+3', '2*x+3', {}, optsNCA)
+    simplifyAndCompare('3+x+x', '3+2*x', {}, optsNCA)
+    simplifyAndCompare('4+x+x+4', '4+2*x+4', {}, optsNCA)
+    // 'n+n -> 2*n'  &  'n3*n1 + n3*n2 -> n3*(n1+n2)'
+    simplifyAndCompare('5+x+x+x+x+5', '5+4*x+5', {}, optsNCA)
 
     const optsNAA = { context: { add: { associative: false } } }
     simplifyAndCompare(

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -457,6 +457,7 @@ describe('simplify', function () {
     simplifyAndCompare('3*n*n*n*3', '3*n^2*n*3', {}, optsNCM)
     simplifyAndCompare('3*3*n*n*n*3', '9*n^2*n*3', {}, optsNCM)
     simplifyAndCompare('(w*z)*n*n*3', 'w*z*n^2*3', {}, optsNCM)
+    simplifyAndCompare('2*n*n*3*n*n*4', '2*n^2*3*n^2*4', {}, optsNCM) // 'double wedged', +applied >1x
     // ('v*(v*n1+n2) ->  v^2*n1+v*n2')
     simplifyAndCompare('w*x*(x*y+z)', 'w*(x^2*y+x*z)', {}, optsNCM)
     simplifyAndCompare('w*x*(x*y+z)*w', 'w*(x^2*y+x*z)*w', {}, optsNCM)
@@ -464,6 +465,7 @@ describe('simplify', function () {
     simplifyAndCompare('x+x+3', '2*x+3', {}, optsNCA)
     simplifyAndCompare('3+x+x', '3+2*x', {}, optsNCA)
     simplifyAndCompare('4+x+x+4', '4+2*x+4', {}, optsNCA)
+    simplifyAndCompare('4+x+x+5+x+x+6', '4+2*x+5+2*x+6', {}, optsNCA) // 'double wedged', +applied >1x
     // 'n+n -> 2*n'  &  'n3*n1 + n3*n2 -> n3*(n1+n2)'
     simplifyAndCompare('5+x+x+x+x+5', '5+4*x+5', {}, optsNCA)
 


### PR DESCRIPTION
Addresses the rule application limitation aspect as highlighted in issue #2825; such that a broader set of successful standard replacement rules are applied to multi-arg/associative expressions in non-commutative contexts.