### PR TITLE
Add assignString to AssignmentNodes

### DIFF
--- a/src/expression/node/AssignmentNode.js
+++ b/src/expression/node/AssignmentNode.js
@@ -71,6 +71,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
       this.object = object
       this.index = value ? index : null
       this.value = value || index
+      this.assignString = '='
 
       // validate input
       if (!isSymbolNode(object) && !isAccessorNode(object)) {
@@ -248,7 +249,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
         value = '(' + value + ')'
       }
 
-      return object + index + ' = ' + value
+      return `${object}${index} ${this.assignString} ${value}`
     }
 
     /**
@@ -294,7 +295,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
 
       return object + index +
         '<span class="math-operator math-assignment-operator ' +
-        'math-variable-assignment-operator math-binary-operator">=</span>' +
+        'math-variable-assignment-operator math-binary-operator">' + this.assignString + '</span>' +
         value
     }
 
@@ -312,7 +313,7 @@ export const createAssignmentNode = /* #__PURE__ */ factory(name, dependencies, 
         value = `\\left(${value}\\right)`
       }
 
-      return object + index + ':=' + value
+      return `${object}${index}${this.assignString}${value}`
     }
   }
 

--- a/src/expression/node/ConditionalNode.js
+++ b/src/expression/node/ConditionalNode.js
@@ -59,8 +59,13 @@ export const createConditionalNode = /* #__PURE__ */ factory(name, dependencies,
       if (!isNode(falseExpr)) { throw new TypeError('Parameter falseExpr must be a Node') }
 
       this.condition = condition
+      this.condition.assignString = ':='
+
       this.trueExpr = trueExpr
+      this.trueExpr.assignString = ':='
+
       this.falseExpr = falseExpr
+      this.falseExpr.assignString = ':='
     }
 
     static name = name

--- a/src/expression/node/FunctionAssignmentNode.js
+++ b/src/expression/node/FunctionAssignmentNode.js
@@ -71,6 +71,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
         return (param && param.type) || 'any'
       })
       this.expr = expr
+      this.assignString = '='
     }
 
     static name = name
@@ -165,7 +166,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
       if (needParenthesis(this, parenthesis, options && options.implicit)) {
         expr = '(' + expr + ')'
       }
-      return this.name + '(' + this.params.join(', ') + ') = ' + expr
+      return `${this.name}(${this.params.join(', ')}) ${this.assignString} ${expr}`
     }
 
     /**
@@ -227,7 +228,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
         params.join('<span class="math-separator">,</span>') +
         '<span class="math-parenthesis math-round-parenthesis">)</span>' +
         '<span class="math-operator math-assignment-operator ' +
-        'math-variable-assignment-operator math-binary-operator">=</span>' +
+        'math-variable-assignment-operator math-binary-operator">' + this.assignString + '</span>' +
         expr
     }
 
@@ -245,7 +246,7 @@ export const createFunctionAssignmentNode = /* #__PURE__ */ factory(name, depend
       }
 
       return '\\mathrm{' + this.name +
-        '}\\left(' + this.params.map(toSymbol).join(',') + '\\right):=' + expr
+        '}\\left(' + this.params.map(toSymbol).join(',') + '\\right)' + this.assignString + expr
     }
   }
 

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -147,6 +147,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
     '|': true,
     '^|': true,
     '=': true,
+    ':=': true,
     ':': true,
     '?': true,
 
@@ -664,18 +665,24 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
     const node = parseConditional(state)
 
-    if (state.token === '=') {
+    if (state.token === '=' || state.token === ':=') {
+      const assignString = state.token
+
       if (isSymbolNode(node)) {
         // parse a variable assignment like 'a = 2/3'
         name = node.name
         getTokenSkipNewline(state)
         value = parseAssignment(state)
-        return new AssignmentNode(new SymbolNode(name), value)
+        const assignmentNode = new AssignmentNode(new SymbolNode(name), value)
+        assignmentNode.assignString = assignString
+        return assignmentNode
       } else if (isAccessorNode(node)) {
         // parse a matrix subset assignment like 'A[1,2] = 4'
         getTokenSkipNewline(state)
         value = parseAssignment(state)
-        return new AssignmentNode(node.object, node.index, value)
+        const assignmentNode = new AssignmentNode(node.object, node.index, value)
+        assignmentNode.assignString = assignString
+        return assignmentNode
       } else if (isFunctionNode(node) && isSymbolNode(node.fn)) {
         // parse function assignment like 'f(x) = x^2'
         valid = true
@@ -693,7 +700,9 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         if (valid) {
           getTokenSkipNewline(state)
           value = parseAssignment(state)
-          return new FunctionAssignmentNode(name, args, value)
+          const assignmentNode = new FunctionAssignmentNode(name, args, value)
+          assignmentNode.assignString = assignString
+          return assignmentNode
         }
       }
 

--- a/test/unit-tests/expression/node/AssignmentNode.test.js
+++ b/test/unit-tests/expression/node/AssignmentNode.test.js
@@ -469,7 +469,7 @@ describe('AssignmentNode', function () {
     const n = new AssignmentNode(object, value)
 
     assert.strictEqual(n.toString({ parenthesis: 'all' }), 'a = (1)')
-    assert.strictEqual(n.toTex({ parenthesis: 'all' }), ' a:=\\left(1\\right)')
+    assert.strictEqual(n.toTex({ parenthesis: 'all' }), ' a=\\left(1\\right)')
   })
 
   it('should stringify a AssignmentNode', function () {
@@ -532,15 +532,16 @@ describe('AssignmentNode', function () {
     const value = new ConstantNode(2)
     const a = new AssignmentNode(new SymbolNode('a'), value)
 
-    assert.strictEqual(a.toTex(), ' a:=2')
+    assert.strictEqual(a.toTex(), ' a=2')
   })
 
   it('should LaTeX an AssignmentNode containing an AssignmentNode', function () {
     const value = new ConstantNode(2)
     const a = new AssignmentNode(new SymbolNode('a'), value)
     const q = new AssignmentNode(new SymbolNode('q'), a)
+    q.assignString = ':='
 
-    assert.strictEqual(q.toTex(), ' q:=\\left( a:=2\\right)')
+    assert.strictEqual(q.toTex(), ' q:=\\left( a=2\\right)')
   })
 
   it('should LaTeX an AssignmentNode with custom toTex', function () {

--- a/test/unit-tests/expression/node/BlockNode.test.js
+++ b/test/unit-tests/expression/node/BlockNode.test.js
@@ -318,7 +318,7 @@ describe('BlockNode', function () {
       { node: new SymbolNode('foo'), visible: true }
     ])
 
-    assert.strictEqual(n.toTex(), '5\\;\\;\n foo:=3;\\;\\;\n foo')
+    assert.strictEqual(n.toTex(), '5\\;\\;\n foo=3;\\;\\;\n foo')
   })
 
   it('should LaTeX a BlockNode with custom toTex', function () {

--- a/test/unit-tests/expression/node/ConditionalNode.test.js
+++ b/test/unit-tests/expression/node/ConditionalNode.test.js
@@ -276,7 +276,7 @@ describe('ConditionalNode', function () {
   it('should stringify a ConditionalNode', function () {
     const n = new ConditionalNode(condition, a, b)
 
-    assert.strictEqual(n.toString(), 'true ? (a = 2) : (b = 3)')
+    assert.strictEqual(n.toString(), 'true ? (a := 2) : (b := 3)')
   })
 
   it('should stringify a ConditionalNode with custom toString', function () {

--- a/test/unit-tests/expression/node/FunctionAssignmentNode.test.js
+++ b/test/unit-tests/expression/node/FunctionAssignmentNode.test.js
@@ -390,8 +390,8 @@ describe('FunctionAssignmentNode', function () {
   })
 
   it('should respect the \'all\' parenthesis option', function () {
-    const expr = math.parse('f(x)=x+1')
-    assert.strictEqual(expr.toString({ parenthesis: 'all' }), 'f(x) = (x + 1)')
+    const expr = math.parse('f(x) := x+1')
+    assert.strictEqual(expr.toString({ parenthesis: 'all' }), 'f(x) := (x + 1)')
     assert.strictEqual(expr.toTex({ parenthesis: 'all' }), '\\mathrm{f}\\left(x\\right):=\\left( x+1\\right)')
   })
 
@@ -465,6 +465,7 @@ describe('FunctionAssignmentNode', function () {
     const o = new OperatorNode('/', 'divide', [x, a])
     const p = new OperatorNode('^', 'pow', [o, a])
     const n = new FunctionAssignmentNode('f', ['x'], p)
+    n.assignString = ':='
 
     assert.strictEqual(n.toTex(), '\\mathrm{f}\\left(x\\right):=\\left({\\frac{ x}{2}}\\right)^{2}')
   })
@@ -473,9 +474,10 @@ describe('FunctionAssignmentNode', function () {
     const a = new ConstantNode(2)
 
     const n1 = new AssignmentNode(new SymbolNode('a'), a)
+    n1.assignString = ':='
     const n = new FunctionAssignmentNode('f', ['x'], n1)
 
-    assert.strictEqual(n.toTex(), '\\mathrm{f}\\left(x\\right):=\\left( a:=2\\right)')
+    assert.strictEqual(n.toTex(), '\\mathrm{f}\\left(x\\right)=\\left( a:=2\\right)')
   })
 
   it('should LaTeX a FunctionAssignmentNode with custom toTex', function () {


### PR DESCRIPTION
This PR replaces the default behaviour of AssignmentNode and FunctionAssignmentNode to use `:=` as the Latex output for assignment String. It also forces the ConditionalNode to use `:=` for the condition, trueExpr and falseExpr.

Additionally it uses the `assignString` in `toHTML` and `toString` methods.

In the usual cases for AssignmentNode and FunctionAssignmentNode the user can decide which `assignString` to use. Either by providing the token as "(a := 3)" or by changing the assignString programmatically. Like:

```
n = new AssignmentNode(...)
n.assignString = ':='
```

The default assignString is `=`, as the `:=` is mostly used for definitions, like in the conditional node case. And most visitors are used to the simple `=` syntax.

https://github.com/josdejong/mathjs/issues/2979