### PR TITLE
fix: Don't override type-native floor/ceil within tolerance of value

### DIFF
--- a/src/function/arithmetic/fix.js
+++ b/src/function/arithmetic/fix.js
@@ -104,6 +104,10 @@ export const createFix = /* #__PURE__ */ factory(name, dependencies, ({ typed, C
       return x.isNegative() ? ceil(x, n) : floor(x, n)
     },
 
+    bigint: b => b,
+    'bigint, number': (b, _dummy) => b,
+    'bigint, BigNumber': (b, _dummy) => b,
+
     Fraction: function (x) {
       return x.s < 0n ? x.ceil() : x.floor()
     },

--- a/src/function/arithmetic/round.js
+++ b/src/function/arithmetic/round.js
@@ -133,6 +133,11 @@ export const createRound = /* #__PURE__ */ factory(name, dependencies, ({ typed,
       return xSelected.toDecimalPlaces(n.toNumber())
     },
 
+    // bigints can't be rounded
+    bigint: b => b,
+    'bigint, number': (b, _dummy) => b,
+    'bigint, BigNumber': (b, _dummy) => b,
+
     Fraction: function (x) {
       return x.round()
     },

--- a/test/unit-tests/function/arithmetic/ceil.test.js
+++ b/test/unit-tests/function/arithmetic/ceil.test.js
@@ -37,6 +37,12 @@ describe('ceil', function () {
     approxEqual(ceil(-2.178, 2), -2.17)
   })
 
+  it('should be safe to call with a bigint', function () {
+    const b = 12345678901234567890n
+    assert.strictEqual(ceil(b), b)
+    assert.strictEqual(ceil(b, 7), b)
+  })
+
   it('should return the ceil of a big number', function () {
     assert.deepStrictEqual(ceil(bignumber(0)), bignumber(0))
     assert.deepStrictEqual(ceil(bignumber(1)), bignumber(1))
@@ -146,6 +152,13 @@ describe('ceil', function () {
     assert.deepStrictEqual(ceil(bignumber(799999.9999999999)), bignumber(800000))
     assert.deepStrictEqual(ceil(bignumber(-30000.000000000004)), bignumber(-30000))
     assert.deepStrictEqual(ceil(bignumber(-799999.9999999999)), bignumber(-800000))
+  })
+
+  it('should not be confused by default tolerances', function () {
+    assert.strictEqual(ceil(1234567890123.4), 1234567890124)
+    assert.strictEqual(
+      ceil(bignumber('12345678901234567890.4')).toFixed(),
+      '12345678901234567891')
   })
 
   it('should ceil units', function () {

--- a/test/unit-tests/function/arithmetic/fix.test.js
+++ b/test/unit-tests/function/arithmetic/fix.test.js
@@ -50,6 +50,12 @@ describe('fix', function () {
     assert.deepStrictEqual(fix(-1.888, bignumber(2)), bignumber(-1.88))
   })
 
+  it('should be safe to call with a bigint', function () {
+    const b = 12345678901234567890n
+    assert.strictEqual(fix(b), b)
+    assert.strictEqual(fix(b, 7), b)
+  })
+
   it('should round big numbers correctly', function () {
     assert.deepStrictEqual(fix(bignumber(0)), bignumber(0))
     assert.deepStrictEqual(fix(bignumber(1)), bignumber(1))

--- a/test/unit-tests/function/arithmetic/floor.test.js
+++ b/test/unit-tests/function/arithmetic/floor.test.js
@@ -45,6 +45,12 @@ describe('floor', function () {
     assert.strictEqual(floor(-2.178, 2), -2.18)
   })
 
+  it('should be safe to call with a bigint', function () {
+    const b = 12345678901234567890n
+    assert.strictEqual(floor(b), b)
+    assert.strictEqual(floor(b, 7), b)
+  })
+
   it('should floor big numbers correctly', function () {
     assert.deepStrictEqual(floor(bignumber(0)), bignumber(0))
     assert.deepStrictEqual(floor(bignumber(1)), bignumber(1))
@@ -127,6 +133,7 @@ describe('floor', function () {
     assert.strictEqual(floor(-7.999999999999999), -8)
     assert.strictEqual(floor(30000.000000000004), 30000)
     assert.strictEqual(floor(799999.9999999999), 800000)
+    assert.strictEqual(floor(799999999.9999999), 800000000)
     assert.strictEqual(floor(-30000.000000000004), -30000)
 
     assert.strictEqual(floor(3.0000000000000004, 2), 3)
@@ -135,7 +142,15 @@ describe('floor', function () {
     assert.strictEqual(floor(-7.999999999999999, 2), -8)
     assert.strictEqual(floor(30000.000000000004, 2), 30000)
     assert.strictEqual(floor(799999.9999999999, 2), 800000)
+    assert.strictEqual(floor(799999.9999999999, 3), 800000)
     assert.strictEqual(floor(-30000.000000000004, 2), -30000)
+  })
+
+  it('should not be confused by default tolerances', function () {
+    assert.strictEqual(floor(1234567890123.5), 1234567890123)
+    assert.strictEqual(
+      floor(bignumber('12345678901234567890.5')).toFixed(),
+      '12345678901234567890')
   })
 
   it('should gracefully handle round-off errors with bignumbers', function () {

--- a/test/unit-tests/function/arithmetic/round.test.js
+++ b/test/unit-tests/function/arithmetic/round.test.js
@@ -72,6 +72,12 @@ describe('round', function () {
     assert.throws(function () { round(null) }, /TypeError: Unexpected type of argument/)
   })
 
+  it('should be safe to call with a bigint', function () {
+    const b = 12345678901234567890n
+    assert.strictEqual(round(b), b)
+    assert.strictEqual(round(b, 7), b)
+  })
+
   it('should round bignumbers', function () {
     assert.deepStrictEqual(round(bignumber(0.145 * 100)), bignumber(15))
     assert.deepStrictEqual(round(bignumber(0.145 * 100), bignumber(0)), bignumber(15))


### PR DESCRIPTION
Formerly, it was sufficient for a value x to be within tolerance of its rounded value for that to override the floor/ceil provided by the type of x. Now, we only override that native floor/ceil when the rounded value is within tolerance **and** the floor/ceil value is distinct from x as perceived by the tolerance. When both the rounded value and the floor/ceil are within tolerance, there is no reason to prefer the rounded value over what the native floor/ceil is telling us.

Practically speaking, this change prevents mathjs from becoming confused by the tolerances and reporting that the floor of 1234567890123.5 is 1234567890124. Similar issues for BigNumbers are also fixed. Note this means that with the default tolerances, which are very loose by BigNumber standards, for large BigNumbers mathjs will end up just falling back to the native BigNumber floor/ceil (since mathjs will always consider a large BigNumber to be "nearly equal to" both its floor and its ceiling). That seems like preferable behavior to always overriding them.

Of my outstanding PRs, this is probably both the lightest weight and the most important, as it corrects numerous questionable return values of `floor`, `ceil`, and `fix`.

Resolves #3247.