### PR TITLE
fix: #3421 require a space or delimiter after hex, bin, and oct values

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -346,7 +346,10 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         next(state)
         state.token += currentCharacter(state)
         next(state)
-        while (parse.isHexDigit(currentCharacter(state))) {
+        while (
+          parse.isAlpha(currentCharacter(state), prevCharacter(state), nextCharacter(state)) ||
+          parse.isDigit(currentCharacter(state))
+        ) {
           state.token += currentCharacter(state)
           next(state)
         }
@@ -355,7 +358,10 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
           state.token += '.'
           next(state)
           // get the digits after the radix
-          while (parse.isHexDigit(currentCharacter(state))) {
+          while (
+            parse.isAlpha(currentCharacter(state), prevCharacter(state), nextCharacter(state)) ||
+            parse.isDigit(currentCharacter(state))
+          ) {
             state.token += currentCharacter(state)
             next(state)
           }
@@ -572,17 +578,6 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    */
   parse.isDigit = function isDigit (c) {
     return (c >= '0' && c <= '9')
-  }
-
-  /**
-   * checks if the given char c is a hex digit
-   * @param {string} c   a string with one character
-   * @return {boolean}
-   */
-  parse.isHexDigit = function isHexDigit (c) {
-    return ((c >= '0' && c <= '9') ||
-            (c >= 'a' && c <= 'f') ||
-            (c >= 'A' && c <= 'F'))
   }
 
   /**

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -287,18 +287,18 @@ describe('parse', function () {
     })
 
     it('should require hex, bin, oct values to be followed by whitespace or a delimiter', function () {
-      assert.throws(() => parseAndEval('0b0a'), /SyntaxError: String "0b0a" is not a valid number/ )
-      assert.throws(() => parseAndEval('0x1k'), /SyntaxError: String "0x1k" is not a valid number/ )
-      assert.throws(() => parseAndEval('0o1k'), /SyntaxError: String "0o1k" is not a valid number/ )
-      assert.throws(() => parseAndEval('0b1k'), /SyntaxError: String "0b1k" is not a valid number/ )
+      assert.throws(() => parseAndEval('0b0a'), /SyntaxError: String "0b0a" is not a valid number/)
+      assert.throws(() => parseAndEval('0x1k'), /SyntaxError: String "0x1k" is not a valid number/)
+      assert.throws(() => parseAndEval('0o1k'), /SyntaxError: String "0o1k" is not a valid number/)
+      assert.throws(() => parseAndEval('0b1k'), /SyntaxError: String "0b1k" is not a valid number/)
 
-      assert.strictEqual(parseAndEval('0x1 k', { k: 2}), 2 )
-      assert.strictEqual(parseAndEval('0o1 k', { k: 2}), 2 )
-      assert.strictEqual(parseAndEval('0b1 k', { k: 2}), 2 )
+      assert.strictEqual(parseAndEval('0x1 k', { k: 2 }), 2)
+      assert.strictEqual(parseAndEval('0o1 k', { k: 2 }), 2)
+      assert.strictEqual(parseAndEval('0b1 k', { k: 2 }), 2)
 
-      assert.strictEqual(parseAndEval('0x1 * k', { k: 2}), 2 )
-      assert.strictEqual(parseAndEval('0o1 * k', { k: 2}), 2 )
-      assert.strictEqual(parseAndEval('0b1 * k', { k: 2}), 2 )
+      assert.strictEqual(parseAndEval('0x1*k', { k: 2 }), 2)
+      assert.strictEqual(parseAndEval('0o1*k', { k: 2 }), 2)
+      assert.strictEqual(parseAndEval('0b1*k', { k: 2 }), 2)
     })
 
     it('should parse a number followed by e', function () {

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -286,6 +286,21 @@ describe('parse', function () {
       assert.strictEqual(parseAndEval('0x1.'), 1)
     })
 
+    it('should require hex, bin, oct values to be followed by whitespace or a delimiter', function () {
+      assert.throws(() => parseAndEval('0b0a'), /SyntaxError: String "0b0a" is not a valid number/ )
+      assert.throws(() => parseAndEval('0x1k'), /SyntaxError: String "0x1k" is not a valid number/ )
+      assert.throws(() => parseAndEval('0o1k'), /SyntaxError: String "0o1k" is not a valid number/ )
+      assert.throws(() => parseAndEval('0b1k'), /SyntaxError: String "0b1k" is not a valid number/ )
+
+      assert.strictEqual(parseAndEval('0x1 k', { k: 2}), 2 )
+      assert.strictEqual(parseAndEval('0o1 k', { k: 2}), 2 )
+      assert.strictEqual(parseAndEval('0b1 k', { k: 2}), 2 )
+
+      assert.strictEqual(parseAndEval('0x1 * k', { k: 2}), 2 )
+      assert.strictEqual(parseAndEval('0o1 * k', { k: 2}), 2 )
+      assert.strictEqual(parseAndEval('0b1 * k', { k: 2}), 2 )
+    })
+
     it('should parse a number followed by e', function () {
       approxEqual(parseAndEval('2e'), 2 * Math.E)
     })
@@ -334,7 +349,7 @@ describe('parse', function () {
 
       assert.throws(function () { parseAndEval('0b123.45') }, /SyntaxError: String "0b123\.45" is not a valid number/)
       assert.throws(function () { parseAndEval('0o89.89') }, /SyntaxError: String "0o89\.89" is not a valid number/)
-      assert.throws(function () { parseAndEval('0xghji.xyz') }, /SyntaxError: String "0x" is not a valid number/)
+      assert.throws(function () { parseAndEval('0xghji.xyz') }, /SyntaxError: String "0xghji.xyz" is not a valid number/)
     })
   })
 


### PR DESCRIPTION
Fixes #3421

A simple solution is to not only parse hex characters, but just parse any alpha and digit character after the prefix `0x`, `0o`, or `0x`, and then try to parse the string into a number. When evaluating `0x1k`, this will give an error messate "SyntaxError: String "0x1k" is not a valid number". 

An alternative solution would be to create separate flows for parsing `hex`, `oct`, and `bin`, with specific functions `isHexDigit`, `isOctDigit` and `isBinDigit`, and then we need a separate check to see if the value is followed by an alpha or digit character and then throw an error like "Unexpected character 'k' (char: 3)". I think though that the former is a more informative error message.

@gwhitney can you have a brief look at this PR?