### PR TITLE
Fix multiplication of arrays with units

### DIFF
--- a/src/function/complex/conj.js
+++ b/src/function/complex/conj.js
@@ -25,13 +25,13 @@ export const createConj = /* #__PURE__ */ factory(name, dependencies, ({ typed }
    *
    *    re, im, arg, abs
    *
-   * @param {number | BigNumber | Complex | Array | Matrix} x
+   * @param {number | BigNumber | Complex | Array | Matrix | Unit} x
    *            A complex number or array with complex numbers
-   * @return {number | BigNumber | Complex | Array | Matrix}
+   * @return {number | BigNumber | Complex | Array | Matrix | Unit}
    *            The complex conjugate of x
    */
   return typed(name, {
-    'number | BigNumber | Fraction': x => x,
+    'number | BigNumber | Fraction | Unit': x => x,
     Complex: x => x.conjugate(),
     'Array | Matrix': typed.referToSelf(self => x => deepMap(x, self))
   })

--- a/test/unit-tests/function/arithmetic/multiply.test.js
+++ b/test/unit-tests/function/arithmetic/multiply.test.js
@@ -318,6 +318,19 @@ describe('multiply', function () {
       approxDeepEqual(multiply(matrix(a), matrix(b)), 32)
     })
 
+    it('should multiply vectors with units correctly (dot product)', function () {
+      const a = [1, 2, 3]
+      const b = [unit('4cm'), unit('5cm'), unit('6cm')]
+
+      approxDeepEqual(multiply(a, b), unit('32cm'))
+      approxDeepEqual(multiply(matrix(a), matrix(b)), unit('32cm'))
+
+      const e = [unit('1cm'), unit('2cm'), unit('3cm')]
+
+      assert.strictEqual(multiply(e, b).format(5), '32 cm^2')
+      assert.strictEqual(multiply(matrix(e), matrix(b)).format(5), '32 cm^2')
+    })
+
     it('should conjugate the first argument in dot product', function () {
       const a = [complex(1, 2), complex(3, 4)]
       const b = [complex(5, 6), complex(7, 8)]

--- a/test/unit-tests/function/complex/conj.test.js
+++ b/test/unit-tests/function/complex/conj.test.js
@@ -26,6 +26,7 @@ describe('conj', function () {
     assert.strictEqual(conj(math.complex('2')).toString(), '2')
     assert.strictEqual(conj(math.complex('-4i')).toString(), '4i')
     assert.strictEqual(conj(math.i).toString(), '-i')
+    assert.strictEqual(conj(math.unit('5cm')).toString(), '5 cm')
   })
 
   it('should calculate the conjugate for each element in a matrix', function () {
@@ -37,7 +38,6 @@ describe('conj', function () {
 
   it('should throw an error when called with an unsupported type of argument', function () {
     assert.throws(function () { conj(new Date()) }, /TypeError: Unexpected type of argument/)
-    assert.throws(function () { conj(math.unit('5cm')) }, /TypeError: Unexpected type of argument/)
   })
 
   it('should throw an error in case of invalid number of arguments', function () {


### PR DESCRIPTION
Add `Unit` as an accepted type for  complex conjugate `conj`