### PR TITLE
fix #3162: add license information about CSParse

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ Thanks Github Actions and BrowserStack for the generous free hosting of this ope
 
 ## License
 
+mathjs is published under the Apache 2.0 license:
+
+```
 Copyright (C) 2013-2024 Jos de Jong <wjosdejong@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -208,3 +211,28 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
+
+mathjs contains a JavaScript port of the [CSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source) library, published under the LGPL-2.1+ license:
+
+```
+CSparse: a Concise Sparse matrix package.
+Copyright (c) 2006, Timothy A. Davis.
+http://www.suitesparse.com
+
+--------------------------------------------------------------------------------
+
+CSparse is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+CSparse is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this Module; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+```

--- a/src/function/algebra/sparse/README.md
+++ b/src/function/algebra/sparse/README.md
@@ -1,0 +1,12 @@
+# CSparse
+
+This folder contains a JavaScript port of the `CSparse` section of the open source `SuiteSparse` library by Timothy A. Davis, see:
+
+https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
+
+```
+CSparse: a Concise Sparse matrix package.
+Copyright (c) 2006, Timothy A. Davis.
+http://www.suitesparse.com
+```

--- a/src/function/algebra/sparse/csAmd.js
+++ b/src/function/algebra/sparse/csAmd.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { factory } from '../../../utils/factory.js'
 import { csFkeep } from './csFkeep.js'
 import { csFlip } from './csFlip.js'
@@ -16,8 +19,6 @@ export const createCsAmd = /* #__PURE__ */ factory(name, dependencies, ({ add, m
    * heuristic for finding a permutation P so that P*A*P' has fewer nonzeros in its factorization
    * than A. It is a gready method that selects the sparsest pivot row and column during the course
    * of a right looking sparse Cholesky factorization.
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    *
    * @param {Number} order    0: Natural, 1: Cholesky, 2: LU, 3: QR
    * @param {Matrix} m        Sparse Matrix

--- a/src/function/algebra/sparse/csChol.js
+++ b/src/function/algebra/sparse/csChol.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { factory } from '../../../utils/factory.js'
 import { csEreach } from './csEreach.js'
 import { createCsSymperm } from './csSymperm.js'
@@ -40,8 +43,6 @@ export const createCsChol = /* #__PURE__ */ factory(name, dependencies, (
    * @param {Object}  s               The symbolic analysis from cs_schol()
    *
    * @return {Number}                 The numeric Cholesky factorization of A or null
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    */
   return function csChol (m, s) {
     // validate input

--- a/src/function/algebra/sparse/csCounts.js
+++ b/src/function/algebra/sparse/csCounts.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { factory } from '../../../utils/factory.js'
 import { csLeaf } from './csLeaf.js'
 
@@ -16,8 +19,6 @@ export const createCsCounts = /* #__PURE__ */ factory(name, dependencies, ({ tra
    * @param {Matrix} ata         Count the columns of A'A instead
    *
    * @return                     An array of size n of the column counts or null on error
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    */
   return function (a, parent, post, ata) {
     // check inputs

--- a/src/function/algebra/sparse/csCumsum.js
+++ b/src/function/algebra/sparse/csCumsum.js
@@ -1,11 +1,13 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * It sets the p[i] equal to the sum of c[0] through c[i-1].
  *
  * @param {Array}   ptr             The Sparse Matrix ptr array
  * @param {Array}   c               The Sparse Matrix ptr array
  * @param {Number}  n               The number of columns
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csCumsum (ptr, c, n) {
   // variables

--- a/src/function/algebra/sparse/csDfs.js
+++ b/src/function/algebra/sparse/csDfs.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csMarked } from './csMarked.js'
 import { csMark } from './csMark.js'
 import { csUnflip } from './csUnflip.js'
@@ -15,8 +18,6 @@ import { csUnflip } from './csUnflip.js'
  * @param {Array}   pinv            The inverse row permutation vector, must be null for L * x = b
  *
  * @return {Number}                 New value of top
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csDfs (j, g, top, xi, pinv) {
   // g arrays

--- a/src/function/algebra/sparse/csEreach.js
+++ b/src/function/algebra/sparse/csEreach.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csMark } from './csMark.js'
 import { csMarked } from './csMarked.js'
 
@@ -11,8 +14,6 @@ import { csMarked } from './csMarked.js'
  *                                  The first n entries is the nonzero pattern, the last n entries is the stack
  *
  * @return {Number}                 The index for the nonzero pattern
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csEreach (a, k, parent, w) {
   // a arrays

--- a/src/function/algebra/sparse/csEtree.js
+++ b/src/function/algebra/sparse/csEtree.js
@@ -1,11 +1,13 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * Computes the elimination tree of Matrix A (using triu(A)) or the
  * elimination tree of A'A without forming A'A.
  *
  * @param {Matrix}  a               The A Matrix
  * @param {boolean} ata             A value of true the function computes the etree of A'A
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csEtree (a, ata) {
   // check inputs

--- a/src/function/algebra/sparse/csFkeep.js
+++ b/src/function/algebra/sparse/csFkeep.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * Keeps entries in the matrix when the callback function returns true, removes the entry otherwise
  *
@@ -10,8 +14,6 @@
  * @param {any}      other          The state
  *
  * @return                          The number of nonzero elements in the matrix
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csFkeep (a, callback, other) {
   // a arrays

--- a/src/function/algebra/sparse/csFlip.js
+++ b/src/function/algebra/sparse/csFlip.js
@@ -1,9 +1,11 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * This function "flips" its input about the integer -1.
  *
  * @param {Number}  i               The value to flip
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csFlip (i) {
   // flip the value

--- a/src/function/algebra/sparse/csIpvec.js
+++ b/src/function/algebra/sparse/csIpvec.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * Permutes a vector; x = P'b. In MATLAB notation, x(p)=b.
  *

--- a/src/function/algebra/sparse/csLeaf.js
+++ b/src/function/algebra/sparse/csLeaf.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * This function determines if j is a leaf of the ith row subtree.
  * Consider A(i,j), node j in ith row subtree and return lca(jprev,j)
@@ -11,8 +15,6 @@
  * @param {Number}  ancestor        The index offset within the workspace for the ancestor array
  *
  * @return {Object}
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csLeaf (i, j, w, first, maxfirst, prevleaf, ancestor) {
   let s, sparent

--- a/src/function/algebra/sparse/csLu.js
+++ b/src/function/algebra/sparse/csLu.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 import { factory } from '../../../utils/factory.js'
 import { createCsSpsolve } from './csSpsolve.js'
 
@@ -27,8 +31,6 @@ export const createCsLu = /* #__PURE__ */ factory(name, dependencies, ({ abs, di
    * @param {Number}  tol             Partial pivoting threshold (1 for partial pivoting)
    *
    * @return {Number}                 The numeric LU factorization of A or null
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    */
   return function csLu (m, s, tol) {
     // validate input

--- a/src/function/algebra/sparse/csMark.js
+++ b/src/function/algebra/sparse/csMark.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 import { csFlip } from './csFlip.js'
 
 /**
@@ -5,8 +9,6 @@ import { csFlip } from './csFlip.js'
  *
  * @param {Array}   w               The array
  * @param {Number}  j               The array index
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csMark (w, j) {
   // mark w[j]

--- a/src/function/algebra/sparse/csMarked.js
+++ b/src/function/algebra/sparse/csMarked.js
@@ -1,10 +1,12 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * Checks if the node at w[j] is marked
  *
  * @param {Array}   w               The array
  * @param {Number}  j               The array index
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csMarked (w, j) {
   // check node is marked

--- a/src/function/algebra/sparse/csPermute.js
+++ b/src/function/algebra/sparse/csPermute.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * Permutes a sparse matrix C = P * A * Q
  *
@@ -7,8 +11,6 @@
  * @param {boolean} values          Create a pattern matrix (false), values and pattern otherwise
  *
  * @return {Matrix}                 C = P * A * Q, null on error
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csPermute (a, pinv, q, values) {
   // a arrays

--- a/src/function/algebra/sparse/csPost.js
+++ b/src/function/algebra/sparse/csPost.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csTdfs } from './csTdfs.js'
 
 /**
@@ -5,8 +8,6 @@ import { csTdfs } from './csTdfs.js'
  *
  * @param {Array}   parent          The tree or forest
  * @param {Number}  n               Number of columns
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csPost (parent, n) {
   // check inputs

--- a/src/function/algebra/sparse/csReach.js
+++ b/src/function/algebra/sparse/csReach.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 import { csMarked } from './csMarked.js'
 import { csMark } from './csMark.js'
 import { csDfs } from './csDfs.js'
@@ -15,8 +19,6 @@ import { csDfs } from './csDfs.js'
  * @param {Array}   pinv            The inverse row permutation vector
  *
  * @return {Number}                 The index for the nonzero pattern
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csReach (g, b, k, xi, pinv) {
   // g arrays

--- a/src/function/algebra/sparse/csSpsolve.js
+++ b/src/function/algebra/sparse/csSpsolve.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csReach } from './csReach.js'
 import { factory } from '../../../utils/factory.js'
 
@@ -25,8 +28,6 @@ export const createCsSpsolve = /* #__PURE__ */ factory(name, dependencies, ({ di
    * @param {boolean} lo              The lower (true) upper triangular (false) flag
    *
    * @return {Number}                 The index for the nonzero pattern
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    */
   return function csSpsolve (g, b, k, xi, x, pinv, lo) {
     // g arrays

--- a/src/function/algebra/sparse/csSqr.js
+++ b/src/function/algebra/sparse/csSqr.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csPermute } from './csPermute.js'
 import { csPost } from './csPost.js'
 import { csEtree } from './csEtree.js'
@@ -25,8 +28,6 @@ export const createCsSqr = /* #__PURE__ */ factory(name, dependencies, ({ add, m
    *                                  symbolic ordering and analysis for LU decomposition (false)
    *
    * @return {Object}                 The Symbolic ordering and analysis for matrix A
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    */
   return function csSqr (order, a, qr) {
     // a arrays

--- a/src/function/algebra/sparse/csSymperm.js
+++ b/src/function/algebra/sparse/csSymperm.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csCumsum } from './csCumsum.js'
 import { factory } from '../../../utils/factory.js'
 
@@ -16,8 +19,6 @@ export const createCsSymperm = /* #__PURE__ */ factory(name, dependencies, ({ co
    * @param {boolean} values          Process matrix values (true)
    *
    * @return {Matrix}                 The C matrix, C = P * A * P'
-   *
-   * Reference: http://faculty.cse.tamu.edu/davis/publications.html
    */
   return function csSymperm (a, pinv, values) {
     // A matrix arrays

--- a/src/function/algebra/sparse/csTdfs.js
+++ b/src/function/algebra/sparse/csTdfs.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
+
 /**
  * Depth-first search and postorder of a tree rooted at node j
  *
@@ -8,8 +12,6 @@
  * @param {Number}  next            The index offset within the workspace for the next array
  * @param {Array}   post            The post ordering array
  * @param {Number}  stack           The index offset within the workspace for the stack array
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csTdfs (j, k, w, head, next, post, stack) {
   // variables

--- a/src/function/algebra/sparse/csUnflip.js
+++ b/src/function/algebra/sparse/csUnflip.js
@@ -1,11 +1,12 @@
+// Copyright (c) 2006-2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: LGPL-2.1+
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/CSparse/Source
 import { csFlip } from './csFlip.js'
 
 /**
  * Flips the value if it is negative of returns the same value otherwise.
  *
  * @param {Number}  i               The value to flip
- *
- * Reference: http://faculty.cse.tamu.edu/davis/publications.html
  */
 export function csUnflip (i) {
   // flip the value if it is negative


### PR DESCRIPTION
See #3162

This PR:

- Adds license information about CSparse in the main README.md
- Adds a README.md file with license information in the `src/function/algebra/sparse` folder
- Replaces the reference links to http://faculty.cse.tamu.edu/davis/publications.html in each of the files under `src/function/algebra/sparse` with license information on top, linking to the github project.