### PR TITLE
fix: updates MathArray types to be n-dimensional

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -857,7 +857,6 @@ Chaining examples
 
   assert.throws(
     () =>
-      // @ts-expect-error ... gcd() supports only 1d matrices!
       math.gcd([
         [
           [1, 5],
@@ -1461,9 +1460,16 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
     [4, 5, 6, 7],
     [5, 6, 7, 8]
   ]
+  const cde = [1, 2, 3, 4]
+  const def = [
+    [1, 2, 3, 4],
+    [2, 3, 4, 5],
+    [4, 5, 6, 7],
+    [5, 6, 7, 8]
+  ]
 
-  const cde: MathArray = [1]
-  const def: MathArray = [2]
+  const efg: MathArray = [1, 2, 3, 4, 5]
+  const fgh: MathArray = [2, 3, 4, 5, 6]
 
   const Mbcd = math.matrix(bcd)
   const Mabc = math.matrix(abc)
@@ -1477,9 +1483,15 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   const _r2 = math.multiply(a, b)
 
   // 1D JS Array
-  const _r12 = math.multiply(cde, def) // equal 2
   const r3 = math.multiply(abc, bcd)
-  const _r31 = r3[1] // By default least promised valid syntax
+  const r31 = math.multiply(cde, def)
+  const r32 = math.multiply(efg, fgh)
+
+  // @ts-expect-error ... Multiplication of two MathArrays can result in a MathNumericType | MathArray
+  const _r3 = r3[1]
+
+  const _r31 = r31[0] // If you let typescript infer the type of r31, it will correctly identify it is an array
+  assert.strictEqual(typeof r32, 'number')
 
   // 2D JS Array
   const r12 = math.multiply(bcd, bcd)
@@ -1488,8 +1500,8 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   const multiDimensional = (x: any): x is any[][] => x.length && x[0].length
   if (multiDimensional(r12)) {
     const _r1211 = r12[1][1]
+    const _r121 = r12[1] // Valid syntax
   }
-  const _r121 = r12[1] // Valid syntax
 
   // Matrix: matrix * vector
   const r7 = math.multiply(Mabc, bcd)
@@ -2807,4 +2819,56 @@ Match types of exact positional arguments.
   const e = math.mode(mathCollection)
   expectTypeOf(e).toMatchTypeOf<MathScalarType[]>()
   assert.deepStrictEqual(e, [1])
+}
+
+/**
+ * N-dimensional array examples
+ */
+{
+  const math = create(all, {})
+
+  const array1 = [1, 2, 3]
+  const array2 = [
+    [1, 2],
+    [3, 4]
+  ]
+  const array3 = [
+    [
+      [1, 2],
+      [3, 4]
+    ],
+    [
+      [5, 6],
+      [7, 8]
+    ]
+  ]
+  const array4 = [
+    [[[1, 2]], [[3, 4]]],
+    [[[5, 6]], [[7, 8]]],
+    [[[9, 10]], [[11, 12]]]
+  ]
+
+  const mixArray3 = [
+    [
+      [1, math.unit(2, 'cm'), math.bignumber(1), math.complex(1, 2)],
+      [3, math.unit(4, 'cm'), math.bignumber(2), math.complex(3, 4)]
+    ],
+    [
+      [5, math.unit(6, 'cm'), math.bignumber(3), math.complex(5, 6)],
+      [7, math.unit(8, 'cm'), math.bignumber(4), math.complex(7, 8)]
+    ]
+  ]
+
+  const unitArray3 = [
+    [[math.unit(1, 'cm'), math.unit(2, 'cm')]],
+    [[math.unit(3, 'cm'), math.unit(4, 'cm')]]
+  ]
+
+  expectTypeOf(array1).toMatchTypeOf<MathArray>()
+  expectTypeOf(array2).toMatchTypeOf<MathArray>()
+  expectTypeOf(array3).toMatchTypeOf<MathArray>()
+  expectTypeOf(array4).toMatchTypeOf<MathArray>()
+
+  expectTypeOf(mixArray3).toMatchTypeOf<MathArray<MathScalarType>>()
+  expectTypeOf(unitArray3).toMatchTypeOf<MathArray<Unit>>()
 }

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1460,13 +1460,6 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
     [4, 5, 6, 7],
     [5, 6, 7, 8]
   ]
-  const cde = [1, 2, 3, 4]
-  const def = [
-    [1, 2, 3, 4],
-    [2, 3, 4, 5],
-    [4, 5, 6, 7],
-    [5, 6, 7, 8]
-  ]
 
   const efg: MathArray = [1, 2, 3, 4, 5]
   const fgh: MathArray = [2, 3, 4, 5, 6]
@@ -1483,15 +1476,11 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   const _r2 = math.multiply(a, b)
 
   // 1D JS Array
-  const r3 = math.multiply(abc, bcd)
-  const r31 = math.multiply(cde, def)
-  const r32 = math.multiply(efg, fgh)
+  const r3 = math.multiply(abc, bcd) // 1D * 2D => Array
+  const r3a = math.multiply(efg, fgh) // 1D * 1D => Scalar
 
-  // @ts-expect-error ... Multiplication of two MathArrays can result in a MathNumericType | MathArray
-  const _r3 = r3[1]
-
-  const _r31 = r31[0] // If you let typescript infer the type of r31, it will correctly identify it is an array
-  assert.strictEqual(typeof r32, 'number')
+  const _r31 = r3[1]
+  assert.strictEqual(typeof r3a, 'number')
 
   // 2D JS Array
   const r12 = math.multiply(bcd, bcd)
@@ -1500,8 +1489,9 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   const multiDimensional = (x: any): x is any[][] => x.length && x[0].length
   if (multiDimensional(r12)) {
     const _r1211 = r12[1][1]
-    const _r121 = r12[1] // Valid syntax
   }
+
+  const _r121 = r12[1]
 
   // Matrix: matrix * vector
   const r7 = math.multiply(Mabc, bcd)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ export type NoLiteralType<T> = T extends number
 export type MathNumericType = number | BigNumber | bigint | Fraction | Complex
 export type MathScalarType = MathNumericType | Unit
 export type MathGeneric<T extends MathScalarType = MathNumericType> = T
-export type MathArray<T = MathGeneric> = T[] | T[][]
+export type MathArray<T = MathGeneric> = T[] | Array<MathArray<T>>
 export type MathCollection<T = MathGeneric> = MathArray<T> | Matrix<T>
 export type MathType = MathScalarType | MathCollection
 export type MathExpression = string | string[] | MathCollection
@@ -1394,7 +1394,7 @@ export interface MathJsInstance extends MathJsFactory {
 
   multiply<T extends MathNumericType[]>(x: T, y: T[]): T
   multiply<T extends MathNumericType[]>(x: T[], y: T): T
-  multiply<T extends MathArray<MathNumericType>>(x: T, y: T): T
+  multiply(x: MathArray, y: MathArray): MathArray | MathNumericType
   multiply(x: Unit, y: Unit): Unit
   multiply(x: number, y: number): number
   multiply(x: MathType, y: MathType): MathType

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1394,7 +1394,7 @@ export interface MathJsInstance extends MathJsFactory {
 
   multiply<T extends MathNumericType[]>(x: T, y: T[]): T
   multiply<T extends MathNumericType[]>(x: T[], y: T): T
-  multiply(x: MathArray, y: MathArray): MathArray | MathNumericType
+  multiply<T extends MathArray>(x: T, y: T): T | MathScalarType
   multiply(x: Unit, y: Unit): Unit
   multiply(x: number, y: number): number
   multiply(x: MathType, y: MathType): MathType

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1392,9 +1392,10 @@ export interface MathJsInstance extends MathJsFactory {
   multiply<T extends Matrix>(x: T, y: MathType): Matrix
   multiply<T extends Matrix>(x: MathType, y: T): Matrix
 
-  multiply<T extends MathNumericType[]>(x: T, y: T[]): T
-  multiply<T extends MathNumericType[]>(x: T[], y: T): T
-  multiply<T extends MathArray>(x: T, y: T): T | MathScalarType
+  multiply<T extends MathArray>(x: T, y: T[]): T
+  multiply<T extends MathArray>(x: T[], y: T): T
+  multiply<T extends MathArray>(x: T[], y: T[]): T
+  multiply<T extends MathArray>(x: T, y: T): MathScalarType
   multiply(x: Unit, y: Unit): Unit
   multiply(x: number, y: number): number
   multiply(x: MathType, y: MathType): MathType


### PR DESCRIPTION
# Description
- Fixes MathArray types to allow for n-dimensional arrays.
- Addresses https://github.com/josdejong/mathjs/issues/3098
- Also addresses issue discussed in: https://github.com/josdejong/mathjs/pull/3269#issuecomment-2408328886
https://github.com/josdejong/mathjs/blob/982bbdcb9b4513e4c00db7e8f09e361eeebec678/src/function/arithmetic/multiply.js#L799-L807

## Test
- Added n-dimensional type tests
- Updated multiply tests

## Additional Notes
- PR is made against the v14 release branch
- Continues from: https://github.com/josdejong/mathjs/pull/3099