### PR TITLE
Included math to syntax when missing

### DIFF
--- a/src/function/algebra/derivative.js
+++ b/src/function/algebra/derivative.js
@@ -43,8 +43,8 @@ export const createDerivative = /* #__PURE__ */ factory(name, dependencies, ({
    *
    * Syntax:
    *
-   *     derivative(expr, variable)
-   *     derivative(expr, variable, options)
+   *     math.derivative(expr, variable)
+   *     math.derivative(expr, variable, options)
    *
    * Examples:
    *

--- a/src/function/algebra/leafCount.js
+++ b/src/function/algebra/leafCount.js
@@ -31,7 +31,7 @@ export const createLeafCount = /* #__PURE__ */ factory(name, dependencies, ({
    *
    * Syntax:
    *
-   *     leafCount(expr)
+   *     math.leafCount(expr)
    *
    * Examples:
    *

--- a/src/function/algebra/polynomialRoot.js
+++ b/src/function/algebra/polynomialRoot.js
@@ -39,7 +39,7 @@ export const createPolynomialRoot = /* #__PURE__ */ factory(name, dependencies, 
    *
    * Syntax:
    *
-   *     polynomialRoot(constant, linearCoeff, quadraticCoeff, cubicCoeff)
+   *     math.polynomialRoot(constant, linearCoeff, quadraticCoeff, cubicCoeff)
    *
    * Examples:
    *     // linear

--- a/src/function/algebra/rationalize.js
+++ b/src/function/algebra/rationalize.js
@@ -67,10 +67,10 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
    *
    * Syntax:
    *
-   *     rationalize(expr)
-   *     rationalize(expr, detailed)
-   *     rationalize(expr, scope)
-   *     rationalize(expr, scope, detailed)
+   *     math.rationalize(expr)
+   *     math.rationalize(expr, detailed)
+   *     math.rationalize(expr, scope)
+   *     math.rationalize(expr, scope, detailed)
    *
    * Examples:
    *

--- a/src/function/algebra/resolve.js
+++ b/src/function/algebra/resolve.js
@@ -25,7 +25,7 @@ export const createResolve = /* #__PURE__ */ factory(name, dependencies, ({
    *
    * Syntax:
    *
-   *     resolve(expr, scope)
+   *     math.resolve(expr, scope)
    *
    * Examples:
    *

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -153,13 +153,13 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
    *
    * Syntax:
    *
-   *     simplify(expr)
-   *     simplify(expr, rules)
-   *     simplify(expr, rules)
-   *     simplify(expr, rules, scope)
-   *     simplify(expr, rules, scope, options)
-   *     simplify(expr, scope)
-   *     simplify(expr, scope, options)
+   *     math.simplify(expr)
+   *     math.simplify(expr, rules)
+   *     math.simplify(expr, rules)
+   *     math.simplify(expr, rules, scope)
+   *     math.simplify(expr, rules, scope, options)
+   *     math.simplify(expr, scope)
+   *     math.simplify(expr, scope, options)
    *
    * Examples:
    *

--- a/src/function/algebra/simplifyConstant.js
+++ b/src/function/algebra/simplifyConstant.js
@@ -48,8 +48,8 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
    *
    * Syntax:
    *
-   *     simplifyConstant(expr)
-   *     simplifyConstant(expr, options)
+   *     math.simplifyConstant(expr)
+   *     math.simplifyConstant(expr, options)
    *
    * Examples:
    *

--- a/src/function/algebra/simplifyCore.js
+++ b/src/function/algebra/simplifyCore.js
@@ -82,8 +82,8 @@ export const createSimplifyCore = /* #__PURE__ */ factory(name, dependencies, ({
    *
    * Syntax:
    *
-   *     simplifyCore(expr)
-   *     simplifyCore(expr, options)
+   *     math.simplifyCore(expr)
+   *     math.simplifyCore(expr, options)
    *
    * Examples:
    *

--- a/src/function/algebra/symbolicEqual.js
+++ b/src/function/algebra/symbolicEqual.js
@@ -31,20 +31,20 @@ export const createSymbolicEqual = /* #__PURE__ */ factory(name, dependencies, (
    *
    * Syntax:
    *
-   *    symbolicEqual(expr1, expr2)
-   *    symbolicEqual(expr1, expr2, options)
+   *     math.symbolicEqual(expr1, expr2)
+   *     math.symbolicEqual(expr1, expr2, options)
    *
    * Examples:
    *
-   *    symbolicEqual('x*y', 'y*x') // Returns true
-   *    symbolicEqual('x*y', 'y*x', {context: {multiply: {commutative: false}}}) // Returns false
-   *    symbolicEqual('x/y', '(y*x^(-1))^(-1)') // Returns true
-   *    symbolicEqual('abs(x)','x') // Returns false
-   *    symbolicEqual('abs(x)','x', simplify.positiveContext) // Returns true
+   *     math.symbolicEqual('x*y', 'y*x') // Returns true
+   *     math.symbolicEqual('x*y', 'y*x', {context: {multiply: {commutative: false}}}) // Returns false
+   *     math.symbolicEqual('x/y', '(y*x^(-1))^(-1)') // Returns true
+   *     math.symbolicEqual('abs(x)','x') // Returns false
+   *     math.symbolicEqual('abs(x)','x', simplify.positiveContext) // Returns true
    *
    * See also:
    *
-   *    simplify, evaluate
+   *     simplify, evaluate
    *
    * @param {Node|string} expr1  The first expression to compare
    * @param {Node|string} expr2  The second expression to compare

--- a/src/function/matrix/sqrtm.js
+++ b/src/function/matrix/sqrtm.js
@@ -49,7 +49,7 @@ export const createSqrtm = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    *
    * Syntax:
    *
-   *     X = math.sqrtm(A)
+   *     math.sqrtm(A)
    *
    * Examples:
    *

--- a/src/type/unit/function/splitUnit.js
+++ b/src/type/unit/function/splitUnit.js
@@ -9,7 +9,7 @@ export const createSplitUnit = /* #__PURE__ */ factory(name, dependencies, ({ ty
    *
    * Syntax:
    *
-   *     splitUnit(unit: Unit, parts: Array.<Unit>)
+   *     math.splitUnit(unit: Unit, parts: Array.<Unit>)
    *
    * Example:
    *


### PR DESCRIPTION
According to #2938

Found the functions that didn't include `math.` in the syntax section and included it in an attempt for docs to be consistent.

https://mathjs.org/docs/reference/functions.html