### PR TITLE
feat: add LaTeX representation for fractions and corresponding tests

### DIFF
--- a/src/utils/latex.js
+++ b/src/utils/latex.js
@@ -124,6 +124,7 @@ export const latexFunctions = {
   expm1: `\\left(e${latexOperators.pow}{\${args[0]}}-1\\right)`,
   fix: { 1: '\\mathrm{${name}}\\left(${args[0]}\\right)' },
   floor: { 1: '\\left\\lfloor${args[0]}\\right\\rfloor' },
+  fraction: { 2: '\\frac{${args[0]}}{${args[1]}}' },
   gcd: '\\gcd\\left(${args}\\right)',
   hypot: '\\hypot\\left(${args}\\right)',
   log: {

--- a/test/unit-tests/type/fraction/function/fraction.test.js
+++ b/test/unit-tests/type/fraction/function/fraction.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
-import math from '../../../../../src/defaultInstance.js'
 import Fraction from 'fraction.js'
+import math from '../../../../../src/defaultInstance.js'
 
 describe('fraction', function () {
   it('should create a fraction', function () {
@@ -80,6 +80,13 @@ describe('fraction', function () {
     assert.throws(function () { math.fraction(Infinity) }, /Error: Infinity cannot be represented as a fraction/)
     assert.throws(function () { math.fraction(-Infinity) }, /Error: -Infinity cannot be represented as a fraction/)
     assert.throws(function () { math.fraction(NaN) }, /Error: NaN cannot be represented as a fraction/)
+  })
+
+  it('should show a Latex Fraction as one over another', function () {
+    const node1 = math.parse('fraction(1,2)')
+    assert.strictEqual(node1.toTex(), '\\frac{1}{2}')
+    const node2 = math.parse('fraction(a,b)')
+    assert.strictEqual(node2.toTex(), '\\frac{ a}{\\mathrm{b}}')
   })
 })
 


### PR DESCRIPTION
# Description
- Addresses #3419 
- Adds fractions to the list of latex functions

## Test
- Added a test to ensure toTex results are changed as expected

### Additional Notes
- Please let me know if I missed any points of documentation that are necessary.
- For the test `math.parse(fraction(a,b)).toTex()` I got back => `\\frac{ a}{\\mathrm{b}}` I assume this is the expected behaviour.