### PR TITLE
Fix misleading documentation for expression tree traverse

### DIFF
--- a/docs/expressions/expression_trees.md
+++ b/docs/expressions/expression_trees.md
@@ -213,7 +213,7 @@ All nodes have the following methods:
     this node and each of its child nodes. Similar to `Array.forEach`, except
     recursive.
     The callback function is a mapping function accepting a node, and returning
-    a replacement for the node or the original node. Function `callback` is
+    nothing. Function `callback` is
     called as `callback(node: Node, path: string, parent: Node)` for every node
     in the tree. Parameter `path` is a string containing a relative JSON Path.
     Example:


### PR DESCRIPTION
Callback function for MathNode.traverse() returns void. Documentation says callback must return a replacement for the existing node (possibly copied from transform() above).