### PR TITLE
fix: the internal number conversion inside `Unit` can throw an exception

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 # Unpublished changes since 14.4.0
 
+- Fix: #3450 support multiplication of valueless units by arbitrary types
+  (#3454).
 - Feat: increase performance of the `map` and `forEach` methods of 
   `DenseMatrix` (#3446). Thanks @dvd101x.
 

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -657,8 +657,13 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
 
     // If at least one operand has a value, then the result should also have a value
     if (this.value !== null || other.value !== null) {
-      const valThis = this.value === null ? this._normalize(1) : this.value
-      const valOther = other.value === null ? other._normalize(1) : other.value
+      const valThis = this.value === null
+        ? this._normalize(convertToTypeOf(1, other.value))
+        : this.value
+      const valOther = other.value === null
+        ? other._normalize(convertToTypeOf(1, this.value))
+        : other.value
+
       res.value = multiplyScalar(valThis, valOther)
     } else {
       res.value = null
@@ -709,8 +714,12 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
 
     // If at least one operand has a value, the result should have a value
     if (this.value !== null || other.value !== null) {
-      const valThis = this.value === null ? this._normalize(1) : this.value
-      const valOther = other.value === null ? other._normalize(1) : other.value
+      const valThis = this.value === null
+        ? this._normalize(convertToTypeOf(1, other.value))
+        : this.value
+      const valOther = other.value === null
+        ? other._normalize(convertToTypeOf(1, this.value))
+        : other.value
       res.value = divideScalar(valThis, valOther)
     } else {
       res.value = null
@@ -770,6 +779,23 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
     } else {
       return unit
     }
+  }
+
+  /**
+   * convert `value` into the numeric type of `typeOfValue`.
+   * For example convertToTypeOf(2, new BigNumber(3)) returns a BigNumber(2)
+   * @param {number | Fraction | BigNumber} value
+   * @param {number | Fraction | BigNumber} typeOfValue
+   * @returns {number | Fraction | BigNumber}
+   */
+  function convertToTypeOf (value, typeOfValue) {
+    // TODO: this is a workaround to prevent the following BigNumber conversion error from throwing:
+    //  "TypeError: Cannot implicitly convert a number with >15 significant digits to BigNumber"
+    //  see https://github.com/josdejong/mathjs/issues/3450
+    //      https://github.com/josdejong/mathjs/pull/3375
+    const convert = Unit._getNumberConverter(typeOf(typeOfValue))
+
+    return convert(value)
   }
 
   /**

--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -657,12 +657,8 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
 
     // If at least one operand has a value, then the result should also have a value
     if (this.value !== null || other.value !== null) {
-      const valThis = this.value === null
-        ? this._normalize(convertToTypeOf(1, other.value))
-        : this.value
-      const valOther = other.value === null
-        ? other._normalize(convertToTypeOf(1, this.value))
-        : other.value
+      const valThis = this.value === null ? this._normalize(one(other.value)) : this.value
+      const valOther = other.value === null ? other._normalize(one(this.value)) : other.value
 
       res.value = multiplyScalar(valThis, valOther)
     } else {
@@ -714,12 +710,8 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
 
     // If at least one operand has a value, the result should have a value
     if (this.value !== null || other.value !== null) {
-      const valThis = this.value === null
-        ? this._normalize(convertToTypeOf(1, other.value))
-        : this.value
-      const valOther = other.value === null
-        ? other._normalize(convertToTypeOf(1, this.value))
-        : other.value
+      const valThis = this.value === null ? this._normalize(one(other.value)) : this.value
+      const valOther = other.value === null ? other._normalize(one(this.value)) : other.value
       res.value = divideScalar(valThis, valOther)
     } else {
       res.value = null
@@ -782,20 +774,19 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
   }
 
   /**
-   * convert `value` into the numeric type of `typeOfValue`.
-   * For example convertToTypeOf(2, new BigNumber(3)) returns a BigNumber(2)
-   * @param {number | Fraction | BigNumber} value
+   * Create a value one with the numeric type of `typeOfValue`.
+   * For example, `one(new BigNumber(3))` returns `BigNumber(1)`
    * @param {number | Fraction | BigNumber} typeOfValue
    * @returns {number | Fraction | BigNumber}
    */
-  function convertToTypeOf (value, typeOfValue) {
+  function one (typeOfValue) {
     // TODO: this is a workaround to prevent the following BigNumber conversion error from throwing:
     //  "TypeError: Cannot implicitly convert a number with >15 significant digits to BigNumber"
     //  see https://github.com/josdejong/mathjs/issues/3450
     //      https://github.com/josdejong/mathjs/pull/3375
     const convert = Unit._getNumberConverter(typeOf(typeOfValue))
 
-    return convert(value)
+    return convert(1)
   }
 
   /**

--- a/test/unit-tests/type/unit/Unit.test.js
+++ b/test/unit-tests/type/unit/Unit.test.js
@@ -1098,12 +1098,20 @@ describe('Unit', function () {
       assert.deepStrictEqual(unit4.divide(unit5), unit6)
     })
 
-    it('should multiply a unit having a number value with a BigNumber', function () {
-      assert.deepStrictEqual(new Unit(null, 'fahrenheit').multiply(math.bignumber(123)).format(12), '123 fahrenheit')
+    it('should multiply valueless units by any supported numeric type', function () {
+      const valuelessF = new Unit(null, 'fahrenheit')
+      assert.strictEqual(valuelessF.multiply(math.bignumber(123)).format(12), '123 fahrenheit')
+      assert.strictEqual(valuelessF.multiply(math.fraction(123, 2)).format(12), '123/2 fahrenheit')
+      assert.strictEqual(valuelessF.multiply(math.complex(123, 123)).format(12), '(123 + 123i) fahrenheit')
+      assert.strictEqual(valuelessF.multiply(123).format(12), '123 fahrenheit')
     })
 
-    it('should divide a unit having a number value with a BigNumber', function () {
-      assert.deepStrictEqual(new Unit(null, 'fahrenheit').divide(math.bignumber(1).div(123)).format(12), '123 fahrenheit')
+    it('should divide valueless units by any supported numeric type', function () {
+      const valuelessF = new Unit(null, 'fahrenheit')
+      assert.strictEqual(valuelessF.divide(math.bignumber(1).div(123)).format(12), '123 fahrenheit')
+      assert.strictEqual(valuelessF.divide(math.fraction(2, 123)).format(12), '123/2 fahrenheit')
+      assert.strictEqual(valuelessF.divide(math.complex(0.25, 0.25)).format(12), '(2 - 2i) fahrenheit')
+      assert.strictEqual(valuelessF.divide(1 / 123).format(12), '123 fahrenheit')
     })
 
     // eslint-disable-next-line mocha/no-skipped-tests

--- a/test/unit-tests/type/unit/Unit.test.js
+++ b/test/unit-tests/type/unit/Unit.test.js
@@ -1098,6 +1098,14 @@ describe('Unit', function () {
       assert.deepStrictEqual(unit4.divide(unit5), unit6)
     })
 
+    it('should multiply a unit having a number value with a BigNumber', function () {
+      assert.deepStrictEqual(new Unit(null, 'fahrenheit').multiply(math.bignumber(123)).format(12), '123 fahrenheit')
+    })
+
+    it('should divide a unit having a number value with a BigNumber', function () {
+      assert.deepStrictEqual(new Unit(null, 'fahrenheit').divide(math.bignumber(1).div(123)).format(12), '123 fahrenheit')
+    })
+
     // eslint-disable-next-line mocha/no-skipped-tests
     it.skip('should cancel units in numerator and denominator', function () {
       assert.strictEqual(math.evaluate('2 J/K/g * 2 g').toString(), '4 J / K')


### PR DESCRIPTION
This is a workaround for #3450.

Note that for the `.multiply` method, it is possible to elimitate the temporarily introduced numbers `1`, but for `.divide` that isn't possible, therefore I kept using the `1` values in both.