### PR TITLE
add an "ifCondition" parameter to rules, so you can programatically choose whether a rule applies or not

### DIFF
--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -449,7 +449,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     }
     newRule.l = removeParens(parse(newRule.l))
     newRule.r = removeParens(parse(newRule.r))
-    for (const prop of ['imposeContext', 'repeat', 'assuming']) {
+    for (const prop of ['imposeContext', 'repeat', 'assuming', 'ifCondition']) {
       if (prop in ruleObject) {
         newRule[prop] = ruleObject[prop]
       }
@@ -695,6 +695,12 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       if (!matches) { // Existence of NC1 implies NC2
         repl = rule.expandedNC2.r
         matches = _ruleMatch(rule.expandedNC2.l, res, mergedContext)[0]
+      }
+    }
+
+    if (matches && rule.ifCondition) {
+      if (!rule.ifCondition(matches)) {
+        matches = false;
       }
     }
 

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -700,7 +700,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
 
     if (matches && rule.ifCondition) {
       if (!rule.ifCondition(matches)) {
-        matches = false;
+        matches = false
       }
     }
 

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -707,12 +707,14 @@ describe('simplify', function () {
   })
 
   it('can should simplify when given an ifCondition rule', function () {
-    let yBeforeXRule = [
+    const yBeforeXRule = [
       {
-        l: 've1 + ve2', r: 've2 + ve1', ifCondition: (matches) => {
+        l: 've1 + ve2',
+        r: 've2 + ve1',
+        ifCondition: (matches) => {
           return matches.placeholders.ve2.toString().indexOf('y') >= 0 && matches.placeholders.ve1.toString().indexOf('x') >= 0
         }
-       }
+      }
     ]
 
     simplifyAndCompare('x + y', 'y + x', yBeforeXRule)

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -705,4 +705,18 @@ describe('simplify', function () {
     assert(!isNaN(posex.evaluate(zeroes)))
     assert.notEqual(expr.evaluate(zeroes), posex.evaluate(zeroes))
   })
+
+  it('can should simplify when given an ifCondition rule', function () {
+    let yBeforeXRule = [
+      {
+        l: 've1 + ve2', r: 've2 + ve1', ifCondition: (matches) => {
+          return matches.placeholders.ve2.toString().indexOf('y') >= 0 && matches.placeholders.ve1.toString().indexOf('x') >= 0
+        }
+       }
+    ]
+
+    simplifyAndCompare('x + y', 'y + x', yBeforeXRule)
+    simplifyAndCompare('y + x', 'y + x', yBeforeXRule)
+    simplifyAndCompare('x^2 + y^2', 'y^2 + x^2', yBeforeXRule)
+  })
 })


### PR DESCRIPTION
I found that when calling `simplify` with equations in different orders (such as "x + x^2" vs "x^2 + x"), I'd get different results. I wanted to make a consistent way to sort terms, and found there wasn't a conditional way to apply simplification rules; you can only either make a rule that always applies or make a change based on the entire node tree (which means I'd need to write my own matching code).

As such, I propose adding an optional function, I called "ifCondition" , that you can place on a rule. It gets passed the matches that are being currently looked at, and if the function returns false, then the swap is not made, and if it returns true, then it is made.