### PR TITLE
Feat/do not override units

### DIFF
--- a/src/core/function/import.js
+++ b/src/core/function/import.js
@@ -162,7 +162,9 @@ export function importFactory (typed, load, math, importedFactories) {
       return
     }
 
-    if (math[name] === undefined || options.override) {
+    const isDefined = math[name] !== undefined
+    const isValuelessUnit = math.Unit?.isValuelessUnit(name)
+    if ((!isDefined && !isValuelessUnit) || options.override) {
       math[name] = value
       delete importedFactories[name]
 

--- a/test/unit-tests/core/import.test.js
+++ b/test/unit-tests/core/import.test.js
@@ -51,6 +51,12 @@ describe('import', function () {
     assert.strictEqual(math.myvalue, 42)
   })
 
+  it('should not override existing units', function () {
+    assert.throws(function () { math.import({ meter: 10 }) },
+      /Error: Cannot import "meter": already exists/)
+    assert.deepStrictEqual(math.evaluate('1 meter'), math.unit('1 meter'))
+  })
+
   it('should allow importing the same function twice if it is strictly equal', function () {
     function foo () { return 'bar' }
 
@@ -90,6 +96,11 @@ describe('import', function () {
   it('should override existing functions if forced', function () {
     math.import({ myvalue: 10 }, { override: true })
     assert.strictEqual(math.myvalue, 10)
+  })
+
+  it('should override existing units if forced', function () {
+    math.import({ meter: 10 }, { override: true })
+    assert.strictEqual(math.evaluate('meter'), 10)
   })
 
   it('should parse the user defined members', function () {
@@ -149,10 +160,10 @@ describe('import', function () {
   it('should ignore properties on Object', function () {
     Object.prototype.foo = 'bar' // eslint-disable-line no-extend-native
 
-    math.import({ bar: 456 })
+    math.import({ baz: 456 })
 
     assert(!hasOwnProperty(math, 'foo'))
-    assert(hasOwnProperty(math, 'bar'))
+    assert(hasOwnProperty(math, 'baz'))
 
     delete Object.prototype.foo
   })


### PR DESCRIPTION
Fixes #3222: prevent `math.import(...)` from overriding units unless you specify `{ override: true }`.

Note that this is a breaking change: usages of `math.import` that worked before like `math.import({ bar: 42 })` can now throw an exception.
