### PR TITLE
Unitless quantity conversion bug

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -780,7 +780,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
   Unit.prototype.abs = function () {
     const ret = this.clone()
     if (ret.value !== null) {
-      if (ret._isDerived() || ret.units[0].unit.offset === 0) {
+      if (ret._isDerived() || ret.units.length === 0 || ret.units[0].unit.offset === 0) {
         ret.value = abs(ret.value)
       } else {
         // To give the correct, but unexpected, results for units with an offset.

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -828,7 +828,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     }
 
     if (this.value === null || this._isDerived() ||
-        this.units.length === 0 ||
+        this.units.length === 0 || other.units.length === 0 ||
         this.units[0].unit.offset === other.units[0].unit.offset) {
       other.value = clone(value)
     } else {

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -828,6 +828,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     }
 
     if (this.value === null || this._isDerived() ||
+        this.units.length === 0 ||
         this.units[0].unit.offset === other.units[0].unit.offset) {
       other.value = clone(value)
     } else {

--- a/test/unit-tests/function/arithmetic/abs.test.js
+++ b/test/unit-tests/function/arithmetic/abs.test.js
@@ -84,6 +84,9 @@ describe('abs', function () {
 
     u = abs(unit(complex(-4, 3), 'in'))
     assert.strictEqual(u.toString(), '5 in')
+
+    u = abs(unit(-10)) // dimensionless unit
+    assert.strictEqual(u.toString(), '10')
   })
 
   it('should throw an error in case of invalid number of arguments', function () {

--- a/test/unit-tests/type/unit/Unit.test.js
+++ b/test/unit-tests/type/unit/Unit.test.js
@@ -393,6 +393,7 @@ describe('Unit', function () {
     it('should convert a unitless quantity', function () {
       const u = Unit.parse('5', { allowNoUnits: true })
       assert.strictEqual(u.toNumeric(), 5)
+      assert.strictEqual(u.toNumeric('mm/m'), 5000)
     })
 
     it('should convert a binary prefixes (1)', function () {


### PR DESCRIPTION
This is a small bug fix for this problem I discovered:

```javascript
math.unit(1).to('m/m')  // TypeError: undefined is not an object (evaluating 'this.units[0].unit') — Unit.js:831
```

Thanks for considering!
Carl