### PR TITLE
fix: #2974 Simplify puts plus and minus signs next to eachother

### DIFF
--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -391,7 +391,6 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
 
     // undo temporary rules
     // { l: '(-1) * n', r: '-n' }, // #811 added test which proved this is redundant
-    { l: 'n+-n1', r: 'n-n1' }, // undo replace 'subtract'
     {
       s: 'n*(n1^-1) -> n/n1', // undo replace 'divide'; for * commutative
       assuming: { multiply: { commutative: true } } // o.w. / not conventional
@@ -425,7 +424,11 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       assuming: { multiply: { associative: true } }
     },
 
-    { l: 'n1/(-n2)', r: '-n1/n2' }
+    { l: 'n1/(-n2)', r: '-n1/n2' },
+
+    { l: 'n+-n1', r: 'n-n1' }, // undo replace 'subtract'
+
+    { l: 'n+-(n1)', r: 'n-(n1)' },
 
   ]
 

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -392,6 +392,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     // undo temporary rules
     // { l: '(-1) * n', r: '-n' }, // #811 added test which proved this is redundant
     { l: 'n+-n1', r: 'n-n1' }, // undo replace 'subtract'
+    { l: 'n+-(n1)', r: 'n-(n1)' },
     {
       s: 'n*(n1^-1) -> n/n1', // undo replace 'divide'; for * commutative
       assuming: { multiply: { commutative: true } } // o.w. / not conventional
@@ -425,9 +426,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       assuming: { multiply: { associative: true } }
     },
 
-    { l: 'n1/(-n2)', r: '-n1/n2' },
-
-    { l: 'n+-(n1)', r: 'n-(n1)' }
+    { l: 'n1/(-n2)', r: '-n1/n2' }
 
   ]
 

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -391,6 +391,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
 
     // undo temporary rules
     // { l: '(-1) * n', r: '-n' }, // #811 added test which proved this is redundant
+    { l: 'n+-n1', r: 'n-n1' }, // undo replace 'subtract'
     {
       s: 'n*(n1^-1) -> n/n1', // undo replace 'divide'; for * commutative
       assuming: { multiply: { commutative: true } } // o.w. / not conventional
@@ -425,8 +426,6 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     },
 
     { l: 'n1/(-n2)', r: '-n1/n2' },
-
-    { l: 'n+-n1', r: 'n-n1' }, // undo replace 'subtract'
 
     { l: 'n+-(n1)', r: 'n-(n1)' }
 

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -428,7 +428,7 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
 
     { l: 'n+-n1', r: 'n-n1' }, // undo replace 'subtract'
 
-    { l: 'n+-(n1)', r: 'n-(n1)' },
+    { l: 'n+-(n1)', r: 'n-(n1)' }
 
   ]
 

--- a/test/unit-tests/function/algebra/simplify.test.js
+++ b/test/unit-tests/function/algebra/simplify.test.js
@@ -423,6 +423,11 @@ describe('simplify', function () {
     simplifyAndCompare('x-0', 'x')
   })
 
+  it('should remove + before -', function () {
+    assert.strictEqual(math.simplify('y + (-x*b) + a * -5').toString(), 'y - 5 * a - x * b')
+    assert.strictEqual(math.simplify('+3y + (-2z) + x * (-3)').toString(), '3 y - 3 * x - 2 * z')
+  })
+
   it('options parameters', function () {
     simplifyAndCompare('0.1*x', 'x/10')
     simplifyAndCompare('0.1*x', 'x/10', math.simplify.rules, {}, { exactFractions: true })


### PR DESCRIPTION
Fix for #2974
Tests included
Added new rule to remove + before - when the term is in parantheses