### PR TITLE
feat: give unary % operator (percentage) higher precedence than binary % operator (modulus)

### DIFF
--- a/docs/expressions/syntax.md
+++ b/docs/expressions/syntax.md
@@ -114,8 +114,9 @@ Operators                         | Description
 `!`                               | Factorial
 `^`, `.^`                         | Exponentiation
 `+`, `-`, `~`, `not`              | Unary plus, unary minus, bitwise not, logical not
+`%`                               | Unary percentage
 See section below                 | Implicit multiplication
-`*`, `/`, `.*`, `./`,`%`, `mod`   | Multiply, divide , percentage, modulus
+`*`, `/`, `.*`, `./`,`%`, `mod`   | Multiply, divide, modulus
 `+`, `-`                          | Add, subtract
 `:`                               | Range
 `to`, `in`                        | Unit conversion
@@ -134,8 +135,8 @@ See section below                 | Implicit multiplication
 `\n`, `;`                         | Statement separators
 
 Lazy evaluation is used where logically possible for bitwise and logical
-operators. In the following example, the value of `x` will not even be 
-evaluated because it cannot effect the final result: 
+operators. In the following example, the value of `x` will not even be
+evaluated because it cannot effect the final result:
 ```js
 math.evaluate('false and x')        // false, no matter what x equals
 ```
@@ -652,7 +653,7 @@ at 1, when the end is undefined, the range will end at the end of the matrix.
 
 There is a context variable `end` available as well to denote the end of the
 matrix. This variable cannot be used in multiple nested indices. In that case,
-`end` will be resolved as the end of the innermost matrix. To solve this, 
+`end` will be resolved as the end of the innermost matrix. To solve this,
 resolving of the nested index needs to be split in two separate operations.
 
 *IMPORTANT: matrix indexes and ranges work differently from the math.js indexes

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1001,7 +1001,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
   function parseAddSubtract (state) {
     let node, name, fn, params
 
-    node = parseMultiplyDivideModulusPercentage(state)
+    node = parseMultiplyDivideModulus(state)
 
     const operators = {
       '+': 'add',
@@ -1012,7 +1012,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
       fn = operators[name]
 
       getTokenSkipNewline(state)
-      const rightNode = parseMultiplyDivideModulusPercentage(state)
+      const rightNode = parseMultiplyDivideModulus(state)
       if (rightNode.isPercentage) {
         params = [node, new OperatorNode('*', 'multiply', [node, rightNode])]
       } else {
@@ -1025,11 +1025,11 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
   }
 
   /**
-   * multiply, divide, modulus, percentage
+   * multiply, divide, modulus
    * @return {Node} node
    * @private
    */
-  function parseMultiplyDivideModulusPercentage (state) {
+  function parseMultiplyDivideModulus (state) {
     let node, last, name, fn
 
     node = parseImplicitMultiplication(state)
@@ -1053,17 +1053,8 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         getTokenSkipNewline(state)
 
         if (name === '%' && state.tokenType === TOKENTYPE.DELIMITER && state.token !== '(') {
-          // If the expression contains only %, then treat that as /100
-          if (state.token !== '' && operators[state.token]) {
-            const left = new OperatorNode('/', 'divide', [node, new ConstantNode(100)], false, true)
-            name = state.token
-            fn = operators[name]
-            getTokenSkipNewline(state)
-            last = parseImplicitMultiplication(state)
-
-            node = new OperatorNode(name, fn, [left, last])
-          } else { node = new OperatorNode('/', 'divide', [node, new ConstantNode(100)], false, true) }
-          // return node
+          // This % cannot be interpreted as a modulus, and it wasn't handled by parseUnaryPostfix
+          throw createSyntaxError(state, 'Unexpected operator %')
         } else {
           last = parseImplicitMultiplication(state)
           node = new OperatorNode(name, fn, [node, last])
@@ -1120,7 +1111,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    * @private
    */
   function parseRule2 (state) {
-    let node = parseUnary(state)
+    let node = parseUnaryPercentage(state)
     let last = node
     const tokenStates = []
 
@@ -1143,7 +1134,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
             // Rewind once and build the "number / number" node; the symbol will be consumed later
             Object.assign(state, tokenStates.pop())
             tokenStates.pop()
-            last = parseUnary(state)
+            last = parseUnaryPercentage(state)
             node = new OperatorNode('/', 'divide', [node, last])
           } else {
             // Not a match, so rewind
@@ -1158,6 +1149,38 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         }
       } else {
         break
+      }
+    }
+
+    return node
+  }
+
+  /**
+   * Unary percentage operator (treated as `value / 100`)
+   * @return {Node} node
+   * @private
+   */
+  function parseUnaryPercentage (state) {
+    let node
+
+    node = parseUnary(state)
+
+    const operators = {
+      '%': 'unaryPercentage'
+    }
+
+    if (hasOwnProperty(operators, state.token)) {
+      const name = state.token
+
+      const previousState = Object.assign({}, state)
+      getTokenSkipNewline(state)
+
+      if (name === '%' && state.tokenType === TOKENTYPE.DELIMITER && state.token !== '(') {
+        // This is unary postfix %, then treat that as /100
+        node = new OperatorNode('/', 'divide', [node, new ConstantNode(100)], false, true)
+      } else {
+        // Not a match, so rewind
+        Object.assign(state, previousState)
       }
     }
 

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1161,21 +1161,13 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    * @private
    */
   function parseUnaryPercentage (state) {
-    let node
+    let node = parseUnary(state)
 
-    node = parseUnary(state)
-
-    const operators = {
-      '%': 'unaryPercentage'
-    }
-
-    if (hasOwnProperty(operators, state.token)) {
-      const name = state.token
-
+    if (state.token === '%') {
       const previousState = Object.assign({}, state)
       getTokenSkipNewline(state)
 
-      if (name === '%' && state.tokenType === TOKENTYPE.DELIMITER && state.token !== '(') {
+      if (state.tokenType === TOKENTYPE.DELIMITER && state.token !== '(') {
         // This is unary postfix %, then treat that as /100
         node = new OperatorNode('/', 'divide', [node, new ConstantNode(100)], false, true)
       } else {

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -1370,18 +1370,29 @@ describe('parse', function () {
     })
 
     it('should parse % with division', function () {
-      approxEqual(parseAndEval('100/50%'), 0.02) // should be treated as ((100/50)%)
-      approxEqual(parseAndEval('100/50%*2'), 0.04) // should be treated as ((100/50)%))×2
+      approxEqual(parseAndEval('100/50%'), 200) // should be treated as 100/(50%)
+      approxEqual(parseAndEval('100/50%*2'), 400) // should be treated as (100/(50%))×2
       approxEqual(parseAndEval('50%/100'), 0.005)
+      approxEqual(parseAndEval('50%(13)'), 11) // should be treated as 50 % (13)
       assert.throws(function () { parseAndEval('50%(/100)') }, /Value expected/)
     })
 
-    it('should parse % with addition', function () {
+    it('should parse unary % before division, binary % with division', function () {
+      approxEqual(parseAndEval('10/200%%3'), 2) // should be treated as (10/(200%))%3
+    })
+
+    it('should reject repeated unary percentage operators', function () {
+      assert.throws(function () { math.parse('17%%') }, /Unexpected operator %/)
+      assert.throws(function () { math.parse('17%%*5') }, /Unexpected operator %/)
+      assert.throws(function () { math.parse('10/200%%%3') }, /Unexpected operator %/)
+    })
+
+    it('should parse unary % with addition', function () {
       approxEqual(parseAndEval('100+3%'), 103)
       approxEqual(parseAndEval('3%+100'), 100.03)
     })
 
-    it('should parse % with subtraction', function () {
+    it('should parse unary % with subtraction', function () {
       approxEqual(parseAndEval('100-3%'), 97)
       approxEqual(parseAndEval('3%-100'), -99.97)
     })
@@ -1390,12 +1401,12 @@ describe('parse', function () {
       approxEqual(parseAndEval('8 mod 3'), 2)
     })
 
-    it('should give equal precedence to % and * operators', function () {
+    it('should give equal precedence to binary % and * operators', function () {
       approxEqual(parseAndStringifyWithParens('10 % 3 * 2'), '(10 % 3) * 2')
       approxEqual(parseAndStringifyWithParens('10 * 3 % 4'), '(10 * 3) % 4')
     })
 
-    it('should give equal precedence to % and / operators', function () {
+    it('should give equal precedence to binary % and / operators', function () {
       approxEqual(parseAndStringifyWithParens('10 % 4 / 2'), '(10 % 4) / 2')
       approxEqual(parseAndStringifyWithParens('10 / 2 % 3'), '(10 / 2) % 3')
     })
@@ -1410,12 +1421,12 @@ describe('parse', function () {
       approxEqual(parseAndStringifyWithParens('8 / 3 mod 2'), '(8 / 3) mod 2')
     })
 
-    it('should give equal precedence to % and .* operators', function () {
+    it('should give equal precedence to binary % and .* operators', function () {
       approxEqual(parseAndStringifyWithParens('10 % 3 .* 2'), '(10 % 3) .* 2')
       approxEqual(parseAndStringifyWithParens('10 .* 3 % 4'), '(10 .* 3) % 4')
     })
 
-    it('should give equal precedence to % and ./ operators', function () {
+    it('should give equal precedence to binary % and ./ operators', function () {
       approxEqual(parseAndStringifyWithParens('10 % 4 ./ 2'), '(10 % 4) ./ 2')
       approxEqual(parseAndStringifyWithParens('10 ./ 2 % 3'), '(10 ./ 2) % 3')
     })


### PR DESCRIPTION
This is a fix/change to https://github.com/josdejong/mathjs/discussions/3349

This gives unary `%` operator (percentage) higher precedence than binary `%` operator (modulo). This also makes unary `%` operator have higher precedence than `*`, `/`, `.*`, `./`, and `mod` operators.

This partially rolls back changes from #3311; however, intended behavior from that change is preserved: the precedence of binary `%` operator (modulo) has _not_ changed. For example, `11*12%13` is still treated as `(11*12)%13`, whereas in MathJS v13 it was treated as `11*(12%13)`.

# Breaking Change

This is a **BREAKING CHANGE** and should get a new major version:

- v13: `100 / 50%` = `100 / (50%)` = `100 / 0.5` = `200`
- v14: `100 / 50%` = `(100 / 50)%` = `2%` = `0.02`
- this PR: `100 / 50%` = `100 / (50%)` = `100 / 0.5` = `200` _(restores v13 behavior in this scenario)_

Another example where 13/14/PR behavior are all different:

- MathJS v13: `10 / 200 % % 3` = `10 / ((200%) % 3)` = `10 / (2 % 3)` = `10 / 2` = `5`
- MathJS v14: `10 / 200 % % 3` = `((10 / 200)%) % 3` = `((0.05)%) % 3` = `0.0005 % 3` = `0.0005`
- This PR: `10 / 200 % % 3` = `(10 / (200%)) % 3` = `(10 / 2) % 3` = `5 % 3` = `2`

-------

Additional change:

`200%%` previously failed with `Unexpected end of expression (char 5)` error; with this PR it fails with `Unexpected operator % (char 5)` error. (This was intentional as I believe it is a clearer error.)

-------

# Additional comments

I looked into ways of handling something like `200%%%` = `(200%)%)%` = `((2)%)%` = `(0.02)%` = `0.0002`, but I couldn't find a way to make it work without breaking other tests. Given that it was already an error in previous version, and it's unlikely (in my estimation) that someone would actually want to do that, I didn't investigate further into fixing.

Additionally, I found that `5%(13)` is treated as `5 mod 13` rather than `(5%) * 13` (implicit multiplication). My PR doesn't change this behavior, and I believe it is actually desirable because the parser doesn't care about whitespace so `5%(13)` and `5% (13)` and `5 % (13)` are all handled the same way. But it may technically be wrong based on the operator precedence documented in `syntax.md`.