### PR TITLE
fix: issue in callback optimization and add error handling for invalid argument types

### DIFF
--- a/test/unit-tests/type/matrix/DenseMatrix.test.js
+++ b/test/unit-tests/type/matrix/DenseMatrix.test.js
@@ -753,6 +753,12 @@ describe('DenseMatrix', function () {
           ]
         ])
     })
+
+    it("should throw an error if it the typed function doesn't accept the type of argument", function () {
+      const matrix = new DenseMatrix([1, 'two'])
+      const callback = math.typed({ number: function (value) { return value + 1 } })
+      assert.throws(() => matrix.map(callback), /TypeError: Function map cannot apply callback arguments/)
+    })
   })
 
   describe('forEach', function () {

--- a/test/unit-tests/type/matrix/utils/deepMap.test.js
+++ b/test/unit-tests/type/matrix/utils/deepMap.test.js
@@ -53,6 +53,12 @@ describe('deepMap', function () {
     assert.deepStrictEqual(result, [math.complex(4, 6), [math.complex(8, 10)]])
   })
 
+  it("should throw an error if it the typed function doesn't accepth the type of argument", function () {
+    const array = [1, 'two']
+    const callback = math.typed({ number: function (value) { return value + 1 } })
+    assert.throws(() => deepMap(array, callback), /Error: Cannot convert "two" to a number/)
+  })
+
   // TODO: either deprecate the skipZeros option, or implement it for real
   // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('should skip zero values if skipZeros is true', function () {


### PR DESCRIPTION
This is a fix for #3390

If a matrix doesn't have a single type then the optimizeCallback function won't simplify the callback and try to find a single signature.