### PR TITLE
Energy prefixes

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -2452,7 +2452,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     joule: {
       name: 'joule',
       base: BASE_UNITS.ENERGY,
-      prefixes: PREFIXES.SHORT,
+      prefixes: PREFIXES.LONG,
       value: 1,
       offset: 0
     },

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -2459,7 +2459,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     erg: {
       name: 'erg',
       base: BASE_UNITS.ENERGY,
-      prefixes: PREFIXES.NONE,
+      prefixes: PREFIXES.SHORTLONG, // Both kiloerg and kerg are acceptable
       value: 1e-7,
       offset: 0
     },


### PR DESCRIPTION
This PR modifies the available prefixes for two units of energy in the library:

**erg** had no prefixes available but we find examples of kiloerg, Merg, and others in the wild like [here](https://en.wikipedia.org/wiki/Template:Convert/list_of_units/energy) and [here](https://lnf-wiki.eecs.umich.edu/wiki/Template:Convert/list_of_units). Adding SHORTLONG prefixes is consistent with the existing unit of bar.

**joule** was set to use SHORTLONG but the short prefixes are not common for this unit. Limiting it to only LONG prefixes is consistent with the existing unit of newton.

Thanks for your consideration!
Carl

