### PR TITLE
Extend typescript definition for ConstantNode to all types parsed as ConstantNode

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -246,8 +246,17 @@ export interface ConditionalNodeCtor {
   ): ConditionalNode
 }
 
-export interface ConstantNode<TValue extends string | number | boolean | null | undefined | bigint | BigNumber | Fraction = number >
-  extends MathNode {
+export interface ConstantNode<
+  TValue extends
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | bigint
+    | BigNumber
+    | Fraction = number
+> extends MathNode {
   type: 'ConstantNode'
   isConstantNode: true
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -255,7 +264,17 @@ export interface ConstantNode<TValue extends string | number | boolean | null | 
 }
 
 export interface ConstantNodeCtor {
-  new <TValue extends string | number | boolean | null | undefined | bigint | BigNumber | Fraction = string>(
+  new <
+    TValue extends
+      | string
+      | number
+      | boolean
+      | null
+      | undefined
+      | bigint
+      | BigNumber
+      | Fraction = string
+  >(
     value: TValue
   ): ConstantNode<TValue>
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -246,7 +246,7 @@ export interface ConditionalNodeCtor {
   ): ConditionalNode
 }
 
-export interface ConstantNode<TValue extends string | number = number>
+export interface ConstantNode<TValue extends string | number | boolean | null | undefined | bigint | BigNumber | Fraction = number >
   extends MathNode {
   type: 'ConstantNode'
   isConstantNode: true
@@ -255,7 +255,7 @@ export interface ConstantNode<TValue extends string | number = number>
 }
 
 export interface ConstantNodeCtor {
-  new <TValue extends string | number = string>(
+  new <TValue extends string | number | boolean | null | undefined | bigint | BigNumber | Fraction = string>(
     value: TValue
   ): ConstantNode<TValue>
 }


### PR DESCRIPTION
We use a forked version of MathJS in a production deployment, and have customised some functionality of our own. In doing so, we believe we found a mistake in the typescript definition of `ConstantNode`. Per #833 back in 2018, ConstantNode was explicitly extended to allow booleans, nulls, undefined's, etc as values, and [parse.js:1344](https://github.com/josdejong/mathjs/blob/30b195c9b5fe1828591ab90d37eed3af5ea8245e/src/expression/parse.js#L1344) parses such values as ConstantNode. Therefore, I believe ConstantNode's typing should allow more than just `number` and `string` values! 