### PR TITLE
fix: #3422 parse dot operators after an implicit multiplication with symbol E

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -420,7 +420,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
           if (parse.isDecimalMark(currentCharacter(state), nextCharacter(state))) {
             throw createSyntaxError(state, 'Digit expected, got "' + currentCharacter(state) + '"')
           }
-        } else if (nextCharacter(state) === '.') {
+        } else if (parse.isDecimalMark(nextCharacter(state), state.expression.charAt(state.index + 2))) {
           next(state)
           throw createSyntaxError(state, 'Digit expected, got "' + currentCharacter(state) + '"')
         }

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -290,6 +290,21 @@ describe('parse', function () {
       approxEqual(parseAndEval('2e'), 2 * Math.E)
     })
 
+    it('should parse dot operators after a value', function () {
+      approxEqual(parseAndEval('2.*3'), 6)
+      approxEqual(parseAndEval('2./3'), 2 / 3)
+      approxEqual(parseAndEval('2.^3'), 2 ** 3)
+    })
+
+    it('should parse dot operators after an implicit multiplication with symbol E', function () {
+      approxEqual(parseAndEval('2E.*3'), 2 * Math.E * 3)
+      approxEqual(parseAndEval('2E./3'), 2 * Math.E / 3)
+      approxEqual(parseAndEval('2E.^3'), 2 * Math.E ** 3)
+      approxEqual(parseAndEval('2e.*3'), 2 * Math.E * 3)
+      approxEqual(parseAndEval('2e./3'), 2 * Math.E / 3)
+      approxEqual(parseAndEval('2e.^3'), 2 * Math.E ** 3)
+    })
+
     it('should throw an error with invalid numbers', function () {
       assert.throws(function () { parseAndEval('.') }, /Value expected/)
       assert.throws(function () { parseAndEval('3.2.2') }, SyntaxError)


### PR DESCRIPTION
Fixes #3422.

@gwhitney can you review this fix?