### PR TITLE
DeepMap-main-offenders

### DIFF
--- a/src/type/matrix/DenseMatrix.js
+++ b/src/type/matrix/DenseMatrix.js
@@ -630,16 +630,34 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
    * @return {Iterable<{ value, index: number[] }>}
    */
   DenseMatrix.prototype[Symbol.iterator] = function * () {
-    const recurse = function * (value, index) {
-      if (isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          yield * recurse(value[i], index.concat(i))
+    const size = this._size
+    const N = size.length
+
+    if (N === 0) return
+    if (N === 1) {
+      for (let i = 0; i < size[0]; i++) {
+        yield { value: this._data[i], index: [i] }
+      }
+      return
+    }
+
+    const recurse = function * (value, depth) {
+      const thisSize = size[depth]
+      if (depth < N - 1) {
+        for (let i = 0; i < thisSize; i++) {
+          index[depth] = i
+          yield * recurse(value[i], depth + 1)
         }
       } else {
-        yield ({ value, index })
+        for (let i = 0; i < thisSize; i++) {
+          index[depth] = i
+          yield { value: value[i], index: index.slice() }
+        }
       }
     }
-    yield * recurse(this._data, [])
+
+    const index = Array(N)
+    yield * recurse(this._data, 0)
   }
 
   /**

--- a/src/type/matrix/DenseMatrix.js
+++ b/src/type/matrix/DenseMatrix.js
@@ -606,7 +606,7 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
     if (maxDepth === 0) return me.clone()
 
     const result = new DenseMatrix(me)
-    const fastCallback = optimizeCallback(callback, me._data, 'map')
+    const fastCallback = optimizeCallback(callback, me, 'map')
     if (maxDepth === 1) {
       return new DenseMatrix(
         me._data.map((value, index) => fastCallback(value, [index], me))
@@ -629,7 +629,7 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
    */
   DenseMatrix.prototype.forEach = function (callback) {
     const me = this
-    const fastCallback = optimizeCallback(callback, me._data, 'map')
+    const fastCallback = optimizeCallback(callback, me, 'map')
     me._forEach(function (arr, i, index) {
       fastCallback(arr[i], index, me)
     })

--- a/src/type/matrix/DenseMatrix.js
+++ b/src/type/matrix/DenseMatrix.js
@@ -600,8 +600,18 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
    */
   DenseMatrix.prototype.map = function (callback) {
     const me = this
+    const size = me._size
+    const maxDepth = size.length
+
+    if (maxDepth === 0) return me.clone()
+
     const result = new DenseMatrix(me)
     const fastCallback = optimizeCallback(callback, me._data, 'map')
+    if (maxDepth === 1) {
+      return new DenseMatrix(
+        me._data.map((value, index) => fastCallback(value, [index], me))
+      )
+    }
 
     result._forEach(function (arr, i, index) {
       arr[i] = fastCallback(arr[i], index, me)

--- a/src/utils/collection.js
+++ b/src/utils/collection.js
@@ -27,14 +27,13 @@ export function containsCollections (array) {
  */
 export function deepForEach (array, callback) {
   if (isMatrix(array)) {
-    array = array.valueOf()
+    array.forEach(callback)
+  } else {
+    recurseForEach(array, callback)
   }
-
-  for (let i = 0, ii = array.length; i < ii; i++) {
-    const value = array[i]
-
+  function recurseForEach (value) {
     if (Array.isArray(value)) {
-      deepForEach(value, callback)
+      value.forEach(recurseForEach)
     } else {
       callback(value)
     }
@@ -54,13 +53,21 @@ export function deepForEach (array, callback) {
  * @return {Array | Matrix} res
  */
 export function deepMap (array, callback, skipZeros) {
-  if (array && (typeof array.map === 'function')) {
-    // TODO: replace array.map with a for loop to improve performance
-    return array.map(function (x) {
-      return deepMap(x, callback, skipZeros)
-    })
+  const skipZerosCallback = skipZeros
+    ? value => value === 0 ? 0 : callback(value)
+    : callback
+  if (isMatrix(array)) {
+    // TODO: use a callback that uses only one arguemnt
+    return array.map(v => skipZerosCallback(v))
   } else {
-    return callback(array)
+    return recurseMap(array)
+  }
+  function recurseMap (value) {
+    if (Array.isArray(value)) {
+      return value.map(recurseMap)
+    } else {
+      return skipZerosCallback(value)
+    }
   }
 }
 

--- a/test/benchmark/forEach.js
+++ b/test/benchmark/forEach.js
@@ -43,6 +43,32 @@ const bench = new Bench({ time: 100, iterations: 100 })
   .add('numberMatrix.forEach(abs.signatures.number)', () => {
     numberMatrix.forEach(abs.signatures.number)
   })
+  .add('genericMatrix.forEach(abs+idx)', () => {
+    genericMatrix.forEach((x, idx) => abs(x) + idx[0] - idx[1])
+  })
+  .add('numberMatrix.forEach(abs+idx)', () => {
+    numberMatrix.forEach((x, idx) => abs(x) + idx[0] - idx[1])
+  })
+  .add('forEach(genericMatrix, abs+idx)', () => {
+    forEach(genericMatrix, (x, idx) => abs(x) + idx[0] - idx[1])
+  })
+  .add('genericMatrix.forEach(abs+idx+arr)', () => {
+    genericMatrix.forEach((x, idx, X) => abs(x) + idx[0] - idx[1] + X.get([0, 0]))
+  })
+  .add('numberMatrix.forEach(abs+idx+arr)', () => {
+    numberMatrix.forEach((x, idx, X) => abs(x) + idx[0] - idx[1] + X.get([0, 0]))
+  })
+  .add('forEach(genericMatrix, abs+idx+arr)', () => {
+    forEach(genericMatrix, (x, idx, X) => abs(x) + idx[0] - idx[1] + X.get([0, 0]))
+  })
+  .add('forEach(array, abs+idx+arr)', () => {
+    forEach(array, (x, idx, X) => abs(x) + idx[0] - idx[1] + X[0][0])
+  })
+  .add('genericMatrix iterate', () => {
+    for (const v of genericMatrix) {
+      abs(v.value)
+    }
+  })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))
 await bench.run()

--- a/test/benchmark/map.js
+++ b/test/benchmark/map.js
@@ -43,6 +43,30 @@ const bench = new Bench({ time: 100, iterations: 100 })
   .add('numberMatrix.map(abs.signatures.number)', () => {
     numberMatrix.map(abs.signatures.number)
   })
+  .add('map(array, abs + idx)', () => {
+    map(array, (x, idx) => abs(x) + idx[0] - idx[1])
+  })
+  .add('genericMatrix.map(abs + idx)', () => {
+    genericMatrix.map((x, idx) => abs(x) + idx[0] - idx[1])
+  })
+  .add('numberMatrix.map(abs + idx)', () => {
+    numberMatrix.map((x, idx) => abs(x) + idx[0] - idx[1])
+  })
+  .add('map(array, abs + idx + arr)', () => {
+    map(array, (x, idx, X) => abs(x) + idx[0] - idx[1] + X[0][0])
+  })
+  .add('genericMatrix.map(abs + idx + matrix)', () => {
+    genericMatrix.map((x, idx, X) => abs(x) + idx[0] - idx[1] + X.get([0, 0]))
+  })
+  .add('numberMatrix.map(abs + idx + matrix)', () => {
+    numberMatrix.map((x, idx, X) => abs(x) + idx[0] - idx[1] + X.get([0, 0]))
+  })
+  .add('genericMatrix iterate', () => {
+    const result = genericMatrix.clone()
+    for (const v of genericMatrix) {
+      result.set(v.index, abs(v.value))
+    }
+  })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))
 await bench.run()

--- a/test/unit-tests/type/matrix/DenseMatrix.test.js
+++ b/test/unit-tests/type/matrix/DenseMatrix.test.js
@@ -818,22 +818,22 @@ describe('DenseMatrix', function () {
       ])
       expected = []
       m.forEach((value, index) => { expected.push({ value, index }) })
-      assert.deepStrictEqual(expected, [...m])
+      assert.deepStrictEqual([...m], expected)
 
       m = new DenseMatrix([1])
       expected = []
       m.forEach((value, index) => { expected.push({ value, index }) })
-      assert.deepStrictEqual(expected, [...m])
+      assert.deepStrictEqual([...m], expected)
 
       m = new DenseMatrix([1, 2, 3])
       expected = []
       m.forEach((value, index) => { expected.push({ value, index }) })
-      assert.deepStrictEqual(expected, [...m])
+      assert.deepStrictEqual([...m], expected)
 
       m = new DenseMatrix([])
       expected = []
       m.forEach((value, index) => { expected.push({ value, index }) })
-      assert.deepStrictEqual(expected, [...m])
+      assert.deepStrictEqual([...m], expected)
     })
   })
 


### PR DESCRIPTION
Hi Jos, this addresses #3262.

The main changes are:

- in collection deepMap uses the matrix map method and implements skip zeros.
- in collection deepForEach uses the matrix forEach method
- fixed an issue in the denseMatrix map and forEach method where the fastCallback was just passing the data of the matrix when it should be the matrix
- implements an iteration algorithm in DenseMatrix that is 2 or 3 times faster.
- added benchmarks
- fixes an issue in tests where actual and expected values were reversed (there might be other cases)

Out of scope and planned for other PR is:
- unify the iteration algorithms for rectangular, and non rectangular arrays, indexed and non indexed calbacks, map, forEach and reduce.
- improve the callback optimizers to pass the number of arguments (arity), add options to not optimize the error message (faster), find if there is a single signature matching the number of arguments, etc.

I did test the using a for loop instead of the array methods map and forEach but didn't find significant improvement (at least in node V22.11.0) so I skipped that part in this PR.