### PR TITLE
Dense matrix increase performance of map and forEach

### DIFF
--- a/src/type/matrix/DenseMatrix.js
+++ b/src/type/matrix/DenseMatrix.js
@@ -546,8 +546,8 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
     const fastCallback = optimizeCallback(callback, me, 'map', isUnary)
     const fastCallbackFn = fastCallback.fn
 
-    const result = me.create(undefined, me._datatype).resize(me._size)
-
+    const result = me.create(undefined, me._datatype)
+    result._size = me._size
     if (isUnary || fastCallback.isUnary) {
       result._data = iterateUnary(me._data)
       return result


### PR DESCRIPTION
Hi,

This PR includes performance improvements in both `.map` and `.forEach` methods in DenseMatrix by separating the logic and avoiding cloning of a matrix. Opting for a create and resize.

![Sin título](https://github.com/user-attachments/assets/5374e3ac-05e5-43b2-8c2d-9109fb4af3f2)

# Data
```
# develop map

abs(genericMatrix)                               2.03 µs   ±0.17%
abs(array)                                       1.11 µs   ±0.53%
abs(numberMatrix)                                2.06 µs   ±0.18%
genericMatrix.map(abs)                           5.14 µs   ±0.18%
numberMatrix.map(abs)                            5.17 µs   ±0.18%
map(genericMatrix, abs)                          5.18 µs   ±0.17%
map(numberMatrix, abs)                           5.21 µs   ±0.20%
map(array, abs)                                  4.33 µs   ±0.17%
map(array, abs.signatures.number)                1.79 µs   ±0.31%
genericMatrix.map(abs.signatures.number)         2.27 µs   ±0.23%
numberMatrix.map(abs.signatures.number)          2.25 µs   ±0.50%
genericMatrix iterate                            8.78 µs   ±1.14%

# develop forEach

abs(genericMatrix)                               2.03 µs   ±0.29%
abs(array)                                       0.86 µs   ±0.16%
abs(numberMatrix)                                2.04 µs   ±0.17%
genericMatrix.forEach(abs)                       4.06 µs   ±0.19%
numberMatrix.forEach(abs)                        4.07 µs   ±0.18%
forEach(genericMatrix, abs)                      4.06 µs   ±0.29%
forEach(numberMatrix, abs)                       4.05 µs   ±0.18%
forEach(array, abs)                              3.94 µs   ±0.19%
forEach(array, abs.signatures.number)            1.56 µs   ±0.18%
genericMatrix.forEach(abs.signatures.number)     1.11 µs   ±0.26%
numberMatrix.forEach(abs.signatures.number)      1.11 µs   ±0.27%
genericMatrix iterate                            5.84 µs   ±0.93%

# PR map

abs(genericMatrix)                               1.27 µs   ±0.22%
abs(array)                                       1.13 µs   ±1.67%
abs(numberMatrix)                                1.28 µs   ±0.17%
genericMatrix.map(abs)                           4.36 µs   ±0.22%
numberMatrix.map(abs)                            4.30 µs   ±0.20%
map(genericMatrix, abs)                          4.32 µs   ±0.18%
map(numberMatrix, abs)                           4.35 µs   ±0.29%
map(array, abs)                                  4.28 µs   ±0.20%
map(array, abs.signatures.number)                1.71 µs   ±0.31%
genericMatrix.map(abs.signatures.number)         1.51 µs   ±0.35%
numberMatrix.map(abs.signatures.number)          1.49 µs   ±0.27%
genericMatrix iterate                            8.87 µs   ±0.67%

# PR forEach

abs(genericMatrix)                               1.08 µs   ±0.19%
abs(array)                                       0.90 µs   ±0.32%
abs(numberMatrix)                                1.05 µs   ±0.94%
genericMatrix.forEach(abs)                       3.62 µs   ±0.18%
numberMatrix.forEach(abs)                        3.69 µs   ±0.35%
forEach(genericMatrix, abs)                      3.68 µs   ±0.30%
forEach(numberMatrix, abs)                       3.64 µs   ±0.21%
forEach(array, abs)                              3.86 µs   ±0.16%
forEach(array, abs.signatures.number)            1.53 µs   ±0.15%
genericMatrix.forEach(abs.signatures.number)     0.85 µs   ±0.06%
numberMatrix.forEach(abs.signatures.number)      0.84 µs   ±1.02%
genericMatrix iterate                            6.02 µs   ±1.43%
```
Plotting all tests
![Sin título](https://github.com/user-attachments/assets/361309eb-9a7a-456a-b59e-0585df14189c)
