### PR TITLE
Add missing eigsDependencies export to TypeScript definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4006,6 +4006,7 @@ export const {
   coulombDependencies,
   deuteronMassDependencies,
   efimovFactorDependencies,
+  eigsDependencies,
   electricConstantDependencies,
   electronMassDependencies,
   elementaryChargeDependencies,


### PR DESCRIPTION
I added the missing `eigsDependencies` entry to the exports in the type definitions. This should fix #3356.