### PR TITLE
Fix: Add "rotationMatrix" function type

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -2302,6 +2302,9 @@ Resolve examples
     math.resolve([math.parse('x + y'), 'x*x'], { x: 0 })
   ).toMatchTypeOf<MathNode[]>()
   expectTypeOf(math.resolve(math.matrix(['x', 'y']))).toMatchTypeOf<Matrix>()
+  expectTypeOf(
+    math.resolve(math.rotationMatrix(math.pi / 2))
+  ).toMatchTypeOf<Matrix>()
 }
 
 /*

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1419,6 +1419,38 @@ Sparse matrices examples
 }
 
 /*
+Rotation matrices examples
+*/
+{
+  const math = create(all, {})
+
+  // create a rotation matrix
+  const a = math.rotationMatrix()
+  const b = math.rotationMatrix(math.pi, [1, 1, 0], 'sparse')
+
+  expectTypeOf(a).toMatchTypeOf<MathCollection>()
+  expectTypeOf(b).toMatchTypeOf<MathCollection>()
+
+  assert.throws(
+    // @ts-expect-error ... verify format parameter is either null, 'sparse' or 'dense'
+    () => math.rotationMatrix(math.pi, [1, 1, 0], 'format'),
+    TypeError
+  )
+
+  assert.throws(
+    // @ts-expect-error ... verify theta is number
+    () => math.rotationMatrix('pi'),
+    TypeError
+  )
+
+  assert.throws(
+    // @ts-expect-error ... verify axis is of MathColletion Type
+    () => math.rotationMatrix(math.pi, 1),
+    TypeError
+  )
+}
+
+/*
 Units examples
 */
 {

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -2302,9 +2302,6 @@ Resolve examples
     math.resolve([math.parse('x + y'), 'x*x'], { x: 0 })
   ).toMatchTypeOf<MathNode[]>()
   expectTypeOf(math.resolve(math.matrix(['x', 'y']))).toMatchTypeOf<Matrix>()
-  expectTypeOf(
-    math.resolve(math.rotationMatrix(math.pi / 2))
-  ).toMatchTypeOf<Matrix>()
 }
 
 /*

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2079,9 +2079,9 @@ declare namespace math {
      * @param {string} [format]                              Result Matrix storage format. Default value: 'dense'.
      * @return {Matrix}                                      Rotation Matrix
      */
-    rotationMatrix<T extends Matrix>(
-      theta: number | BigNumber | Complex | Unit,
-      axis?: MathArray | Matrix,
+    rotationMatrix<T extends MathCollection>(
+      theta?: number | BigNumber | Complex | Unit,
+      axis?: T,
       format?: 'sparse' | 'dense'
     ): T
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2073,6 +2073,19 @@ declare namespace math {
     ): T
 
     /**
+     * Return a Rotation Matrix for a given angle in radians
+     * @param {number | BigNumber | Complex | Unit} theta    Rotation angle
+     * @param {Array | Matrix} [v]                           Rotation axis
+     * @param {string} [format]                              Result Matrix storage format. Default value: 'dense'.
+     * @return {Matrix}                                      Rotation Matrix
+     */
+    rotationMatrix<T extends Matrix>(
+      theta: number | BigNumber | Complex | Unit,
+      axis?: MathArray | Matrix,
+      format?: 'sparse' | 'dense'
+    ): T
+
+    /**
      * Return a row from a Matrix.
      * @param value An array or matrix
      * @param row The index of the row


### PR DESCRIPTION
Issue: #2803 

Why: The type for the function rotationMatrix was missing in index.d.ts

What: Add such type in index.d.ts

Suggestion: Maybe add a type SquareMatrix that extends from Matrix  and the function "rotationMatrix" would return such type ( since rotation matrices are always square ) ?  