### PR TITLE
Import Decimal from decimal.js rather than decimal.mjs

### DIFF
--- a/src/type/bignumber/BigNumber.js
+++ b/src/type/bignumber/BigNumber.js
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from 'decimal.js/decimal.js'
 import { factory } from '../../utils/factory.js'
 
 const name = 'BigNumber'


### PR DESCRIPTION
The `decimal.js` package provides the decimal.js as well as decimal.mjs files. See: https://github.com/MikeMcl/decimal.js

In certain webpack configurations, the decimal.mjs file is loaded, causing the error:
```
Uncaught TypeError: decimal_js__WEBPACK_IMPORTED_MODULE_0__.default.clone is not a function
    createBigNumberClass BigNumber.js:12
    assertAndCreate factory.js:35
```

When we are more specific with this import, this error is resolved.