### PR TITLE
[fix] intersect method parameter type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1676,7 +1676,7 @@ declare namespace math {
       w: MathCollection,
       x: MathCollection,
       y: MathCollection,
-      z: MathCollection
+      z?: MathCollection
     ): MathArray
 
     /*************************************************************************


### PR DESCRIPTION
Please check the issue #2896 

I fixed the last parameter of intersect method to calculate intersection between a line and a plane using typescript.