### PR TITLE
feat: Add option to eigs() to turn off eigenvector computation

### DIFF
--- a/src/expression/embeddedDocs/function/matrix/eigs.js
+++ b/src/expression/embeddedDocs/function/matrix/eigs.js
@@ -4,9 +4,10 @@ export const eigsDocs = {
   syntax: [
     'eigs(x)'
   ],
-  description: 'Calculate the eigenvalues and eigenvectors of a real symmetric matrix',
+  description: 'Calculate the eigenvalues and optionally eigenvectors of a square matrix',
   examples: [
-    'eigs([[5, 2.3], [2.3, 1]])'
+    'eigs([[5, 2.3], [2.3, 1]])',
+    'eigs([[1, 2, 3], [4, 5, 6], [7, 8, 9]], { precision: 1e-6, eigenvectors: false }'
   ],
   seealso: [
     'inv'

--- a/src/function/matrix/eigs.js
+++ b/src/function/matrix/eigs.js
@@ -13,7 +13,7 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
   const doComplexEigs = createComplexEigs({ config, addScalar, subtract, multiply, multiplyScalar, flatten, divideScalar, sqrt, abs, bignumber, diag, size, reshape, qr, inv, usolve, usolveAll, equal, complex, larger, smaller, matrixFromColumns, dot })
 
   /**
-   * Compute eigenvalues and eigenvectors of a square matrix.
+   * Compute eigenvalues and optionally eigenvectors of a square matrix.
    * The eigenvalues are sorted by their absolute value, ascending, and
    * returned as a vector in the `values` property of the returned project.
    * An eigenvalue with algebraic multiplicity k will be listed k times, so
@@ -31,9 +31,21 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
    * in that case, however, you may still find useful information
    * in `err.values` and `err.vectors`.
    *
+   * Note that the 'precision' option does not directly specify the _accuracy_
+   * of the returned eigenvalues. Rather, it determines how small an entry
+   * of the iterative approximations to an upper triangular matrix must be
+   * in order to be considered zero. The actual accuracy of the returned
+   * eigenvalues may be greater or less than the precision, depending on the
+   * conditioning of the matrix and how far apart or close the actual
+   * eigenvalues are. Note that currently, relatively simple, "traditional"
+   * methods of eigenvalue computation are being used; this is not a modern,
+   * high-precision eigenvalue computation. That said, it should typically
+   * produce fairly reasonable results.
+   *
    * Syntax:
    *
    *     math.eigs(x, [prec])
+   *     math.eigs(x, {options})
    *
    * Examples:
    *
@@ -47,14 +59,17 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
    *     const UTxHxU = multiply(transpose(U), H, U) // diagonalizes H if possible
    *     E[0] == UTxHxU[0][0]  // returns true always
    *
+   *     // Compute only approximate eigenvalues:
+   *     const {values} = eigs(H, {eigenvectors: false, precision: 1e-6})
+   *
    * See also:
    *
    *     inv
    *
    * @param {Array | Matrix} x  Matrix to be diagonalized
    *
-   * @param {number | BigNumber} [prec] Precision, default value: 1e-15
-   * @return {{values: Array|Matrix, eigenvectors: Array<EVobj>}} Object containing an array of eigenvalues and an array of {value: number|BigNumber, vector: Array|Matrix} objects.
+   * @param {number | BigNumber | OptsObject} [opts] Object with keys `precision`, defaulting to config.epsilon, and `eigenvectors`, defaulting to true and specifying whether to compute eigenvectors. If just a number, specifies precision.
+   * @return {{values: Array|Matrix, eigenvectors?: Array<EVobj>}} Object containing an array of eigenvalues and an array of {value: number|BigNumber, vector: Array|Matrix} objects. The eigenvectors property is undefined if eigenvectors were not requested.
    *
    */
   return typed('eigs', {
@@ -67,38 +82,46 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
     // is a roundabout way of doing type detection.
     Array: function (x) { return doEigs(matrix(x)) },
     'Array, number|BigNumber': function (x, prec) {
-      return doEigs(matrix(x), prec)
+      return doEigs(matrix(x), { precision: prec })
     },
+    'Array, Object' (x, opts) { return doEigs(matrix(x), opts) },
     Matrix: function (mat) {
-      return doEigs(mat, undefined, true)
+      return doEigs(mat, { matricize: true })
     },
     'Matrix, number|BigNumber': function (mat, prec) {
-      return doEigs(mat, prec, true)
+      return doEigs(mat, { precision: prec, matricize: true })
+    },
+    'Matrix, Object': function (mat, opts) {
+      const useOpts = { matricize: true }
+      Object.assign(useOpts, opts)
+      return doEigs(mat, useOpts)
     }
   })
 
-  function doEigs (mat, prec, matricize = false) {
-    const result = computeValuesAndVectors(mat, prec)
-    if (matricize) {
+  function doEigs (mat, opts = {}) {
+    const computeVectors = 'eigenvectors' in opts ? opts.eigenvectors : true
+    const prec = opts.precision ?? config.epsilon
+    const result = computeValuesAndVectors(mat, prec, computeVectors)
+    if (opts.matricize) {
       result.values = matrix(result.values)
-      result.eigenvectors = result.eigenvectors.map(({ value, vector }) =>
-        ({ value, vector: matrix(vector) }))
-    }
-    Object.defineProperty(result, 'vectors', {
-      enumerable: false, // to make sure that the eigenvectors can still be
-      // converted to string.
-      get: () => {
-        throw new Error('eigs(M).vectors replaced with eigs(M).eigenvectors')
+      if (computeVectors) {
+        result.eigenvectors = result.eigenvectors.map(({ value, vector }) =>
+          ({ value, vector: matrix(vector) }))
       }
-    })
+    }
+    if (computeVectors) {
+      Object.defineProperty(result, 'vectors', {
+        enumerable: false, // to make sure that the eigenvectors can still be
+        // converted to string.
+        get: () => {
+          throw new Error('eigs(M).vectors replaced with eigs(M).eigenvectors')
+        }
+      })
+    }
     return result
   }
 
-  function computeValuesAndVectors (mat, prec) {
-    if (prec === undefined) {
-      prec = config.epsilon
-    }
-
+  function computeValuesAndVectors (mat, prec, computeVectors) {
     const arr = mat.toArray() // NOTE: arr is guaranteed to be unaliased
     // and so safe to modify in place
     const asize = mat.size()
@@ -114,12 +137,12 @@ export const createEigs = /* #__PURE__ */ factory(name, dependencies, ({ config,
 
       if (isSymmetric(arr, N, prec)) {
         const type = coerceTypes(mat, arr, N) // modifies arr by side effect
-        return doRealSymmetric(arr, N, prec, type)
+        return doRealSymmetric(arr, N, prec, type, computeVectors)
       }
     }
 
     const type = coerceTypes(mat, arr, N) // modifies arr by side effect
-    return doComplexEigs(arr, N, prec, type)
+    return doComplexEigs(arr, N, prec, type, computeVectors)
   }
 
   /** @return {boolean} */

--- a/src/function/matrix/eigs/complexEigs.js
+++ b/src/function/matrix/eigs/complexEigs.js
@@ -10,11 +10,7 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
    *
    * @returns {{ values: number[], vectors: number[][] }}
    */
-  function complexEigs (arr, N, prec, type, findVectors) {
-    if (findVectors === undefined) {
-      findVectors = true
-    }
-
+  function complexEigs (arr, N, prec, type, findVectors = true) {
     // TODO check if any row/col are zero except the diagonal
 
     // make sure corresponding rows and columns have similar magnitude

--- a/src/function/matrix/eigs/complexEigs.js
+++ b/src/function/matrix/eigs/complexEigs.js
@@ -42,13 +42,12 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
     // (So U = C^-1 arr C and the relationship between current arr
     // and original A is unchanged.)
 
-    let eigenvectors
-
     if (findVectors) {
-      eigenvectors = findEigenvectors(arr, N, C, R, values, prec, type)
+      const eigenvectors = findEigenvectors(arr, N, C, R, values, prec, type)
+      return { values, eigenvectors }
     }
 
-    return { values, eigenvectors }
+    return { values }
   }
 
   /**

--- a/src/function/matrix/eigs/complexEigs.js
+++ b/src/function/matrix/eigs/complexEigs.js
@@ -150,7 +150,7 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
     }
 
     // return the diagonal row transformation matrix
-    return diag(Rdiag)
+    return findVectors ? diag(Rdiag) : null
   }
 
   /**

--- a/src/function/matrix/eigs/complexEigs.js
+++ b/src/function/matrix/eigs/complexEigs.js
@@ -90,9 +90,8 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
 
         for (let j = 0; j < N; j++) {
           if (i === j) continue
-          const c = abs(arr[i][j]) // should be real
-          colNorm = addScalar(colNorm, c)
-          rowNorm = addScalar(rowNorm, c)
+          colNorm = addScalar(colNorm, abs(arr[j][i]))
+          rowNorm = addScalar(rowNorm, abs(arr[i][j]))
         }
 
         if (!equal(colNorm, 0) && !equal(rowNorm, 0)) {
@@ -131,13 +130,13 @@ export function createComplexEigs ({ addScalar, subtract, flatten, multiply, mul
               if (i === j) {
                 continue
               }
-              arr[i][j] = multiplyScalar(arr[i][j], f)
-              arr[j][i] = multiplyScalar(arr[j][i], g)
+              arr[i][j] = multiplyScalar(arr[i][j], g)
+              arr[j][i] = multiplyScalar(arr[j][i], f)
             }
 
             // keep track of transformations
             if (findVectors) {
-              Rdiag[i] = multiplyScalar(Rdiag[i], f)
+              Rdiag[i] = multiplyScalar(Rdiag[i], g)
             }
           }
         }

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1291,6 +1291,13 @@ Matrices examples
     const eig = math.eigs(D)
     assert.ok(math.deepEqual(eig.values, [1, 1]))
     assert.deepStrictEqual(eig.eigenvectors, [{ value: 1, vector: [1, 0] }])
+    const eigvv = math.eigs(D, { precision: 1e-6 })
+    assert.ok(math.deepEqual(eigvv.values, [1, 1]))
+    assert.deepStrictEqual(eigvv.eigenvectors, [{ value: 1, vector: [1, 0] }])
+    const eigv = math.eigs(D, { eigenvectors: false })
+    assert.ok(math.deepEqual(eigv.values, [1, 1]))
+    //@ts-expect-error  ...verify that eigenvectors not expected to be there
+    eigv.eigenvectors
   }
 
   // Fourier transform and inverse

--- a/test/unit-tests/function/matrix/eigs.test.js
+++ b/test/unit-tests/function/matrix/eigs.test.js
@@ -94,12 +94,18 @@ describe('eigs', function () {
         [1.0, 1.0, 1.0]]).values,
     [0, 0, 3]
     )
-    approx.deepEqual(eigs(
+    const sym4 =
       [[0.6163396801190624, -3.8571699139231796, 2.852995822026198, 4.1957619745869845],
         [-3.8571699139231796, 0.7047577966772156, 0.9122549659760404, 0.9232933211541949],
         [2.852995822026198, 0.9122549659760404, 1.6598316026960402, -1.2931270747054358],
-        [4.1957619745869845, 0.9232933211541949, -1.2931270747054358, -4.665994662426116]]).values,
-    [-0.9135495807127523, 2.26552473288741, 5.6502090685149735, -8.687249803623432]
+        [4.1957619745869845, 0.9232933211541949, -1.2931270747054358, -4.665994662426116]]
+    const fullValues = eigs(sym4).values
+    approx.deepEqual(fullValues,
+      [-0.9135495807127523, 2.26552473288741, 5.6502090685149735, -8.687249803623432]
+    )
+    assert.deepStrictEqual(
+      fullValues,
+      eigs(sym4, { eigenvectors: false }).values
     )
   })
 
@@ -147,6 +153,8 @@ describe('eigs', function () {
       [4.14, 4.27, 3.05, 2.24, 2.73, -4.47]]
     const ans = eigs(H)
     const E = ans.values
+    const justvalues = eigs(H, { eigenvectors: false })
+    assert.deepStrictEqual(E, justvalues.values)
     testEigenvectors(ans,
       (v, j) => approx.deepEqual(multiply(E[j], v), multiply(H, v))
     )
@@ -251,6 +259,8 @@ describe('eigs', function () {
       [4.24, -4.68, -3.33, 1.67, 2.80, 2.73],
       [4.14, 4.27, 3.05, 2.24, 2.73, -4.47]])
     const ans = eigs(H)
+    const justvalues = eigs(H, { eigenvectors: false })
+    assert.deepStrictEqual(ans.values, justvalues.values)
     const E = ans.values
     const Vcols = ans.eigenvectors.map(obj => obj.vector)
     const V = matrixFromColumns(...Vcols)

--- a/test/unit-tests/function/matrix/eigs.test.js
+++ b/test/unit-tests/function/matrix/eigs.test.js
@@ -240,7 +240,7 @@ describe('eigs', function () {
     const difficult = [[2, 0, 0], [-1, -1, 9], [0, -1, 5]]
     const poor = eigs(difficult, 1e-14)
     assert.strictEqual(poor.values.length, 3)
-    approx.deepEqual(poor.values, [2, 2, 2], 6e-6)
+    approx.deepEqual(poor.values, [2, 2, 2], 7e-6)
     // Note the eigenvectors are junk, so we don't test them. The function
     // eigs thinks there are three of them, for example. Hopefully some
     // future iteration of mathjs will be able to discover there is really

--- a/test/unit-tests/function/matrix/eigs.test.js
+++ b/test/unit-tests/function/matrix/eigs.test.js
@@ -107,10 +107,9 @@ describe('eigs', function () {
     approx.deepEqual(fullValues,
       [-0.9135495807127523, 2.26552473288741, 5.6502090685149735, -8.687249803623432]
     )
-    assert.deepStrictEqual(
-      fullValues,
-      eigs(sym4, { eigenvectors: false }).values
-    )
+    const justEigs = eigs(sym4, { eigenvectors: false })
+    assert.deepStrictEqual(fullValues, justEigs.values)
+    assert.ok(!('eigenvectors' in justEigs))
   })
 
   it('calculates eigenvalues and eigenvectors for 5x5 matrix', function () {
@@ -162,6 +161,7 @@ describe('eigs', function () {
     testEigenvectors(ans,
       (v, j) => approx.deepEqual(multiply(E[j], v), multiply(H, v))
     )
+    assert.ok(!('eigenvectors' in justvalues))
     const Vcols = ans.eigenvectors.map(obj => obj.vector)
     const V = matrixFromColumns(...Vcols)
     const VtHV = multiply(transpose(V), H, V)
@@ -250,6 +250,7 @@ describe('eigs', function () {
     // Make sure the precision argument can go in the options object
     const stillbad = eigs(difficult, { precision: 1e-14, eigenvectors: false })
     assert.deepStrictEqual(stillbad.values, poor.values)
+    assert.ok(!('eigenvectors' in stillbad))
   })
 
   it('diagonalizes matrix with bigNumber', function () {
@@ -268,6 +269,7 @@ describe('eigs', function () {
     const ans = eigs(H)
     const justvalues = eigs(H, { eigenvectors: false })
     assert.deepStrictEqual(ans.values, justvalues.values)
+    assert.ok(!('eigenvectors' in justvalues))
     const E = ans.values
     const Vcols = ans.eigenvectors.map(obj => obj.vector)
     const V = matrixFromColumns(...Vcols)

--- a/test/unit-tests/function/matrix/eigs.test.js
+++ b/test/unit-tests/function/matrix/eigs.test.js
@@ -30,13 +30,17 @@ describe('eigs', function () {
       vector => assert(Array.isArray(vector) && vector[0] instanceof Complex)
     )
 
-    const realSymMatrix = eigs(matrix([[1, 0], [0, 1]]))
+    const id2 = matrix([[1, 0], [0, 1]])
+    const realSymMatrix = eigs(id2)
     assert(realSymMatrix.values instanceof Matrix)
     assert.deepStrictEqual(size(realSymMatrix.values), matrix([2]))
     testEigenvectors(realSymMatrix, vector => {
       assert(vector instanceof Matrix)
       assert.deepStrictEqual(size(vector), matrix([2]))
     })
+    // Check we get exact values in this trivial case with lower precision
+    const rough = eigs(id2, { precision: 1e-6 })
+    assert.deepStrictEqual(realSymMatrix, rough)
 
     const genericMatrix = eigs(matrix([[0, 1], [-1, 0]]))
     assert(genericMatrix.values instanceof Matrix)

--- a/test/unit-tests/function/matrix/eigs.test.js
+++ b/test/unit-tests/function/matrix/eigs.test.js
@@ -243,6 +243,9 @@ describe('eigs', function () {
     // only one.
     const poorm = eigs(matrix(difficult), 1e-14)
     assert.deepStrictEqual(poorm.values.size(), [3])
+    // Make sure the precision argument can go in the options object
+    const stillbad = eigs(difficult, { precision: 1e-14, eigenvectors: false })
+    assert.deepStrictEqual(stillbad.values, poor.values)
   })
 
   it('diagonalizes matrix with bigNumber', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1763,7 +1763,10 @@ declare namespace math {
      */
     eigs(
       x: MathCollection,
-      prec?: number | BigNumber
+      opts?:
+        | number
+        | BigNumber
+        | { precision?: number | BigNumber; eigenvectors?: true }
     ): {
       values: MathCollection
       eigenvectors: {
@@ -1771,7 +1774,10 @@ declare namespace math {
         vector: MathCollection
       }[]
     }
-
+    eigs(
+      x: MathCollection,
+      opts: { eigenvectors: false; precision?: number | BigNumber }
+    ): { values: MathCollection }
     /**
      * Compute the matrix exponential, expm(A) = e^A. The matrix must be
      * square. Not to be confused with exp(a), which performs element-wise


### PR DESCRIPTION
  For large matrices, the eigenvector computation can be noticeably expensive
  and so it's worthwhile to have a way to turn it off if the eigenvectors
  will not be used.
  Resolves https://github.com/josdejong/mathjs/issues/2180.

  Note that this PR is stacked on #3037, so it should only be merged into develop _after_ that one has been.