### PR TITLE
Fixed MathArray TS type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ export type NoLiteralType<T> = T extends number
 // TODO: introduce generics for MathCollection, MathMatrix, and MathArray
 export type MathNumericType = number | BigNumber | Fraction | Complex
 export type MathScalarType = MathNumericType | Unit
-export type MathArray = MathNumericType[] | MathNumericType[][] // TODO: MathArray can also contain Unit
+export type MathArray = MathNumericType[] | MathArray[] // TODO: MathArray can also contain Unit
 export type MathCollection = MathArray | Matrix
 export type MathType = MathScalarType | MathCollection
 export type MathExpression = string | string[] | MathCollection


### PR DESCRIPTION
Fixed type of MathArray to prevent typescript erroring for any n-dimensional array (previously only worked for n<=2). Solution uses a conditionally recursive type.