### PR TITLE
Make fraction equality less strict 

### DIFF
--- a/src/core/function/typed.js
+++ b/src/core/function/typed.js
@@ -78,7 +78,7 @@ import {
   isUnit
 } from '../../utils/is.js'
 import typedFunction from 'typed-function'
-import { digits } from '../../utils/number.js'
+import { digits, nearlyEqual } from '../../utils/number.js'
 import { factory } from '../../utils/factory.js'
 import { isMap } from '../../utils/map.js'
 
@@ -94,7 +94,8 @@ const dependencies = [
   '?BigNumber',
   '?Complex',
   '?DenseMatrix',
-  '?Fraction'
+  '?Fraction',
+  '?config'
 ]
 
 /**
@@ -102,7 +103,7 @@ const dependencies = [
  * @param {Object} dependencies   Object with data types like Complex and BigNumber
  * @returns {Function}
  */
-export const createTyped = /* #__PURE__ */ factory('typed', dependencies, function createTyped ({ BigNumber, Complex, DenseMatrix, Fraction }) {
+export const createTyped = /* #__PURE__ */ factory('typed', dependencies, function createTyped ({ BigNumber, Complex, DenseMatrix, Fraction, config }) {
   // TODO: typed-function must be able to silently ignore signatures with unknown data types
 
   // get a new instance of typed-function
@@ -225,9 +226,8 @@ export const createTyped = /* #__PURE__ */ factory('typed', dependencies, functi
         if (!Fraction) {
           throwNoFraction(x)
         }
-
         const f = new Fraction(x)
-        if (f.valueOf() !== x) {
+        if (!nearlyEqual(f.valueOf(), x, config.epsilon)) {
           throw new TypeError('Cannot implicitly convert a number to a Fraction when there will be a loss of precision ' +
             '(value: ' + x + '). ' +
             'Use function fraction(x) to convert to Fraction.')

--- a/src/function/relational/equalScalar.js
+++ b/src/function/relational/equalScalar.js
@@ -33,7 +33,7 @@ export const createEqualScalar = /* #__PURE__ */ factory(name, dependencies, ({ 
     },
 
     'Fraction, Fraction': function (x, y) {
-      return x.equals(y)
+      return nearlyEqual(x.valueOf(), y.valueOf(), config.epsilon)
     },
 
     'Complex, Complex': function (x, y) {

--- a/src/function/relational/equalScalar.js
+++ b/src/function/relational/equalScalar.js
@@ -33,7 +33,7 @@ export const createEqualScalar = /* #__PURE__ */ factory(name, dependencies, ({ 
     },
 
     'Fraction, Fraction': function (x, y) {
-      return nearlyEqual(x.valueOf(), y.valueOf(), config.epsilon)
+      return x.equals(y)
     },
 
     'Complex, Complex': function (x, y) {

--- a/src/type/fraction/Fraction.js
+++ b/src/type/fraction/Fraction.js
@@ -1,10 +1,11 @@
 import Fraction from 'fraction.js'
 import { factory } from '../../utils/factory.js'
+import { nearlyEqual } from '../../utils/number.js'
 
 const name = 'Fraction'
-const dependencies = []
+const dependencies = ['config']
 
-export const createFractionClass = /* #__PURE__ */ factory(name, dependencies, () => {
+export const createFractionClass = /* #__PURE__ */ factory(name, dependencies, ({ config }) => {
   /**
    * Attach type information
    */
@@ -12,6 +13,9 @@ export const createFractionClass = /* #__PURE__ */ factory(name, dependencies, (
   Fraction.prototype.constructor = Fraction
   Fraction.prototype.type = 'Fraction'
   Fraction.prototype.isFraction = true
+  Fraction.prototype.equals = function (fb) {
+    return nearlyEqual(this.valueOf(), fb.valueOf(), config.epsilon)
+  }
 
   /**
    * Get a JSON representation of a Fraction containing type information

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -300,7 +300,7 @@ describe('simplify', function () {
   })
 
   it('should simplify non-rational expressions with no symbols to number', function () {
-    simplifyAndCompare('3+sin(4)', '2.2431975046920716')
+    simplifyAndCompare('3+sin(4)', '2.2431975046920716', undefined, { exactFractions: false })
   })
 
   it('should collect like terms', function () {

--- a/test/unit-tests/function/arithmetic/addScalar.test.js
+++ b/test/unit-tests/function/arithmetic/addScalar.test.js
@@ -85,10 +85,10 @@ describe('addScalar', function () {
     assert.deepStrictEqual(add(math.fraction(1, 3), 1), math.fraction(4, 3))
   })
 
-  it('should throw an error when converting a number to a fraction that is not an exact representation', function () {
-    assert.throws(function () {
-      add(math.pi, math.fraction(1, 3))
-    }, /Cannot implicitly convert a number to a Fraction when there will be a loss of precision/)
+  it('should not throw an error when converting a number to a fraction that is not an exact representation but nearly equal', function () {
+    const oneThird = math.fraction(1, 3)
+    assert.strictEqual(oneThird.equals(0.3333333333333333), true)
+    assert.strictEqual(add(math.pi, math.fraction(1, 3)).valueOf(), 3.4749259869233007)
   })
 
   it('should add strings to numbers', function () {

--- a/test/unit-tests/type/fraction/function/fraction.test.js
+++ b/test/unit-tests/type/fraction/function/fraction.test.js
@@ -59,6 +59,21 @@ describe('fraction', function () {
     assert.throws(function () { math.fraction(-Infinity) }, /Error: -Infinity cannot be represented as a fraction/)
     assert.throws(function () { math.fraction(NaN) }, /Error: NaN cannot be represented as a fraction/)
   })
+
+  it('should consider fractions equal if their difference is less than the default epsilon', function () {
+    const fractMath = math.create()
+    fractMath.config({ number: 'Fraction', epsilon: 1e-12 })
+    fractMath.createUnit('rotation', { definition: '360 deg', aliases: ['tour', 'tr'] })
+
+    const a = fractMath.unit(360, 'deg')
+    const b = fractMath.unit(1, 'rotation')
+    const fa = fractMath.fraction(a.value)
+    const fb = fractMath.fraction(b.value)
+
+    assert.strictEqual(a.equals(b), true)
+    assert.strictEqual(fa.equals(fb), true)
+    assert.strictEqual(fractMath.equal(fa, fb), true)
+  })
 })
 
 function equalFraction (a, b) {


### PR DESCRIPTION
This PR fixes equality of fraction when there is loss of precision during conversions as addressed in https://github.com/josdejong/mathjs/issues/2918. It replaces the strict equality when dealing with fractions by the function ```nearlyEqual```. It also changes the equals function inside the prototype of ```Fraction``` in order to make consistent with the other changes. 