### PR TITLE
Workaround for min and sec parsing problem

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -578,6 +578,9 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    */
   function parseStart (expression, extraNodes) {
     const state = initialState()
+    expression = expression
+      .replaceAll(/\bmin\b(?!\()/g, 'minute') // avoid confusion of unit min and function min()
+      .replaceAll(/\bsec\b(?!\()/g, 's') // avoid confusion of unit sec and function sec()
     Object.assign(state, { expression, extraNodes })
     getToken(state)
 

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -537,6 +537,14 @@ describe('parse', function () {
       approx.deepEqual(parseAndEval('a in', { a: 5 }), new Unit(5, 'in'))
       approx.deepEqual(parseAndEval('0.5in + 1.5in to cm'), new Unit(5.08, 'cm').to('cm'))
     })
+
+    it('should evaluate unit "min" (should not conflict with function "min")', function () {
+      approx.deepEqual(parseAndEval('2 minute - 2 min'), new Unit(0, 'minute'))
+    })
+
+    it('should evaluate unit "sec" (should not conflict with function "sec")', function () {
+      approx.deepEqual(parseAndEval('2 s - 2 sec'), new Unit(0, 's'))
+    })
   })
 
   describe('complex', function () {


### PR DESCRIPTION
The expression parser `math.evaluate` currently has some confusion between the unit `min` (minutes) and the function `min` (minimum). Similarly for `sec` (seconds) and the function `sec` (secant). Presently, the units are mistakenly recognized as functions in the parser and results in errors. This issue was raised in #2095 and in later discussion within #2771 

It seems to me that function names should always be followed by left parenthesis "(" and the proper fix would be to have the parser look for that character to recognize any function. A fix like that should allow functions and units to coexist so that the user could even define _new_ functions with names that match unit names without trouble. Currently, new functions like this will fail just like the built-in `sec` and `min`.

I'm not familiar enough with the code to implement a change like describe above so, for a temporary workaround, I've added a regular expression to immediately rename any `min` and `sec` units found in the parse expression.