### PR TITLE
fix: infer the correct type for 2D arrays in multiply function

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1525,7 +1525,8 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   const efg: MathArray = [1, 2, 3, 4, 5]
   const fgh: MathArray = [2, 3, 4, 5, 6]
 
-  const ijk: number[][] = [[1], [2], [3], [4]]
+  const ijk: number[] = [1, 2, 3, 4]
+  const lmn: number[][] = [[1], [2], [3], [4]]
 
   const Mbcd = math.matrix(bcd)
   const Mabc = math.matrix(abc)
@@ -1541,9 +1542,11 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   // 1D JS Array
   const r3 = math.multiply(abc, bcd) // 1D * 2D => Array
   const r3a = math.multiply(efg, fgh) // 1D * 1D => Scalar
+  const r3b = math.multiply(ijk, ijk) // 1D * 1D => Scalar
 
   const _r31 = r3[1]
   assert.strictEqual(typeof r3a, 'number')
+  assert.strictEqual(typeof r3b, 'number')
 
   // 2D JS Array
   const r12 = math.multiply(bcd, bcd)
@@ -1554,9 +1557,9 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
     const _r1211 = r12[1][1]
   }
 
-  const r131 = math.multiply(ijk, ijk)
+  const r12a = math.multiply(lmn, lmn)
 
-  const _r1400 = r131[0][0]
+  const _r12a00 = r12a[0][0]
 
   // Matrix: matrix * vector
   const r7 = math.multiply(Mabc, bcd)

--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -1525,6 +1525,8 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
   const efg: MathArray = [1, 2, 3, 4, 5]
   const fgh: MathArray = [2, 3, 4, 5, 6]
 
+  const ijk: number[][] = [[1], [2], [3], [4]]
+
   const Mbcd = math.matrix(bcd)
   const Mabc = math.matrix(abc)
 
@@ -1552,7 +1554,9 @@ Math types examples: Type results after multiplying  'MathTypes' with matrices
     const _r1211 = r12[1][1]
   }
 
-  const _r121 = r12[1]
+  const r131 = math.multiply(ijk, ijk)
+
+  const _r1400 = r131[0][0]
 
   // Matrix: matrix * vector
   const r7 = math.multiply(Mabc, bcd)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1454,9 +1454,10 @@ export interface MathJsInstance extends MathJsFactory {
   multiply<T extends Matrix>(x: T, y: MathType): Matrix
   multiply<T extends Matrix>(x: MathType, y: T): Matrix
 
+  // multiply<T extends MathGeneric[][]>(x: T, y: T): T
   multiply<T extends MathArray>(x: T, y: T[]): T
   multiply<T extends MathArray>(x: T[], y: T): T
-  multiply<T extends MathArray>(x: T[], y: T[]): T
+  multiply<T extends MathArray>(x: T[], y: T[]): T[]
   multiply<T extends MathArray>(x: T, y: T): MathScalarType
   multiply(x: Unit, y: Unit): Unit
   multiply(x: number, y: number): number


### PR DESCRIPTION
# Description
- Addresses: https://github.com/josdejong/mathjs/issues/3406

## Test
- Added test based on issue example

### Assumptions
- Assumes that multiplication of arrays of the same dimensionality greater than 1 results in an array of the same dimensionality. (I believe that we currently only support the multiplication of matrix/arrays of D <= 2)