### PR TITLE
fix: numeric literals can be set as object keys and used to access objects

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,6 +43,10 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': [
           'error',
           { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+        ],
+        'prettier/prettier': [
+          'error',
+          { endOfLine: 'auto' }
         ]
       },
       plugins: ['@typescript-eslint'],

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   semi: false,
   singleQuote: true,
-  trailingComma: 'none'
+  trailingComma: 'none',
+  endOfLine: 'auto'
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ import log from 'fancy-log'
 import webpack from 'webpack'
 import babel from 'gulp-babel'
 import { mkdirp } from 'mkdirp'
-import { cleanup, iteratePath }  from './tools/docgenerator.js'
+import { cleanup, iteratePath } from './tools/docgenerator.js'
 import { generateEntryFiles } from './tools/entryGenerator.js'
 import { getAllFiles, validateChars } from './tools/validateAsciiChars.js'
 

--- a/src/expression/node/AccessorNode.js
+++ b/src/expression/node/AccessorNode.js
@@ -6,6 +6,7 @@ import {
   isIndexNode,
   isNode,
   isObjectNode,
+  isOperatorNode,
   isParenthesisNode,
   isSymbolNode
 } from '../../utils/is.js'
@@ -92,6 +93,15 @@ export const createAccessorNode = /* #__PURE__ */ factory(name, dependencies, ({
     _compile (math, argNames) {
       const evalObject = this.object._compile(math, argNames)
       const evalIndex = this.index._compile(math, argNames)
+
+      // If index contains operator node, evaluate result of the operation and access object with result
+      if (isOperatorNode(this.index.dimensions[0]) && isObjectNode(this.object)) {
+        const operatorNode = this.index.dimensions[0]
+        return function evalAccessorNode (scope, args, context) {
+          const result = operatorNode._compile(math, argNames)(scope, args, context)
+          return getSafeProperty(evalObject(scope, args, context), String(result))
+        }
+      }
 
       if (this.index.isObjectProperty()) {
         const prop = this.index.getObjectProperty()

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1,5 +1,5 @@
 import { factory } from '../utils/factory.js'
-import { isAccessorNode, isConstantNode, isFunctionNode, isOperatorNode, isSymbolNode, rule2Node } from '../utils/is.js'
+import { isAccessorNode, isConstantNode, isFunctionNode, isObjectNode, isOperatorNode, isSymbolNode, rule2Node } from '../utils/is.js'
 import { deepMap } from '../utils/collection.js'
 import { safeNumberType } from '../utils/number.js'
 import { hasOwnProperty } from '../utils/object.js'
@@ -1413,6 +1413,11 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         closeParams(state)
         getToken(state)
 
+        // If param value is number and node is object node, make param value a string
+        if (typeof params[0].value === 'number' && isObjectNode(node) && params.length === 1 && isConstantNode(params[0])) {
+          params[0].value = String(params[0].value)
+        }
+
         node = new AccessorNode(node, new IndexNode(params))
       } else {
         // dot notation like variable.prop
@@ -1615,11 +1620,11 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
           // parse key
           if (state.token === '"' || state.token === "'") {
             key = parseStringToken(state, state.token)
-          } else if (state.tokenType === TOKENTYPE.SYMBOL || (state.tokenType === TOKENTYPE.DELIMITER && state.token in NAMED_DELIMITERS)) {
+          } else if (state.tokenType === TOKENTYPE.SYMBOL || (state.tokenType === TOKENTYPE.DELIMITER && state.token in NAMED_DELIMITERS) || state.tokenType === TOKENTYPE.NUMBER) {
             key = state.token
             getToken(state)
           } else {
-            throw createSyntaxError(state, 'Symbol or string expected as object key')
+            throw createSyntaxError(state, 'Symbol, numeric literal or string expected as object key')
           }
 
           // parse key/value separator

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -1415,7 +1415,8 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
 
         // If param value is number and node is object node, make param value a string
         if (typeof params[0].value === 'number' && isObjectNode(node) && params.length === 1 && isConstantNode(params[0])) {
-          params[0].value = String(params[0].value)
+          // Number constructor is first used to manage situations of numbers with preceding zero digit(s)
+          params[0].value = String(Number(params[0].value))
         }
 
         node = new AccessorNode(node, new IndexNode(params))
@@ -1621,7 +1622,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
           if (state.token === '"' || state.token === "'") {
             key = parseStringToken(state, state.token)
           } else if (state.tokenType === TOKENTYPE.SYMBOL || (state.tokenType === TOKENTYPE.DELIMITER && state.token in NAMED_DELIMITERS) || state.tokenType === TOKENTYPE.NUMBER) {
-            key = state.token
+            key = state.tokenType === TOKENTYPE.NUMBER ? String(Number(state.token)) : state.token
             getToken(state)
           } else {
             throw createSyntaxError(state, 'Symbol, numeric literal or string expected as object key')


### PR DESCRIPTION
- Parser extended to accept numeric literals as object keys.
- Parser extended to accept numeric literals as object accessors.
- Parser extended to accept operations as object accessors.
- If a number is parsed as an object key or accessor, it is converted to a string before being used as an object key / accessor.
- If an operation is parsed as an object accessor, the result of the operation is evaluated before being converted to a string and used as an object accessor
- Care was taken to manage numbers with preceeding zeros either as object keys or accessors. eg 05. They're run through a Number constructor before being converted to strings to ensure there are no preceeding zeros

Closes #3352 