### PR TITLE
adds additional ampere aliases

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -2833,6 +2833,8 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     joules: 'joule',
 
     amperes: 'ampere',
+    amps: 'ampere',
+    amp: 'ampere',
     coulombs: 'coulomb',
     volts: 'volt',
     ohms: 'ohm',


### PR DESCRIPTION
Minor change to add `"amps"` and `"amp"` as new aliases for `"ampere"`. Some of our US-based users were surprised that `"1 amp"` or `"5 amps"` wasn't parsed properly, while `"5 volts"` was.