### PR TITLE
feat: better min/max return type

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -2416,3 +2416,25 @@ MathNode examples
   expectTypeOf(instance3).toMatchTypeOf<MathNodeCommon>()
   expectTypeOf(instance3).toMatchTypeOf<CustomNode>()
 }
+
+/*
+min/max return types
+*/
+{
+  const math = create(all, {})
+  expectTypeOf(math.min(1, 2, 3)).toMatchTypeOf<number>()
+  expectTypeOf(
+    math.min(math.bignumber('123'), math.bignumber('456'))
+  ).toMatchTypeOf<BigNumber>()
+  expectTypeOf(math.min(123, math.bignumber('456'))).toMatchTypeOf<
+    number | BigNumber
+  >()
+
+  expectTypeOf(math.max(1, 2, 3)).toMatchTypeOf<number>()
+  expectTypeOf(
+    math.max(math.bignumber('123'), math.bignumber('456'))
+  ).toMatchTypeOf<BigNumber>()
+  expectTypeOf(math.max(123, math.bignumber('456'))).toMatchTypeOf<
+    number | BigNumber
+  >()
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2596,8 +2596,7 @@ declare namespace math {
      * @param args A single matrix or multiple scalar values
      * @returns The maximum value
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    max(...args: MathType[]): any
+    max<T extends MathType[]>(...args: T): T[number]
     /**
      * @param A A single matrix
      * @param dim The maximum over the selected dimension
@@ -2639,14 +2638,13 @@ declare namespace math {
 
     /**
      * Compute the minimum value of a matrix or a list of values. In case of
-     * a multi dimensional array, the minimun of the flattened array will be
-     * calculated. When dim is provided, the minimun over the selected
+     * a multi dimensional array, the minimum of the flattened array will be
+     * calculated. When dim is provided, the minimum over the selected
      * dimension will be calculated. Parameter dim is zero-based.
      * @param args A single matrix or or multiple scalar values
      * @returns The minimum value
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    min(...args: MathType[]): any
+    min<T extends MathType[]>(...args: T): T[number]
     /**
      * @param A A single matrix
      * @param dim The minimum over the selected dimension


### PR DESCRIPTION
Addresses https://github.com/josdejong/mathjs/issues/2954
Tests included
And a small typo fix

Couldn't fully run TS tests on local:
```
> mathjs@11.8.0 test:types
> tsc -p ./tsconfig.json && node --loader ts-node/esm ./test/typescript-tests/testTypes.ts

(node:64308) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/max/mathjs/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366
    throw new ERR_MODULE_NOT_FOUND(
          ^
CustomError: Cannot find module '/Users/max/mathjs/lib/esm/index.js' imported from /Users/max/mathjs/test/typescript-tests/testTypes.ts
    at finalizeResolution (/Users/max/mathjs/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366:11)
    at moduleResolve (/Users/max/mathjs/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:801:10)
    at Object.defaultResolve (/Users/max/mathjs/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:912:11)
    at /Users/max/mathjs/node_modules/ts-node/src/esm.ts:218:35
    at entrypointFallback (/Users/max/mathjs/node_modules/ts-node/src/esm.ts:168:34)
    at /Users/max/mathjs/node_modules/ts-node/src/esm.ts:217:14
    at addShortCircuitFlag (/Users/max/mathjs/node_modules/ts-node/src/esm.ts:409:21)
    at resolve (/Users/max/mathjs/node_modules/ts-node/src/esm.ts:197:12)
    at ESMLoader.resolve (node:internal/modules/esm/loader:422:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:222:40)
```

But it compiles fine, TSC doesn't complain, hopefully, CI will have more luck with it.