### PR TITLE
fix: types static methods and members for Unit class

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -466,7 +466,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    * Return the type of the value of this unit
    *
    * @memberof Unit
-   * @ return {string} type of the value of the unit
+   * @return {string} type of the value of the unit
    */
   Unit.prototype.valueType = function () {
     return typeOf(this.value)
@@ -476,6 +476,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    * Return whether the unit is derived (such as m/s, or cm^2, but not N)
    * @memberof Unit
    * @return {boolean} True if the unit is derived
+   * @private
    */
   Unit.prototype._isDerived = function () {
     if (this.units.length === 0) {
@@ -585,7 +586,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    * check if this unit has given base unit
    * If this unit is a derived unit, this will ALWAYS return false, since by definition base units are not derived.
    * @memberof Unit
-   * @param {BASE_UNITS | string | undefined} base
+   * @param {BASE_UNIT | string | undefined} base
    */
   Unit.prototype.hasBase = function (base) {
     if (typeof (base) === 'string') {
@@ -2975,6 +2976,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
 
   /**
    * Set a unit system for formatting derived units.
+   * @memberof Unit
    * @param {string} [name] The name of the unit system.
    */
   Unit.setUnitSystem = function (name) {
@@ -2987,6 +2989,7 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
 
   /**
    * Return the current unit system.
+   * @memberof Unit
    * @return {string} The current unit system.
    */
   Unit.getUnitSystem = function () {
@@ -3080,7 +3083,9 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
   /**
    * Checks if a character is a valid latin letter (upper or lower case).
    * Note that this function can be overridden, for example to allow support of other alphabets.
+   * @memberof Unit
    * @param {string} c Tested character
+   * @return {boolean} true if the character is a latin letter
    */
   Unit.isValidAlpha = function isValidAlpha (c) {
     return /^[a-zA-Z]$/.test(c)
@@ -3100,20 +3105,24 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
   /**
    * Wrapper around createUnitSingle.
    * Example:
-   *  createUnit({
-   *    foo: { },
-   *    bar: {
-   *      definition: 'kg/foo',
-   *      aliases: ['ba', 'barr', 'bars'],
-   *      offset: 200
-   *    },
-   *    baz: '4 bar'
-   *  },
-   *  {
-   *    override: true
-   *  })
+   *  createUnit( {
+   *     foo: {
+   *       prefixes: 'long',
+   *       baseName: 'essence-of-foo'
+   *     },
+   *     bar: '40 foo',
+   *     baz: {
+   *       definition: '1 bar/hour',
+   *       prefixes: 'long'
+   *     }
+   *   },
+   *   {
+   *     override: true
+   *   })
+   * @memberof Unit
    * @param {object} obj      Object map. Each key becomes a unit which is defined by its value.
    * @param {object} options
+   * @return {Unit} the last created unit
    */
   Unit.createUnit = function (obj, options) {
     if (typeof (obj) !== 'object') {
@@ -3148,13 +3157,13 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    * Create a user-defined unit and register it with the Unit type.
    * Example:
    *  createUnitSingle('knot', '0.514444444 m/s')
-   *  createUnitSingle('acre', new Unit(43560, 'ft^2'))
    *
+   * @memberof Unit
    * @param {string} name      The name of the new unit. Must be unique. Example: 'knot'
-   * @param {string, Unit, Object} definition      Definition of the unit in terms
+   * @param {string | Unit | object} definition      Definition of the unit in terms
    * of existing units. For example, '0.514444444 m / s'. Can be a Unit, a string,
    * or an Object. If an Object, may have the following properties:
-   *   - definition {string|Unit} The definition of this unit.
+   *   - definition {string | Unit} The definition of this unit.
    *   - prefixes {string} "none", "short", "long", "binary_short", or "binary_long".
    *     The default is "none".
    *   - aliases {Array} Array of strings. Example: ['knots', 'kt', 'kts']

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1627,17 +1627,40 @@ Units examples
   const baseUnits = Unit.BASE_UNITS
   assert.ok(Object.keys(baseUnits).length > 0)
 
+  const units = Unit.UNITS
+  assert.ok(Object.keys(units).length > 0)
+
+  Unit.createUnit(
+    {
+      foo: {
+        prefixes: 'long',
+        baseName: 'essence-of-foo'
+      },
+      bar: '40 foo',
+      baz: {
+        definition: '1 bar/hour',
+        prefixes: 'long'
+      }
+    },
+    {
+      override: true
+    }
+  )
+
+  Unit.createUnitSingle('knot', '0.514444444 m/s')
+
   const unitSystems = Unit.UNIT_SYSTEMS
   assert.ok(Object.keys(unitSystems).length > 0)
 
-  const units = Unit.UNITS
-  assert.ok(Object.keys(units).length > 0)
+  Unit.setUnitSystem('si')
+  assert.strictEqual(Unit.getUnitSystem(), 'si')
 
   expectTypeOf(Unit.isValuelessUnit('cm')).toMatchTypeOf<boolean>()
   expectTypeOf(Unit.parse('5cm')).toMatchTypeOf<Unit>()
   expectTypeOf(
     Unit.fromJSON({ value: 5.2, unit: 'inch' })
   ).toMatchTypeOf<Unit>()
+  expectTypeOf(Unit.isValidAlpha('cm')).toMatchTypeOf<boolean>()
 }
 
 /**

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -43,6 +43,7 @@ import {
   SymbolNode,
   MathNodeCommon,
   Unit,
+  UnitPrefix,
   Node,
   isSymbolNode,
   MathScalarType
@@ -307,8 +308,6 @@ Chaining examples
       })
     )
   ).toMatchTypeOf<MathJsChain<Unit>>()
-
-  expectTypeOf(new Unit(15, 'cm')).toMatchTypeOf<Unit>()
 
   // fraction
   expectTypeOf(math.chain(math.fraction('123'))).toMatchTypeOf<
@@ -1615,11 +1614,15 @@ Units examples
  * Unit static methods and members
  */
 {
+  expectTypeOf(new Unit(15, 'cm')).toMatchTypeOf<Unit>()
+
   const prefixes = Unit.PREFIXES
   assert.ok(Object.keys(prefixes).length > 0)
+  expectTypeOf(Unit.PREFIXES).toMatchTypeOf<Record<string, UnitPrefix>>()
 
   const baseDimensions = Unit.BASE_DIMENSIONS
   assert.ok(baseDimensions.length > 0)
+  expectTypeOf(Unit.BASE_DIMENSIONS).toMatchTypeOf<string[]>()
 
   const baseUnits = Unit.BASE_UNITS
   assert.ok(Object.keys(baseUnits).length > 0)
@@ -1629,6 +1632,7 @@ Units examples
 
   const units = Unit.UNITS
   assert.ok(Object.keys(units).length > 0)
+
   expectTypeOf(Unit.isValuelessUnit('cm')).toMatchTypeOf<boolean>()
   expectTypeOf(Unit.parse('5cm')).toMatchTypeOf<Unit>()
   expectTypeOf(

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1612,6 +1612,31 @@ Units examples
 }
 
 /**
+ * Unit static methods and members
+ */
+{
+  const prefixes = Unit.PREFIXES
+  assert.ok(Object.keys(prefixes).length > 0)
+
+  const baseDimensions = Unit.BASE_DIMENSIONS
+  assert.ok(baseDimensions.length > 0)
+
+  const baseUnits = Unit.BASE_UNITS
+  assert.ok(Object.keys(baseUnits).length > 0)
+
+  const unitSystems = Unit.UNIT_SYSTEMS
+  assert.ok(Object.keys(unitSystems).length > 0)
+
+  const units = Unit.UNITS
+  assert.ok(Object.keys(units).length > 0)
+  expectTypeOf(Unit.isValuelessUnit('cm')).toMatchTypeOf<boolean>()
+  expectTypeOf(Unit.parse('5cm')).toMatchTypeOf<Unit>()
+  expectTypeOf(
+    Unit.fromJSON({ value: 5.2, unit: 'inch' })
+  ).toMatchTypeOf<Unit>()
+}
+
+/**
  * Example of custom fallback for onUndefinedSymbol & onUndefinedFunction
  */
 {
@@ -2565,12 +2590,6 @@ Statistics functions' return types
   >()
   expectTypeOf(
     math.quantileSeq([math.unit('5cm'), math.unit('10cm')], 0.75)
-  ).toMatchTypeOf<Unit>()
-
-  expectTypeOf(Unit.isValuelessUnit('cm')).toMatchTypeOf<boolean>()
-  expectTypeOf(Unit.parse('5cm')).toMatchTypeOf<Unit>()
-  expectTypeOf(
-    Unit.fromJSON({ value: 5.2, unit: 'inch' })
   ).toMatchTypeOf<Unit>()
 }
 

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -308,6 +308,8 @@ Chaining examples
     )
   ).toMatchTypeOf<MathJsChain<Unit>>()
 
+  expectTypeOf(new Unit(15, 'cm')).toMatchTypeOf<Unit>()
+
   // fraction
   expectTypeOf(math.chain(math.fraction('123'))).toMatchTypeOf<
     MathJsChain<Fraction>
@@ -2563,6 +2565,12 @@ Statistics functions' return types
   >()
   expectTypeOf(
     math.quantileSeq([math.unit('5cm'), math.unit('10cm')], 0.75)
+  ).toMatchTypeOf<Unit>()
+
+  expectTypeOf(Unit.isValuelessUnit('cm')).toMatchTypeOf<boolean>()
+  expectTypeOf(Unit.parse('5cm')).toMatchTypeOf<Unit>()
+  expectTypeOf(
+    Unit.fromJSON({ value: 5.2, unit: 'inch' })
   ).toMatchTypeOf<Unit>()
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -508,6 +508,7 @@ export interface MathJsInstance extends MathJsFactory {
   RelationalNode: RelationalNodeCtor
   SymbolNode: SymbolNodeCtor
 
+  Unit: UnitCtor
   Matrix: MatrixCtor
 
   /**
@@ -4011,11 +4012,7 @@ export interface UnitPrefix {
   scientific: boolean
 }
 
-export declare class Unit {
-  constructor(
-    value: number | BigNumber | Fraction | Complex | boolean,
-    name: string
-  )
+export interface Unit {
   valueOf(): string
   clone(): Unit
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -4042,19 +4039,16 @@ export declare class Unit {
   value: number
   fixPrefix: boolean
   skipAutomaticSimplification: true
-  /**
-   * Parse a string into a unit. The value of the unit is parsed as number, BigNumber, or Fraction depending on the math.js config setting number.
-   *
-   * Throws an exception if the provided string does not contain a valid unit or cannot be parsed.
-   */
-  static parse: (str: string) => Unit
-  /** Test if the given expression is a unit.
-   *
-   * The unit can have a prefix but cannot have a value.
-   */
-  static isValuelessUnit: (name: string) => boolean
-  /** Instantiate a Unit from a JSON object */
-  static fromJSON: (json: object) => Unit
+}
+
+export interface UnitCtor {
+  new (
+    value: number | BigNumber | Fraction | Complex | boolean,
+    name: string
+  ): Unit
+  parse(str: string): Unit
+  isValuelessUnit(name: string): boolean
+  fromJSON(json: object): Unit
 }
 
 export interface CreateUnitOptions {
@@ -6863,6 +6857,7 @@ export const {
   RelationalNode,
   SymbolNode,
   Matrix,
+  Unit,
 
   uninitialized,
   version,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4015,6 +4015,7 @@ export interface UnitPrefix {
 export interface Unit {
   valueOf(): string
   clone(): Unit
+  _isDerived(): boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hasBase(base: any): boolean
   equalBase(unit: Unit): boolean
@@ -4041,14 +4042,25 @@ export interface Unit {
   skipAutomaticSimplification: true
 }
 
-export interface UnitCtor {
+export interface UnitStatic {
+  PREFIXES: Record<string, UnitPrefix>
+  BASE_DIMENSIONS: string[]
+  BASE_UNITS: Record<string, { dimensions: number[] }>
+  UNIT_SYSTEMS: Record<
+    string,
+    Record<string, { unit: Unit; prefix: UnitPrefix }>
+  >
+  UNITS: Record<string, Unit>
+  parse(str: string): Unit
+  isValuelessUnit(name: string): boolean
+  fromJSON(json: MathJSON): Unit
+}
+
+export interface UnitCtor extends UnitStatic {
   new (
     value: number | BigNumber | Fraction | Complex | boolean,
     name: string
   ): Unit
-  parse(str: string): Unit
-  isValuelessUnit(name: string): boolean
-  fromJSON(json: object): Unit
 }
 
 export interface CreateUnitOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4011,7 +4011,11 @@ export interface UnitPrefix {
   scientific: boolean
 }
 
-export interface Unit {
+export declare class Unit {
+  constructor(
+    value: number | BigNumber | Fraction | Complex | boolean,
+    name: string
+  )
   valueOf(): string
   clone(): Unit
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -4038,6 +4042,19 @@ export interface Unit {
   value: number
   fixPrefix: boolean
   skipAutomaticSimplification: true
+  /**
+   * Parse a string into a unit. The value of the unit is parsed as number, BigNumber, or Fraction depending on the math.js config setting number.
+   *
+   * Throws an exception if the provided string does not contain a valid unit or cannot be parsed.
+   */
+  static parse: (str: string) => Unit
+  /** Test if the given expression is a unit.
+   *
+   * The unit can have a prefix but cannot have a value.
+   */
+  static isValuelessUnit: (name: string) => boolean
+  /** Instantiate a Unit from a JSON object */
+  static fromJSON: (json: object) => Unit
 }
 
 export interface CreateUnitOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3990,15 +3990,17 @@ export interface MathJSON {
   fixPrefix?: boolean
 }
 
+export interface BaseUnit {
+  dimensions: number[]
+  key: string
+}
+
 export interface UnitComponent {
   power: number
   prefix: string
   unit: {
     name: string
-    base: {
-      dimensions: number[]
-      key: string
-    }
+    base: BaseUnit
     prefixes: Record<string, UnitPrefix>
     value: number
     offset: number
@@ -4015,9 +4017,7 @@ export interface UnitPrefix {
 export interface Unit {
   valueOf(): string
   clone(): Unit
-  _isDerived(): boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  hasBase(base: any): boolean
+  hasBase(base: BaseUnit | string | undefined): boolean
   equalBase(unit: Unit): boolean
   equals(unit: Unit): boolean
   multiply(unit: Unit): Unit
@@ -4042,18 +4042,31 @@ export interface Unit {
   skipAutomaticSimplification: true
 }
 
+export type UnitSystemName = 'si' | 'cgs' | 'us' | 'auto'
+
 export interface UnitStatic {
   PREFIXES: Record<string, UnitPrefix>
   BASE_DIMENSIONS: string[]
-  BASE_UNITS: Record<string, { dimensions: number[] }>
+  BASE_UNITS: Record<string, BaseUnit>
   UNIT_SYSTEMS: Record<
-    string,
+    UnitSystemName,
     Record<string, { unit: Unit; prefix: UnitPrefix }>
   >
   UNITS: Record<string, Unit>
   parse(str: string): Unit
   isValuelessUnit(name: string): boolean
   fromJSON(json: MathJSON): Unit
+  isValidAlpha(c: string): boolean
+  createUnit(
+    obj: Record<string, string | Unit | UnitDefinition>,
+    options?: { override: boolean }
+  ): Unit
+  createUnitSingle(
+    name: string,
+    definition: string | Unit | UnitDefinition
+  ): Unit
+  getUnitSystem(): UnitSystemName
+  setUnitSystem(name: UnitSystemName): void
 }
 
 export interface UnitCtor extends UnitStatic {


### PR DESCRIPTION
# Description
- Adds static methods based on documentation: https://mathjs.org/docs/reference/classes/unit.html#unitparsestr--codeunitcode
- Adds static members based on code at `src/type/unit/Unit.js`
- Addresses: https://github.com/josdejong/mathjs/issues/2286

## Test
- Added tests to testTypes.ts

## Additional Notes
I do not see the simplify and format unit in the class documentation. Is it just missing, or am I looking in the wrong place?
- https://mathjs.org/docs/reference/classes/unit.html
- Similarly, the documentation does not reference the following static members.
```
Unit.PREFIXES = PREFIXES
Unit.BASE_DIMENSIONS = BASE_DIMENSIONS
Unit.BASE_UNITS = BASE_UNITS
Unit.UNIT_SYSTEMS = UNIT_SYSTEMS
Unit.UNITS = UNITS
```
- I can take a look at updating the documentation in the future
- Currently, the types I used are pretty generic. I can make them more specific in the future (ex., string[] versus BASE_DIMENSION[])
