### PR TITLE
Correctly parse (lbf in)

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -935,7 +935,8 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
       getTokenSkipNewline(state)
 
-      if (name === 'in' && state.token === '') {
+      if (name === 'in' &&
+          (state.token === ')' || state.token === ']' || state.token === ',' || state.token === '')) {
         // end of expression -> this is the unit 'in' ('inch')
         node = new OperatorNode('*', 'multiply', [node, new SymbolNode('in')], true)
       } else {

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -935,8 +935,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
       getTokenSkipNewline(state)
 
-      if (name === 'in' &&
-          (state.token === ')' || state.token === ']' || state.token === ',' || state.token === '')) {
+      if (name === 'in' && (state.token === '' || '])},;'.includes(state.token))) {
         // end of expression -> this is the unit 'in' ('inch')
         node = new OperatorNode('*', 'multiply', [node, new SymbolNode('in')], true)
       } else {

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -935,7 +935,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
       getTokenSkipNewline(state)
 
-      if (name === 'in' && (state.token === '' || '])},;'.includes(state.token))) {
+      if (name === 'in' && '])},;'.includes(state.token)) {
         // end of expression -> this is the unit 'in' ('inch')
         node = new OperatorNode('*', 'multiply', [node, new SymbolNode('in')], true)
       } else {

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -599,6 +599,10 @@ describe('parse', function () {
     it('should evaluate unit "in" (should not conflict with operator "in")', function () {
       approxDeepEqual(parseAndEval('2 in'), new Unit(2, 'in'))
       approxEqual(parseAndEval('(2 lbf in).toNumeric("lbf in")'), 2)
+      approxEqual(parseAndEval('[2 lbf in][1].toNumeric("lbf in")'), 2)
+      approxEqual(parseAndEval('[2 lbf in, 5][1].toNumeric("lbf in")'), 2)
+      approxEqual(parseAndEval('[2 lbf in; 5][1,1].toNumeric("lbf in")'), 2)
+      approxEqual(parseAndEval('{foo:2 lbf in}["foo"].toNumeric("lbf in")'), 2)
       approxDeepEqual(parseAndEval('5.08 cm in in'), new Unit(2, 'in').to('in'))
       approxDeepEqual(parseAndEval('5 in in in'), new Unit(5, 'in').to('in'))
       approxDeepEqual(parseAndEval('2 in to meter'), new Unit(2, 'inch').to('meter'))

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -598,6 +598,7 @@ describe('parse', function () {
 
     it('should evaluate unit "in" (should not conflict with operator "in")', function () {
       approxDeepEqual(parseAndEval('2 in'), new Unit(2, 'in'))
+      approxEqual(parseAndEval('(2 lbf in).toNumeric("lbf in")'), 2)
       approxDeepEqual(parseAndEval('5.08 cm in in'), new Unit(2, 'in').to('in'))
       approxDeepEqual(parseAndEval('5 in in in'), new Unit(5, 'in').to('in'))
       approxDeepEqual(parseAndEval('2 in to meter'), new Unit(2, 'inch').to('meter'))


### PR DESCRIPTION
This is a little fix for #3474 to allow correct parsing (avoid syntax error) of compound units ending with `in` but not the end of the line, for example `(2 lbf in)`

Thanks for considering.
Carl