### PR TITLE
A faster DenseMatrix Symbol.iterator

### DIFF
--- a/src/type/matrix/DenseMatrix.js
+++ b/src/type/matrix/DenseMatrix.js
@@ -630,16 +630,34 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
    * @return {Iterable<{ value, index: number[] }>}
    */
   DenseMatrix.prototype[Symbol.iterator] = function * () {
-    const recurse = function * (value, index) {
-      if (isArray(value)) {
+    const maxDepth = this._size.length - 1
+
+    if (maxDepth < 0) {
+      return
+    }
+
+    if (maxDepth === 0) {
+      for (let i = 0; i < this._data.length; i++) {
+        yield ({ value: this._data[i], index: [i] })
+      }
+      return
+    }
+
+    const index = []
+    const recurse = function * (value, depth) {
+      if (depth < maxDepth) {
         for (let i = 0; i < value.length; i++) {
-          yield * recurse(value[i], index.concat(i))
+          index[depth] = i
+          yield * recurse(value[i], depth + 1)
         }
       } else {
-        yield ({ value, index })
+        for (let i = 0; i < value.length; i++) {
+          index[depth] = i
+          yield ({ value: value[i], index: index.slice() })
+        }
       }
     }
-    yield * recurse(this._data, [])
+    yield * recurse(this._data, 0)
   }
 
   /**

--- a/test/benchmark/forEach.js
+++ b/test/benchmark/forEach.js
@@ -43,6 +43,11 @@ const bench = new Bench({ time: 100, iterations: 100 })
   .add('numberMatrix.forEach(abs.signatures.number)', () => {
     numberMatrix.forEach(abs.signatures.number)
   })
+  .add('genericMatrix iterate', () => {
+    for (const v of genericMatrix) {
+      abs(v.value)
+    }
+  })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))
 await bench.run()

--- a/test/benchmark/map.js
+++ b/test/benchmark/map.js
@@ -43,6 +43,12 @@ const bench = new Bench({ time: 100, iterations: 100 })
   .add('numberMatrix.map(abs.signatures.number)', () => {
     numberMatrix.map(abs.signatures.number)
   })
+  .add('genericMatrix iterate', () => {
+    const result = genericMatrix.clone()
+    for (const v of genericMatrix) {
+      result.set(v.index, abs(v.value))
+    }
+  })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))
 await bench.run()


### PR DESCRIPTION
Hi,

This is a faster algorithm for doing Symbol.iterator and some benchmarks. It runs 3 to 4 times faster.

The main changes that increase speed are:

- Don't clone the index in every iteration (just on function calls) about 2.4 times faster
- Don't check if the last dimension is the last dimension on every element of the last dimension about 1.5 times faster
