### PR TITLE
Add numeric types to `complex()` type declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -622,7 +622,7 @@ declare namespace math {
      * complex number
      * @returns Returns a complex value
      */
-    complex(arg?: Complex | string | PolarCoordinates): Complex
+    complex(arg?: MathNumericType | string | PolarCoordinates): Complex
     complex(arg?: MathCollection): MathCollection
     /**
      * @param re Argument specifying the real part of the complex number


### PR DESCRIPTION
`complex(a)` creates the complex number `a + 0i` when `a` is a non-complex numeric. This should be expressed in the type declaration.