### PR TITLE
fix: #1905 handle `not` as a function in cases like `help(not)`

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1184,7 +1184,15 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
       name = state.token
 
       getTokenSkipNewline(state)
+
+      state.silentParseEnd = true
       params = [parseUnary(state)]
+      state.silentParseEnd = false
+
+      if (name === 'not' && state.end) {
+        // not without a param on the right side, for example `help(not)`
+        return new SymbolNode(name)
+      }
 
       return new OperatorNode(name, fn, params)
     }
@@ -1709,7 +1717,9 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    * @private
    */
   function parseEnd (state) {
-    if (state.token === '') {
+    if (state.silentParseEnd) {
+      state.end = true
+    } else if (state.token === '') {
       // syntax error or unexpected end of expression
       throw createSyntaxError(state, 'Unexpected end of expression')
     } else {

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -1750,6 +1750,8 @@ describe('parse', function () {
 
     it('should parse logical not', function () {
       assert.strictEqual(parseAndEval('not 2'), false)
+      assert.strictEqual(parseAndEval('not (2)'), false)
+      assert.strictEqual(parseAndEval('not -2'), false)
       assert.strictEqual(parseAndEval('not not 2'), true)
       assert.strictEqual(parseAndEval('not not not 2'), false)
       assert.strictEqual(parseAndEval('not true'), false)
@@ -1762,6 +1764,13 @@ describe('parse', function () {
       assert.strictEqual(parseAndEval('4 + not 2'), 4)
 
       assert.strictEqual(parseAndEval('10+not not 3'), 11)
+    })
+
+    it('should parse logical not returning the function', function () {
+      assert.strictEqual(math.parse('help(not)').toString(), 'help(not)')
+      assert.strictEqual(math.parse('help(not )').toString(), 'help(not)')
+      assert.strictEqual(parseAndEval('not'), math.not)
+      assert.strictEqual(parseAndEval('cond ? not : and', { cond: true }), math.not)
     })
 
     it('should parse minus -', function () {


### PR DESCRIPTION
See #1905

This is a workaround and not very pretty.