### PR TITLE
feat: always infer function call when args empty or have comma

### DIFF
--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -755,8 +755,11 @@ math.evaluate('(1+2)(3+4)')   // 21
 ```
 
 Parentheses are parsed as a function call when there is a symbol or accessor on
-the left hand side, like `sqrt(4)` or `obj.method(4)`. In other cases the
-parentheses are interpreted as an implicit multiplication.
+the left hand side, like `sqrt(4)` or `obj.method(4)`, when the argument
+list is empty, like `(f()=1)()`, or when the argument list contains a comma,
+like `(f(x,y) = 2x-y)(3,1)`. To enable calling a unary function this way, you
+may add a final comma in the argument list, as in `(f(x)=(x+1)x/2)(3,)`. In all
+other cases the parentheses are interpreted as an implicit multiplication.
 
 Math.js will always evaluate implicit multiplication before explicit multiplication `*`, so that the expression `x * y z` is parsed as `x * (y * z)`. Math.js also gives implicit multiplication higher precedence than division, *except* when the division matches the pattern `[unaryPrefixOp]?[number] / [number] [symbol]` or `[unaryPrefixOp]?[number] / [number] [left paren]`. In that special case, the division is evaluated first:
 

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -963,6 +963,14 @@ describe('parse', function () {
       assert.deepStrictEqual(parseAndEval('sqrt(4)(1+2)(2)'), 12)
     })
 
+    it('should allow calling a function-valued expression', function () {
+      assert.deepStrictEqual(parseAndEval('(f()=7)()'), 7)
+      assert.deepStrictEqual(parseAndEval('(f(x)=x+3)(4,)'), 7)
+      assert.deepStrictEqual(parseAndEval('(f(x,y)=x+y)(4,3)'), 7)
+      assert.deepStrictEqual(parseAndEval('(f(x,y)=x+y)(4,3,)'), 7)
+      assert.deepStrictEqual(parseAndEval('(f(g)=(_(x)=g(x)+1))(floor,)(6.5,)'), 7)
+    })
+
     it('should invoke a function on an object with the right context', function () {
       approxEqual(parseAndEval('(2.54 cm).toNumeric("inch")'), 1)
       assert.deepStrictEqual(parseAndEval('bignumber(2).plus(3)'), math.bignumber(5))

--- a/test/unit-tests/expression/security.test.js
+++ b/test/unit-tests/expression/security.test.js
@@ -247,8 +247,9 @@ describe('security', function () {
 
   it('should not allow replacing validateSafeMethod with a local variant', function () {
     assert.throws(function () {
-      math.evaluate("evaluate(\"f(validateSafeMethod)=cos.constructor(\\\"return evaluate\\\")()\")(evaluate(\"f(x,y)=0\"))(\"console.log('hacked...')\")")
-    }, /SyntaxError: Value expected/)
+      const hack = "evaluate(\"f(validateSafeMethod)=cos.constructor(\\\"return evaluate\\\")()\")(evaluate(\"f(x,y)=0\"),)(\"console.log('hacked...')\",)"
+      math.evaluate(hack)
+    }, /Error: No access .*constructor/)
   })
 
   it('should not allow abusing toString', function () {
@@ -259,14 +260,16 @@ describe('security', function () {
 
   it('should not allow creating a bad FunctionAssignmentNode', function () {
     assert.throws(function () {
-      math.evaluate("badNode={isNode:true,type:\"FunctionAssignmentNode\",expr:parse(\"1\"),types:{join:evaluate(\"f(a)=\\\"\\\"\")},params:{\"forEach\":evaluate(\"f(x)=1\"),\"join\":evaluate(\"f(x)=\\\"){return evaluate;}});return fn;})())}});return fn;})());}};//\\\"\")}};parse(\"f()=x\").map(evaluate(\"f(a,b,c)=badNode\",{\"badNode\":badNode})).compile().evaluate()()()(\"console.log('hacked...')\")")
-    }, /SyntaxError: Value expected/)
+      math.evaluate("badNode={isNode:true,constructor:{prototype:{isNode:true}},type:\"FunctionAssignmentNode\",expr:parse(\"1\"),types:{join:evaluate(\"f(a)=\\\"\\\"\")},params:{\"forEach\":evaluate(\"f(x)=1\"),\"join\":evaluate(\"f(x)=\\\"){return evaluate;}});return fn;})())}});return fn;})());}};//\\\"\")}};parse(\"f()=x\").map(evaluate(\"f(a,b,c)=badNode\",{\"badNode\":badNode})).compile().evaluate()()()(\"console.log('hacked...')\")")
+    }, /Error: No access to property "isNode"/)
   })
 
+  // FIXME: Appears to be identical to prior test; is it supposed to be
+  //        testing something else?
   it('should not allow creating a bad OperatorNode (1)', function () {
     assert.throws(function () {
-      math.evaluate("badNode={isNode:true,type:\"FunctionAssignmentNode\",expr:parse(\"1\"),types:{join:evaluate(\"f(a)=\\\"\\\"\")},params:{\"forEach\":evaluate(\"f(x)=1\"),\"join\":evaluate(\"f(x)=\\\"){return evaluate;}});return fn;})())}});return fn;})());}};//\\\"\")}};parse(\"f()=x\").map(evaluate(\"f(a,b,c)=badNode\",{\"badNode\":badNode})).compile().evaluate()()()(\"console.log('hacked...')\")")
-    }, /SyntaxError: Value expected/)
+      math.evaluate("badNode={isNode:true,constructor:{prototype:{isNode:true}},type:\"FunctionAssignmentNode\",expr:parse(\"1\"),types:{join:evaluate(\"f(a)=\\\"\\\"\")},params:{\"forEach\":evaluate(\"f(x)=1\"),\"join\":evaluate(\"f(x)=\\\"){return evaluate;}});return fn;})())}});return fn;})());}};//\\\"\")}};parse(\"f()=x\").map(evaluate(\"f(a,b,c)=badNode\",{\"badNode\":badNode})).compile().evaluate()()()(\"console.log('hacked...')\")")
+    }, /Error: No access to property "isNode"/)
   })
 
   it('should not allow creating a bad OperatorNode (2)', function () {
@@ -316,7 +319,7 @@ describe('security', function () {
           'evilMath=x.create().done();' +
           'evilMath.import({"_compile":f(a,b,c)="evaluate","isNode":f()=true}); ' +
           "parse(\"(1)\").map(g(a,b,c)=evilMath.chain()).compile().evaluate()(\"console.log('hacked...')\")")
-    }, /SyntaxError: Value expected/)
+    }, /Error: Undefined symbol Chain/)
   })
 
   it('should not allow passing a function name containg bad contents', function () {


### PR DESCRIPTION
This is a proposed PR to resolve #3358. It interprets `EXPR()` and `EXPR(..., ...)` as function calls regardless of what `EXPR` is, rather than syntax errors unless `EXPR` is a symbol or accessor. To enable this syntax to cover unary function calls as well, it allows a trailing comma in argument lists, meaning `exp(3,)` is now a legal synonym for `exp(3)`. With these conventions, you can write `(f(x) = x+1)(6,)` to get 7.

I would totally be open to other syntaxes that would allow one to call a function that was the result of an expression (rather than a direct symbol or accessor), but I wanted a PR available so that you could try this one in practice.

Note that re-allowing expressions that return functions to be called makes a small handful of the security tests no longer simply syntax errors. However, all such tests still show these exploits ineffective, due to other security measures (that were likely already in place when the prior syntax for calling a function returned from an expression, `(EXPR)(3)`, was eliminated in favor of implicit multiplication.

Looking forward to your thoughts.