### PR TITLE
Extend function `round` with support for units

### DIFF
--- a/src/expression/embeddedDocs/function/arithmetic/round.js
+++ b/src/expression/embeddedDocs/function/arithmetic/round.js
@@ -13,7 +13,9 @@ export const roundDocs = {
     'round(-4.2)',
     'round(-4.8)',
     'round(pi, 3)',
-    'round(123.45678, 2)'
+    'round(123.45678, 2)',
+    'round(3.241cm, 2, cm)',
+    'round([3.2, 3.8, -4.7])'
   ],
   seealso: ['ceil', 'floor', 'fix']
 }

--- a/src/expression/embeddedDocs/function/arithmetic/round.js
+++ b/src/expression/embeddedDocs/function/arithmetic/round.js
@@ -3,7 +3,9 @@ export const roundDocs = {
   category: 'Arithmetic',
   syntax: [
     'round(x)',
-    'round(x, n)'
+    'round(x, n)',
+    'round(unit, valuelessUnit)',
+    'round(unit, n, valuelessUnit)',
   ],
   description:
       'round a value towards the nearest integer.If x is complex, both real and imaginary part are rounded towards the nearest integer. When n is specified, the value is rounded to n decimals.',

--- a/src/expression/embeddedDocs/function/arithmetic/round.js
+++ b/src/expression/embeddedDocs/function/arithmetic/round.js
@@ -5,7 +5,7 @@ export const roundDocs = {
     'round(x)',
     'round(x, n)',
     'round(unit, valuelessUnit)',
-    'round(unit, n, valuelessUnit)',
+    'round(unit, n, valuelessUnit)'
   ],
   description:
       'round a value towards the nearest integer.If x is complex, both real and imaginary part are rounded towards the nearest integer. When n is specified, the value is rounded to n decimals.',

--- a/src/function/arithmetic/round.js
+++ b/src/function/arithmetic/round.js
@@ -136,18 +136,6 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
 
     'Array | Matrix, Unit': typed.referToSelf(self => (x, unit) => self(x, 0, unit)),
 
-    'Unit, Array | Matrix, Unit': typed.referToSelf(self => (x, nCollection, unit) => {
-      // deep map collection, skip zeros since round(0) = 0
-      return deepMap(nCollection, (n) => self(x, n, unit), true)
-    }),
-
-    'Unit, number | BigNumber, Array | Matrix': typed.referToSelf(self => (x, n, unitCollection) => {
-      // deep map collection, skip zeros since round(0) = 0
-      return deepMap(unitCollection, (unit) => self(x, n, unit), true)
-    }),
-
-    'Unit, Array | Matrix': typed.referToSelf(self => (x, unitCollection) => self(x, 0, unitCollection)),
-
     'Array | Matrix': typed.referToSelf(self => x => {
       // deep map collection, skip zeros since round(0) = 0
       return deepMap(x, self, true)

--- a/src/function/arithmetic/round.js
+++ b/src/function/arithmetic/round.js
@@ -30,6 +30,7 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
    *
    *    math.round(x)
    *    math.round(x, n)
+   *    math.round(unit, valuelessUnit)
    *    math.round(unit, n, valuelessUnit)
    *
    * Examples:

--- a/test/node-tests/doc.test.js
+++ b/test/node-tests/doc.test.js
@@ -99,7 +99,7 @@ const knownProblems = new Set([
   'mod', 'invmod', 'floor', 'fix', 'expm1', 'exp', 'dotPow', 'dotMultiply',
   'dotDivide', 'divide', 'ceil', 'cbrt', 'add', 'usolveAll', 'usolve', 'slu',
   'rationalize', 'qr', 'lusolve', 'lup', 'lsolveAll', 'lsolve', 'derivative',
-  'symbolicEqual', 'map', 'schur', 'sylvester', 'freqz'
+  'symbolicEqual', 'map', 'schur', 'sylvester', 'freqz', 'round'
 ])
 
 function maybeCheckExpectation (name, expected, expectedFrom, got, gotFrom) {

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -633,6 +633,9 @@ Chaining examples
   expectTypeOf(math.chain([1]).round()).toMatchTypeOf<
     MathJsChain<MathCollection>
   >()
+  expectTypeOf(
+    math.chain(math.unit('5.2cm')).round(math.unit('cm'))
+  ).toMatchTypeOf<MathJsChain<Unit>>()
 
   // cube
   expectTypeOf(math.chain(1).cube()).toMatchTypeOf<MathJsChain<number>>()
@@ -1902,6 +1905,16 @@ Function round examples
   assert.deepStrictEqual(
     math.round(c, math.bignumber(1)),
     math.complex(3.2, -2.7)
+  )
+
+  // unit input
+  assert.deepStrictEqual(
+    math.round(math.unit('5.21 cm'), math.unit('cm')),
+    math.unit('5 cm')
+  )
+  assert.deepStrictEqual(
+    math.round(math.unit('5.21 cm'), 1, math.unit('cm')),
+    math.unit('5.2 cm')
   )
 
   // array input

--- a/test/unit-tests/function/arithmetic/round.test.js
+++ b/test/unit-tests/function/arithmetic/round.test.js
@@ -9,6 +9,7 @@ const fraction = math.fraction
 const matrix = math.matrix
 const sparse = math.sparse
 const round = math.round
+const unit = math.unit
 
 describe('round', function () {
   it('should round a number to te given number of decimals', function () {
@@ -118,10 +119,38 @@ describe('round', function () {
     assert.deepStrictEqual(round(complex(2.157, math.pi), bignumber(2)), complex(2.16, 3.14))
   })
 
-  it('should throw an error if used with a unit', function () {
-    assert.throws(function () { round(math.unit('5cm')) }, TypeError, 'Function round(unit) not supported')
-    assert.throws(function () { round(math.unit('5cm'), 2) }, TypeError, 'Function round(unit) not supported')
-    assert.throws(function () { round(math.unit('5cm'), bignumber(2)) }, TypeError, 'Function round(unit) not supported')
+  it('should round units', function () {
+    assert.deepStrictEqual(round(unit('3.12345 cm'), 3, unit('cm')), unit('3.123 cm'))
+    assert.deepStrictEqual(round(unit('3.12345 cm'), unit('cm')), unit('3 cm'))
+    assert.deepStrictEqual(round(unit('2 inch'), unit('cm')), unit('5 cm'))
+    assert.deepStrictEqual(round(unit('2 inch'), 1, unit('cm')), unit('5.1 cm'))
+
+    // bignumber values
+    assert.deepStrictEqual(round(unit('3.12345 cm'), bignumber(2), unit('cm')), unit('3.12 cm'))
+    assert.deepStrictEqual(round(unit(bignumber('2'), 'inch'), unit('cm')), unit(bignumber('5'), 'cm'))
+    assert.deepStrictEqual(round(unit(bignumber('2'), 'inch'), bignumber(1), unit('cm')), unit(bignumber('5.1'), 'cm'))
+
+    // first argument is a collection
+    assert.deepStrictEqual(round([unit('2 inch'), unit('3 inch')], unit('cm')), [unit('5 cm'), unit('8 cm')])
+    assert.deepStrictEqual(round(matrix([unit('2 inch'), unit('3 inch')]), unit('cm')), matrix([unit('5 cm'), unit('8 cm')]))
+
+    // decimals is a collection
+    assert.deepStrictEqual(round(unit('3.12345 cm'), [0, 1, 2], unit('cm')), [unit('3 cm'), unit('3.1 cm'), unit('3.12 cm')])
+
+    // unit is a collection
+    assert.deepStrictEqual(round(unit('3.12345 cm'), [unit('cm'), unit('mm')]), [unit('3 cm'), unit('31 mm')])
+    assert.deepStrictEqual(round(unit('3.12345 cm'), 1, [unit('cm'), unit('mm')]), [unit('3.1 cm'), unit('31.2 mm')])
+  })
+
+  it('should throw an error if used with a unit without valueless unit', function () {
+    assert.throws(function () { round(unit('5cm')) }, TypeError, 'Function round(unit) not supported')
+    assert.throws(function () { round(unit('5cm'), 2) }, TypeError, 'Function round(unit) not supported')
+    assert.throws(function () { round(unit('5cm'), bignumber(2)) }, TypeError, 'Function round(unit) not supported')
+  })
+
+  it('should throw an error if used with a unit with a second unit that is not valueless', function () {
+    assert.throws(function () { round(unit('2 inch'), 1, unit('10 cm')) }, Error)
+    assert.throws(function () { round(unit('2 inch'), unit('10 cm')) }, Error)
   })
 
   it('should convert to a number when used with a string', function () {

--- a/test/unit-tests/function/arithmetic/round.test.js
+++ b/test/unit-tests/function/arithmetic/round.test.js
@@ -133,13 +133,6 @@ describe('round', function () {
     // first argument is a collection
     assert.deepStrictEqual(round([unit('2 inch'), unit('3 inch')], unit('cm')), [unit('5 cm'), unit('8 cm')])
     assert.deepStrictEqual(round(matrix([unit('2 inch'), unit('3 inch')]), unit('cm')), matrix([unit('5 cm'), unit('8 cm')]))
-
-    // decimals is a collection
-    assert.deepStrictEqual(round(unit('3.12345 cm'), [0, 1, 2], unit('cm')), [unit('3 cm'), unit('3.1 cm'), unit('3.12 cm')])
-
-    // unit is a collection
-    assert.deepStrictEqual(round(unit('3.12345 cm'), [unit('cm'), unit('mm')]), [unit('3 cm'), unit('31 mm')])
-    assert.deepStrictEqual(round(unit('3.12345 cm'), 1, [unit('cm'), unit('mm')]), [unit('3.1 cm'), unit('31.2 mm')])
   })
 
   it('should throw an error if used with a unit without valueless unit', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1103,7 +1103,14 @@ export interface MathJsInstance extends MathJsFactory {
     x: T,
     n?: number | BigNumber
   ): NoLiteralType<T>
-  round<U extends MathCollection>(x: MathNumericType, n: U): U
+  round<U extends MathCollection>(x: MathNumericType | U, n: U): U
+  round(x: Unit, n: number | BigNumber, unit: Unit): Unit
+  round(x: Unit, unit: Unit): Unit
+  round<U extends MathCollection>(x: U, unit: Unit): U
+  round<U extends MathCollection>(x: U, n: number | BigNumber, unit: Unit): U
+  round<U extends MathCollection>(x: Unit, n: U, unit: Unit): U
+  round<U extends MathCollection>(x: Unit, n: number | BigNumber, unit: U): U
+  round<U extends MathCollection>(x: Unit, unit: U): U
 
   // End of group of rounding functions
 
@@ -4738,8 +4745,27 @@ export interface MathJsChain<TValue> {
    */
   round<T extends MathNumericType | MathCollection>(
     this: MathJsChain<T>,
-    n?: number | BigNumber | MathCollection
-  ): MathJsChain<T>
+    n?: number | BigNumber
+  ): NoLiteralType<T>
+  round<U extends MathCollection>(
+    this: MathJsChain<MathNumericType | U>,
+    n: U
+  ): U
+  round(this: MathJsChain<Unit>, n: number | BigNumber, unit: Unit): Unit
+  round(this: MathJsChain<Unit>, unit: Unit): Unit
+  round<U extends MathCollection>(this: MathJsChain<U>, unit: Unit): U
+  round<U extends MathCollection>(
+    this: MathJsChain<U>,
+    n: number | BigNumber,
+    unit: Unit
+  ): U
+  round<U extends MathCollection>(this: MathJsChain<Unit>, n: U, unit: Unit): U
+  round<U extends MathCollection>(
+    this: MathJsChain<Unit>,
+    n: number | BigNumber,
+    unit: U
+  ): U
+  round<U extends MathCollection>(this: MathJsChain<Unit>, unit: U): U
 
   // End of rounding group
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1103,7 +1103,7 @@ export interface MathJsInstance extends MathJsFactory {
     x: T,
     n?: number | BigNumber
   ): NoLiteralType<T>
-  round<U extends MathCollection>(x: MathNumericType | U, n: U): U
+  round<U extends MathCollection>(x: MathNumericType, n: U): U
   round(x: Unit, n: number | BigNumber, unit: Unit): Unit
   round(x: Unit, unit: Unit): Unit
   round<U extends MathCollection>(x: U, unit: Unit): U
@@ -4745,27 +4745,41 @@ export interface MathJsChain<TValue> {
    */
   round<T extends MathNumericType | MathCollection>(
     this: MathJsChain<T>,
-    n?: number | BigNumber
-  ): NoLiteralType<T>
+    n?: number | BigNumber | MathCollection
+  ): MathJsChain<T>
   round<U extends MathCollection>(
     this: MathJsChain<MathNumericType | U>,
     n: U
-  ): U
-  round(this: MathJsChain<Unit>, n: number | BigNumber, unit: Unit): Unit
-  round(this: MathJsChain<Unit>, unit: Unit): Unit
-  round<U extends MathCollection>(this: MathJsChain<U>, unit: Unit): U
+  ): MathJsChain<U>
+  round(
+    this: MathJsChain<Unit>,
+    n: number | BigNumber,
+    unit: Unit
+  ): MathJsChain<Unit>
+  round(this: MathJsChain<Unit>, unit: Unit): MathJsChain<Unit>
+  round<U extends MathCollection>(
+    this: MathJsChain<U>,
+    unit: Unit
+  ): MathJsChain<U>
   round<U extends MathCollection>(
     this: MathJsChain<U>,
     n: number | BigNumber,
     unit: Unit
-  ): U
-  round<U extends MathCollection>(this: MathJsChain<Unit>, n: U, unit: Unit): U
+  ): MathJsChain<U>
+  round<U extends MathCollection>(
+    this: MathJsChain<Unit>,
+    n: U,
+    unit: Unit
+  ): MathJsChain<U>
   round<U extends MathCollection>(
     this: MathJsChain<Unit>,
     n: number | BigNumber,
     unit: U
-  ): U
-  round<U extends MathCollection>(this: MathJsChain<Unit>, unit: U): U
+  ): MathJsChain<U>
+  round<U extends MathCollection>(
+    this: MathJsChain<Unit>,
+    unit: U
+  ): MathJsChain<U>
 
   // End of rounding group
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1104,13 +1104,10 @@ export interface MathJsInstance extends MathJsFactory {
     n?: number | BigNumber
   ): NoLiteralType<T>
   round<U extends MathCollection>(x: MathNumericType, n: U): U
-  round(x: Unit, n: number | BigNumber, unit: Unit): Unit
-  round(x: Unit, unit: Unit): Unit
   round<U extends MathCollection>(x: U, unit: Unit): U
+  round(x: Unit, unit: Unit): Unit
+  round(x: Unit, n: number | BigNumber, unit: Unit): Unit
   round<U extends MathCollection>(x: U, n: number | BigNumber, unit: Unit): U
-  round<U extends MathCollection>(x: Unit, n: U, unit: Unit): U
-  round<U extends MathCollection>(x: Unit, n: number | BigNumber, unit: U): U
-  round<U extends MathCollection>(x: Unit, unit: U): U
 
   // End of group of rounding functions
 
@@ -4751,34 +4748,20 @@ export interface MathJsChain<TValue> {
     this: MathJsChain<MathNumericType | U>,
     n: U
   ): MathJsChain<U>
-  round(
-    this: MathJsChain<Unit>,
-    n: number | BigNumber,
-    unit: Unit
-  ): MathJsChain<Unit>
   round(this: MathJsChain<Unit>, unit: Unit): MathJsChain<Unit>
   round<U extends MathCollection>(
     this: MathJsChain<U>,
     unit: Unit
   ): MathJsChain<U>
+  round(
+    this: MathJsChain<Unit>,
+    n: number | BigNumber,
+    unit: Unit
+  ): MathJsChain<Unit>
   round<U extends MathCollection>(
     this: MathJsChain<U>,
     n: number | BigNumber,
     unit: Unit
-  ): MathJsChain<U>
-  round<U extends MathCollection>(
-    this: MathJsChain<Unit>,
-    n: U,
-    unit: Unit
-  ): MathJsChain<U>
-  round<U extends MathCollection>(
-    this: MathJsChain<Unit>,
-    n: number | BigNumber,
-    unit: U
-  ): MathJsChain<U>
-  round<U extends MathCollection>(
-    this: MathJsChain<Unit>,
-    unit: U
   ): MathJsChain<U>
 
   // End of rounding group


### PR DESCRIPTION
Implements #2761

With three arguments, the number of different combinations of one or multiple of the arguments being an array explodes quickly. I'm not yet sure which signatures _actually_ make sense. Feedback would be welcome.