### PR TITLE
Faster subset

### DIFF
--- a/src/type/matrix/DenseMatrix.js
+++ b/src/type/matrix/DenseMatrix.js
@@ -262,25 +262,19 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
     return { data: getSubmatrixRecursive(data), size }
 
     function getSubmatrixRecursive (data, depth = 0) {
-      const range = index.dimension(depth).valueOf()
-      const rangeLength = range.length
-      size[depth] = rangeLength
-      const result = Array(rangeLength)
-
+      const ranges = index.dimension(depth)
+      size[depth] = ranges.size()[0]
       if (depth < maxDepth) {
-        for (let i = 0; i < rangeLength; i++) {
-          const rangeIndex = range[i]
+        return ranges.map(rangeIndex => {
           validateIndex(rangeIndex, data.length)
-          result[i] = getSubmatrixRecursive(data[rangeIndex], depth + 1)
-        }
+          return getSubmatrixRecursive(data[rangeIndex], depth + 1)
+        }).valueOf()
       } else {
-        for (let i = 0; i < rangeLength; i++) {
-          const rangeIndex = range[i]
+        return ranges.map(rangeIndex => {
           validateIndex(rangeIndex, data.length)
-          result[i] = data[rangeIndex]
-        }
+          return data[rangeIndex]
+        }).valueOf()
       }
-      return result
     }
   }
 
@@ -391,21 +385,17 @@ export const createDenseMatrixClass = /* #__PURE__ */ factory(name, dependencies
     setSubmatrixRecursive(data, submatrix)
 
     function setSubmatrixRecursive (data, submatrix, depth = 0) {
-      const range = index.dimension(depth).valueOf()
-      const rangeLength = range.length
-
+      const range = index.dimension(depth)
       if (depth < maxDepth) {
-        for (let i = 0; i < rangeLength; i++) {
-          const rangeIndex = range[i]
+        range.forEach((rangeIndex, i) => {
           validateIndex(rangeIndex, data.length)
-          setSubmatrixRecursive(data[rangeIndex], submatrix[i], depth + 1)
-        }
+          setSubmatrixRecursive(data[rangeIndex], submatrix[i[0]], depth + 1)
+        })
       } else {
-        for (let i = 0; i < rangeLength; i++) {
-          const rangeIndex = range[i]
+        range.forEach((rangeIndex, i) => {
           validateIndex(rangeIndex, data.length)
-          data[rangeIndex] = submatrix[i]
-        }
+          data[rangeIndex] = submatrix[i[0]]
+        })
       }
     }
   }

--- a/test/benchmark/subset.js
+++ b/test/benchmark/subset.js
@@ -9,9 +9,7 @@ const fiveNumbers = [0, 1, 5, 7, 9]
 const twoNumbers = [4, 6]
 const range = new Range(2, 9, 3)
 const rangeAll = new Range(0, 10)
-
-// console.log('data', array)
-// console.log('abs(data)', abs(array))npm run
+const replacement = [1]
 
 const bench = new Bench({ time: 100, iterations: 100 })
   .add('subset(matrix, rows and columns)', () => {
@@ -55,6 +53,48 @@ const bench = new Bench({ time: 100, iterations: 100 })
   })
   .add('subset(array, all and all)', () => {
     subset(array, index(rangeAll, rangeAll))
+  })
+  .add('subset(matrix, rows and columns, replacement)', () => {
+    subset(matrix, index(fiveNumbers, twoNumbers), replacement)
+  })
+  .add('subset(array, rows and columns, replacement)', () => {
+    subset(array, index(fiveNumbers, twoNumbers), replacement)
+  })
+  .add('subset(matrix, booleans and columns, replacement)', () => {
+    subset(matrix, index(arrayOfBooleans, twoNumbers), replacement)
+  })
+  .add('subset(array, booleans and columns, replacement)', () => {
+    subset(array, index(arrayOfBooleans, twoNumbers), replacement)
+  })
+  .add('subset(matrix, columns and booleans, replacement)', () => {
+    subset(matrix, index(arrayOfBooleans, twoNumbers), replacement)
+  })
+  .add('subset(array, columns and booleans, replacement)', () => {
+    subset(array, index(arrayOfBooleans, twoNumbers), replacement)
+  })
+  .add('subset(matrix, range and rows, replacement)', () => {
+    subset(matrix, index(range, twoNumbers), replacement)
+  })
+  .add('subset(array, range and rows, replacement)', () => {
+    subset(array, index(range, twoNumbers), replacement)
+  })
+  .add('subset(matrix, range and all, replacement)', () => {
+    subset(matrix, index(range, rangeAll), replacement)
+  })
+  .add('subset(array, range and all, replacement)', () => {
+    subset(array, index(range, rangeAll), replacement)
+  })
+  .add('subset(matrix, all and range, replacement)', () => {
+    subset(matrix, index(rangeAll, range), replacement)
+  })
+  .add('subset(array, all and range, replacement)', () => {
+    subset(array, index(rangeAll, range), replacement)
+  })
+  .add('subset(matrix, all and all, replacement)', () => {
+    subset(matrix, index(rangeAll, rangeAll), replacement)
+  })
+  .add('subset(array, all and all, replacement)', () => {
+    subset(array, index(rangeAll, rangeAll), replacement)
   })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))

--- a/test/benchmark/subset.js
+++ b/test/benchmark/subset.js
@@ -4,10 +4,13 @@ import { formatTaskResult } from './utils/formatTaskResult.js'
 
 const matrix = map(ones(10, 10, 'dense'), _ => round(random(-5, 5), 2))
 const array = matrix.toArray()
+const bigMatrix = map(ones(150, 150, 'dense'), _ => round(random(-5, 5), 2))
+const bigArray = map(ones(150, 150, 'dense'), _ => round(random(-5, 5), 2))
 const arrayOfBooleans = [true, false, false, true, true, true, false, true, false, true]
 const fiveNumbers = [0, 1, 5, 7, 9]
 const twoNumbers = [4, 6]
 const range = new Range(2, 9, 3)
+const bigRange = new Range(1, 150, 10)
 const rangeAll = new Range(0, 10)
 const replacement = [1]
 
@@ -95,6 +98,18 @@ const bench = new Bench({ time: 100, iterations: 100 })
   })
   .add('subset(array, all and all, replacement)', () => {
     subset(array, index(rangeAll, rangeAll), replacement)
+  })
+  .add('subset(bigMatrix, rows and columns)', () => {
+    subset(bigMatrix, index(fiveNumbers, twoNumbers))
+  })
+  .add('subset(bigArray, rows and columns)', () => {
+    subset(bigArray, index(fiveNumbers, twoNumbers))
+  })
+  .add('subset(bigMatrix, range and columns)', () => {
+    subset(bigMatrix, index(bigRange, twoNumbers))
+  })
+  .add('subset(bigArray, rows and range)', () => {
+    subset(bigArray, index(fiveNumbers, bigRange))
   })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))

--- a/test/benchmark/subset.js
+++ b/test/benchmark/subset.js
@@ -8,7 +8,7 @@ const arrayOfBooleans = [true, false, false, true, true, true, false, true, fals
 const fiveNumbers = [0, 1, 5, 7, 9]
 const twoNumbers = [4, 6]
 const range = new Range(2, 9, 3)
-const rangeAll = new Range()
+const rangeAll = new Range(0, 10)
 
 // console.log('data', array)
 // console.log('abs(data)', abs(array))npm run

--- a/test/benchmark/subset.js
+++ b/test/benchmark/subset.js
@@ -4,7 +4,7 @@ import { formatTaskResult } from './utils/formatTaskResult.js'
 
 const matrix = map(ones(10, 10, 'dense'), _ => round(random(-5, 5), 2))
 const array = matrix.toArray()
-const arrayOfBooleans = [true, false, false, true, true, true, false, true, false, true,]
+const arrayOfBooleans = [true, false, false, true, true, true, false, true, false, true]
 const fiveNumbers = [0, 1, 5, 7, 9]
 const twoNumbers = [4, 6]
 const range = new Range(2, 9, 3)
@@ -15,48 +15,47 @@ const rangeAll = new Range()
 
 const bench = new Bench({ time: 100, iterations: 100 })
   .add('subset(matrix, rows and columns)', () => {
-	subset(matrix, index(fiveNumbers, twoNumbers))
+    subset(matrix, index(fiveNumbers, twoNumbers))
   })
   .add('subset(array, rows and columns)', () => {
-	subset(array, index(fiveNumbers, twoNumbers))
+    subset(array, index(fiveNumbers, twoNumbers))
   })
   .add('subset(matrix, booleans and columns)', () => {
-	subset(matrix, index(arrayOfBooleans, twoNumbers))
+    subset(matrix, index(arrayOfBooleans, twoNumbers))
   })
   .add('subset(array, booleans and columns)', () => {
-	subset(array, index(arrayOfBooleans, twoNumbers))
+    subset(array, index(arrayOfBooleans, twoNumbers))
   })
   .add('subset(matrix, columns and booleans)', () => {
-	subset(matrix, index(arrayOfBooleans, twoNumbers))
+    subset(matrix, index(arrayOfBooleans, twoNumbers))
   })
   .add('subset(array, columns and booleans)', () => {
-	subset(array, index(arrayOfBooleans, twoNumbers))
+    subset(array, index(arrayOfBooleans, twoNumbers))
   })
   .add('subset(matrix, range and rows)', () => {
-	subset(matrix, index(range, twoNumbers))
+    subset(matrix, index(range, twoNumbers))
   })
   .add('subset(array, range and rows)', () => {
-	subset(array, index(range, twoNumbers))
+    subset(array, index(range, twoNumbers))
   })
   .add('subset(matrix, range and all)', () => {
-	subset(matrix, index(range, rangeAll))
+    subset(matrix, index(range, rangeAll))
   })
   .add('subset(array, range and all)', () => {
-	subset(array, index(range, rangeAll))
+    subset(array, index(range, rangeAll))
   })
   .add('subset(matrix, all and range)', () => {
-	subset(matrix, index(rangeAll, range))
+    subset(matrix, index(rangeAll, range))
   })
   .add('subset(array, all and range)', () => {
-	subset(array, index(rangeAll, range))
+    subset(array, index(rangeAll, range))
   })
   .add('subset(matrix, all and all)', () => {
-	subset(matrix, index(rangeAll, rangeAll))
+    subset(matrix, index(rangeAll, rangeAll))
   })
   .add('subset(array, all and all)', () => {
-	subset(array, index(rangeAll, rangeAll))
+    subset(array, index(rangeAll, rangeAll))
   })
-  
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))
 await bench.run()

--- a/test/benchmark/subset.js
+++ b/test/benchmark/subset.js
@@ -1,0 +1,62 @@
+import { Bench } from 'tinybench'
+import { index, Range, subset, map, ones, random, round } from '../../lib/esm/index.js'
+import { formatTaskResult } from './utils/formatTaskResult.js'
+
+const matrix = map(ones(10, 10, 'dense'), _ => round(random(-5, 5), 2))
+const array = matrix.toArray()
+const arrayOfBooleans = [true, false, false, true, true, true, false, true, false, true,]
+const fiveNumbers = [0, 1, 5, 7, 9]
+const twoNumbers = [4, 6]
+const range = new Range(2, 9, 3)
+const rangeAll = new Range()
+
+// console.log('data', array)
+// console.log('abs(data)', abs(array))npm run
+
+const bench = new Bench({ time: 100, iterations: 100 })
+  .add('subset(matrix, rows and columns)', () => {
+	subset(matrix, index(fiveNumbers, twoNumbers))
+  })
+  .add('subset(array, rows and columns)', () => {
+	subset(array, index(fiveNumbers, twoNumbers))
+  })
+  .add('subset(matrix, booleans and columns)', () => {
+	subset(matrix, index(arrayOfBooleans, twoNumbers))
+  })
+  .add('subset(array, booleans and columns)', () => {
+	subset(array, index(arrayOfBooleans, twoNumbers))
+  })
+  .add('subset(matrix, columns and booleans)', () => {
+	subset(matrix, index(arrayOfBooleans, twoNumbers))
+  })
+  .add('subset(array, columns and booleans)', () => {
+	subset(array, index(arrayOfBooleans, twoNumbers))
+  })
+  .add('subset(matrix, range and rows)', () => {
+	subset(matrix, index(range, twoNumbers))
+  })
+  .add('subset(array, range and rows)', () => {
+	subset(array, index(range, twoNumbers))
+  })
+  .add('subset(matrix, range and all)', () => {
+	subset(matrix, index(range, rangeAll))
+  })
+  .add('subset(array, range and all)', () => {
+	subset(array, index(range, rangeAll))
+  })
+  .add('subset(matrix, all and range)', () => {
+	subset(matrix, index(rangeAll, range))
+  })
+  .add('subset(array, all and range)', () => {
+	subset(array, index(rangeAll, range))
+  })
+  .add('subset(matrix, all and all)', () => {
+	subset(matrix, index(rangeAll, rangeAll))
+  })
+  .add('subset(array, all and all)', () => {
+	subset(array, index(rangeAll, rangeAll))
+  })
+  
+
+bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))
+await bench.run()


### PR DESCRIPTION
Hi,

This improves the speed of subset by following a recommendation in the TODO comments and other recursion improvements.

These are the results

![image](https://github.com/user-attachments/assets/871182c1-8a1f-4c9f-9ad5-a22dd4e0ab5b)

```
develop
======
subset(matrix, rows and columns)         1.89 µs   ±0.13%
subset(array, rows and columns)          4.89 µs   ±0.25%
subset(matrix, booleans and columns)     2.15 µs   ±0.25%
subset(array, booleans and columns)      5.09 µs   ±0.14%
subset(matrix, columns and booleans)     2.15 µs   ±0.35%
subset(array, columns and booleans)      5.13 µs   ±0.34%
subset(matrix, range and rows)           1.19 µs   ±0.20%
subset(array, range and rows)            4.19 µs   ±0.16%
subset(matrix, range and all)            1.73 µs   ±0.20%
subset(array, range and all)             4.70 µs   ±0.16%
subset(matrix, all and range)            2.32 µs   ±0.20%
subset(array, all and range)             5.24 µs   ±0.19%
subset(matrix, all and all)              4.69 µs   ±0.26%
subset(array, all and all)               7.64 µs   ±0.20%

this pr
=====
subset(matrix, rows and columns)         1.23 µs   ±0.15%
subset(array, rows and columns)          4.17 µs   ±0.19%
subset(matrix, booleans and columns)     1.37 µs   ±0.18%
subset(array, booleans and columns)      4.30 µs   ±0.50%
subset(matrix, columns and booleans)     1.37 µs   ±0.18%
subset(array, columns and booleans)      4.29 µs   ±0.20%
subset(matrix, range and rows)           0.82 µs   ±0.20%
subset(array, range and rows)            3.74 µs   ±0.16%
subset(matrix, range and all)            0.81 µs   ±0.26%
subset(array, range and all)             3.64 µs   ±0.14%
subset(matrix, all and range)            1.10 µs   ±0.37%
subset(array, all and range)             3.97 µs   ±0.30%
subset(matrix, all and all)              1.64 µs   ±0.20%
subset(array, all and all)               4.43 µs   ±0.17%
```