### PR TITLE
Fix NaN for non-number types

### DIFF
--- a/src/function/utils/isNaN.js
+++ b/src/function/utils/isNaN.js
@@ -54,8 +54,6 @@ export const createIsNaN = /* #__PURE__ */ factory(name, dependencies, ({ typed 
       return Number.isNaN(x.value)
     },
 
-    'Array | Matrix': function (x) {
-      return deepMap(x, Number.isNaN)
-    }
+    'Array | Matrix': typed.referToSelf(self => x => deepMap(x, self))
   })
 })

--- a/test/unit-tests/function/utils/isNaN.test.js
+++ b/test/unit-tests/function/utils/isNaN.test.js
@@ -59,11 +59,11 @@ describe('isNegative', function () {
     assert.strictEqual(isNaN(''), false)
   })
 
-  it('should test isNegative element wise on an Array', function () {
+  it('should test isNaN element wise on an Array', function () {
     assert.deepStrictEqual(isNaN([0, 5, -2, NaN]), [false, false, false, true])
   })
 
-  it('should test isNegative element wise on a Matrix', function () {
+  it('should test isNaN element wise on a Matrix', function () {
     assert.deepStrictEqual(isNaN(math.matrix([0, 5, -2, NaN])), math.matrix([false, false, false, true]))
   })
 

--- a/test/unit-tests/function/utils/isNaN.test.js
+++ b/test/unit-tests/function/utils/isNaN.test.js
@@ -67,6 +67,10 @@ describe('isNegative', function () {
     assert.deepStrictEqual(isNaN(math.matrix([0, 5, -2, NaN])), math.matrix([false, false, false, true]))
   })
 
+  it('should test isNaN element wise on a Matrix of units', function () {
+    assert.deepStrictEqual(isNaN(math.matrix([new Unit(3, 'ft'), new Unit(NaN, 'ft')])), math.matrix([false, true]))
+  })
+
   it('should throw an error in case of unsupported data types', function () {
     assert.throws(function () { isNaN(new Date()) }, /TypeError: Unexpected type of argument/)
     assert.throws(function () { isNaN({}) }, /TypeError: Unexpected type of argument/)


### PR DESCRIPTION
Fixes #3192 

This is my first PR on an open project, give as much feedback as you like.

While doing this I realized that this didn't only affect units, but also Complex, BigNumber, etc -> anything that wasn't a straight up number was getting sent directly to the Number.isNaN function, which automatically sets `false` for non-number types.

Also added a test case for this.