### PR TITLE
fix(parse): Parse &nbsp; as white space

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -543,7 +543,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
    */
   parse.isWhitespace = function isWhitespace (c, nestingLevel) {
     // TODO: also take '\r' carriage return as newline? Or does that give problems on mac?
-    return c === ' ' || c === '\t' || (c === '\n' && nestingLevel > 0)
+    return c === ' ' || c === '\t' || c === '\u00A0' || (c === '\n' && nestingLevel > 0)
   }
 
   /**

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -97,6 +97,9 @@ describe('parse', function () {
     math.evaluate('\uD835\uDD38 = 1', scope) // double struck capital A
     assert.strictEqual(scope['\uD835\uDD38'], 1)
 
+    math.evaluate('x\t=\u00A02 +\u00A04', scope) // Non-breaking space (&nbsp;)
+    assert.strictEqual(scope.x, 6)
+
     // should not allow the "holes"
     assert.throws(function () {
       math.evaluate('\uD835\uDCA3 = 1', scope)


### PR DESCRIPTION
Updates parser to handle `&nbsp;` as a whitespace character. 

In #2199 I saw the suggestion of doing a regex search for other possible unicode whitespace characters. Running `/^\s$/.test('\u00A0')` does indeed work. With that change, I think I'm seeing a 5% hit on the parser benchmarks, but it's a small change and might not be a meaningful difference?

Currently this PR takes the simplest approach, `c === '\u00A0'`, no regex, and adds a unit test.

Related:
- Fixes #2199
- Fixes https://github.com/gtg922r/obsidian-numerals/issues/106