### PR TITLE
bugFix-3219

### DIFF
--- a/src/function/arithmetic/dotDivide.js
+++ b/src/function/arithmetic/dotDivide.js
@@ -5,6 +5,7 @@ import { createMatAlgo07xSSf } from '../../type/matrix/utils/matAlgo07xSSf.js'
 import { createMatAlgo11xS0s } from '../../type/matrix/utils/matAlgo11xS0s.js'
 import { createMatAlgo12xSfs } from '../../type/matrix/utils/matAlgo12xSfs.js'
 import { createMatrixAlgorithmSuite } from '../../type/matrix/utils/matrixAlgorithmSuite.js'
+import { createSparseMatrixClass } from '../../type/matrix/SparseMatrix.js'
 
 const name = 'dotDivide'
 const dependencies = [
@@ -22,6 +23,7 @@ export const createDotDivide = /* #__PURE__ */ factory(name, dependencies, ({ ty
   const matAlgo07xSSf = createMatAlgo07xSSf({ typed, DenseMatrix })
   const matAlgo11xS0s = createMatAlgo11xS0s({ typed, equalScalar })
   const matAlgo12xSfs = createMatAlgo12xSfs({ typed, DenseMatrix })
+  const SparseMatrix = createSparseMatrixClass({typed,equalScalar,Matrix:matrix})
   const matrixAlgorithmSuite = createMatrixAlgorithmSuite({ typed, matrix, concat })
 
   /**
@@ -52,7 +54,11 @@ export const createDotDivide = /* #__PURE__ */ factory(name, dependencies, ({ ty
    */
   return typed(name, matrixAlgorithmSuite({
     elop: divideScalar,
-    SS: matAlgo07xSSf,
+    SS: (a,b)=>{
+      const result = matAlgo07xSSf(a, b, divideScalar, false)
+      const isSparseMatrix=(result instanceof SparseMatrix)
+      return isSparseMatrix ? result : new SparseMatrix(result)
+    },
     DS: matAlgo03xDSf,
     SD: matAlgo02xDS0,
     Ss: matAlgo11xS0s,

--- a/test/unit-tests/function/arithmetic/dotDivide.test.js
+++ b/test/unit-tests/function/arithmetic/dotDivide.test.js
@@ -168,8 +168,22 @@ describe('dotDivide', function () {
     it('should perform (sparse matrix ./ sparse matrix) element-wise matrix division', function () {
       const a = math.sparse([[1, 2], [0, 4]])
       const b = math.sparse([[5, 0], [7, 8]])
-      assert.deepStrictEqual(dotDivide(a, b), math.matrix([[1 / 5, Infinity], [0, 4 / 8]]))
+      const result=dotDivide(a, b);
+      const expected = math.sparse([[1 / 5, Infinity],[0, 4 / 8]])
+      assert.deepStrictEqual(result.toArray(), expected.toArray())
+      const isSparseMatrix = !!(result._values && result._index && result._ptr)
+      assert.strictEqual(isSparseMatrix, true)
     })
+
+     it('should perform (sparse matrix ./ sparse matrix) element-wise matrix division', function () {
+       const a = math.sparse([1, 2])
+       const b = math.sparse([1, 5])
+       const result = dotDivide(a, b)
+       const expected = math.sparse([1,0.4])
+       assert.deepStrictEqual(result.toArray(), expected.toArray())
+       const isSparseMatrix = !!(result._values && result._index && result._ptr)
+       assert.strictEqual(isSparseMatrix, true)
+     })
 
     it('should throw an error when dividing element-wise with differing size is not broadcastable', function () {
       assert.throws(function () { dotDivide(math.sparse([[1, 2], [3, 4]]), math.sparse([1, 2, 3])) })


### PR DESCRIPTION
Added fixes of BUG - 3219
Changed functions in order to preserve sparse matrix result in (sparse-sparse) dotDivide operation

**Fix: Preserve Sparse Matrix Output in dotDivide**
This PR addresses an issue in the dotDivide function, where the result of dividing two sparse matrices returns a dense matrix instead of preserving the sparse matrix format. 
The fix ensures that the result of sparse-sparse division is correctly returned as a sparse matrix, maintaining consistency with the input types.

**Changes:**
- Updated the SS (sparse-sparse) case in dotDivide to ensure type preservation for sparse matrices.
- Added a check to convert the result back into a sparse matrix using the SparseMatrix class when applicable.
- New test cases added to validate the expected behavior of dotDivide for sparse matrix inputs.