### PR TITLE
Fix types for `multiply()` with `number[]` and `number[][]`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1296,10 +1296,14 @@ declare namespace math {
 
     multiply<T extends Matrix>(x: T, y: MathType): Matrix
     multiply<T extends Matrix>(x: MathType, y: T): Matrix
+    
+    multiply<T extends MathNumericType[]>(x: T, y: T[]): T
+    multiply<T extends MathNumericType[]>(x: T[], y: T): T
 
+    multiply<T extends MathArray>(x: T, y: T): T
+    
     multiply(x: Unit, y: Unit): Unit
     multiply(x: number, y: number): number
-    multiply(x: MathArray, y: MathArray): MathArray
     multiply(x: MathType, y: MathType): MathType
 
     /**


### PR DESCRIPTION
Fix types for `multiply( number[][], number[] )`, `multiply( number[], number[][] )` and `multiply( number[][], number[][] )`

Type errors were introduced to users using `number[]` with #2623, which used MathArray directly (where `MathArray` could be `MathNumericType[]` or `MathNumericType[][]`), causing the return type to be `MathNumericType[] | MathNumericType[][]`, breaking any existing usage of `multiply( number[], number[][] )` and `multiply( number[][], number[][] )`.

The fix in #2623 also didn't fix the case of `multiply( number[], number[][] )`.