### PR TITLE
add exactConstantFunctions to simplify, to tell mathjs to not convert constant functions into decimals

### DIFF
--- a/src/function/algebra/simplifyConstant.js
+++ b/src/function/algebra/simplifyConstant.js
@@ -360,8 +360,8 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
           if (operatorFunctions.indexOf(node.name) === -1) {
             const args = node.args.map(arg => foldFraction(arg, options))
 
-            // If all args are numbers
-            if (!args.some(isNode)) {
+            // If all args are numbers and we want to simplify constanct functions down into a number
+            if (!args.some(isNode) && !options.exactConstantFunctions) {
               try {
                 return _eval(node.name, args, options)
               } catch (ignoreandcontinue) { }

--- a/src/function/algebra/simplifyConstant.js
+++ b/src/function/algebra/simplifyConstant.js
@@ -361,7 +361,10 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
             const args = node.args.map(arg => foldFraction(arg, options))
 
             // If all args are numbers and we want to simplify constanct functions down into a number
-            if (!args.some(isNode) && !options.exactConstantFunctions) {
+            // allow calling the following simple functions that return exact values
+            const exactFunctions = [...operatorFunctions, 'abs', 'ceil', 'fix', 'floor', 'round', 'sign', 'subtract', 'unaryMinus', 'unaryPlus']
+
+            if (!args.some(isNode) && (!options.exactConstantFunctions || exactFunctions.indexOf(node.name) > -1)) {
               try {
                 return _eval(node.name, args, options)
               } catch (ignoreandcontinue) { }

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -300,7 +300,12 @@ describe('simplify', function () {
   })
 
   it('should simplify non-rational expressions with no symbols to number', function () {
+    // default turn all constants into decimals
     simplifyAndCompare('3+sin(4)', '2.2431975046920716')
+    // exactConstantFunctions lets sin, cos, log, etc stay in exact form
+    simplifyAndCompare('3+sin(4)', '3+sin(4)', {}, { exactConstantFunctions: true })
+    // but still make sure to consolidate the numeric constants
+    simplifyAndCompare('3+(4*3)', '15', {}, { exactConstantFunctions: true })
   })
 
   it('should collect like terms', function () {

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -306,6 +306,8 @@ describe('simplify', function () {
     simplifyAndCompare('3+sin(4)', '3+sin(4)', {}, { exactConstantFunctions: true })
     // but still make sure to consolidate the numeric constants
     simplifyAndCompare('3+(4*3)', '15', {}, { exactConstantFunctions: true })
+    // when we say we want exact functions, abs is still exact
+    simplifyAndCompare('abs(-2)', '2', {}, { exactConstantFunctions: true })
   })
 
   it('should collect like terms', function () {


### PR DESCRIPTION
I had a case which ended up with a constant log in it, which I wanted to stay as an exact value and not a decimal. I've added an option, `exactConstantFunctions`, so when passed as true it'll not evaluate functions. So while by default `simplify("3 + sin(4)")` will give you back `2.2431975046920716`, with `{ exactConstantFunctions: true }` passed you'll get back `3 + sin(4)`. It'll still add, multiply, apply exponents to raw constants, just not call most functions (especially not desirable for me for the trig/log functions to be called).