### PR TITLE
fix: updates parser types

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1119,10 +1119,15 @@ Expressions examples
     const _x = parser.get('x')
     const f = parser.get('f')
     const _y = parser.getAll()
+    const _z = parser.getAllAsMap()
     const _g = f(3, 3)
 
     parser.set('h', 500)
+    assert.strictEqual(parser.get('h'), 500)
+    assert.strictEqual(parser.evaluate('h'), 500)
     parser.set('hello', (name: string) => `hello, ${name}!`)
+    parser.remove('h')
+    assert.strictEqual(parser.get('h'), undefined)
   }
 
   // clear defined functions and variables

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4292,14 +4292,44 @@ export interface MathNode {
 }
 
 export interface Parser {
+  /**
+   * Evaluate an expression. Returns the result of the expression.
+   * @param expr The expression to evaluate
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   evaluate(expr: string | string[]): any
+  /**
+   * Retrieve a variable or function from the parser’s scope.
+   * @param name The name of the variable or function to be retrieved
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get(variable: string): any
+  get(name: string): any
+  /**
+   * Retrieve an object with all defined variables in the parser’s scope.
+   * @returns An object with all defined variables
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getAll(): { [key: string]: any }
+  /**
+   * Retrieve a map with all defined variables in the parser’s scope.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  set: (variable: string, value: any) => void
+  getAllAsMap(): Map<string, any>
+  /**
+   * Set a variable or function in the parser’s scope.
+   * @param name The name of the variable or function to be set
+   * @param value The value of the variable or function to be set
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  set: (name: string, value: any) => void
+  /**
+   * Remove a variable or function from the parser’s scope.
+   * @param name The name of the variable or function to be removed
+   */
+  remove: (name: string) => void
+  /**
+   * Completely clear the parser’s scope.
+   */
   clear: () => void
 }
 


### PR DESCRIPTION
# Description 
Updates the parser typing based on documentation: https://mathjs.org/docs/expressions/parsing.html#parser

## Testing
- Added tests to testTypes.ts

## Fixes
https://github.com/josdejong/mathjs/issues/2348

## Additional Notes
First-time contribution. Please let me know if I am missing anything! Thanks!