### PR TITLE
sign of zero fraction should return 0/1 instead of 1/1

### DIFF
--- a/src/function/arithmetic/sign.js
+++ b/src/function/arithmetic/sign.js
@@ -52,7 +52,7 @@ export const createSign = /* #__PURE__ */ factory(name, dependencies, ({ typed, 
     },
 
     Fraction: function (x) {
-      return new Fraction(x.s)
+      return x.n === 0n ? new Fraction(0) : new Fraction(x.s)
     },
 
     // deep map collection, skip zeros since sign(0) = 0

--- a/test/unit-tests/function/arithmetic/sign.test.js
+++ b/test/unit-tests/function/arithmetic/sign.test.js
@@ -37,6 +37,7 @@ describe('sign', function () {
     assert.strictEqual(math.sign(a).toString(), '1')
     assert.strictEqual(math.sign(fraction(-0.5)).toString(), '-1')
     assert.strictEqual(a.toString(), '0.5')
+    assert.deepStrictEqual(math.sign(math.fraction(0)), math.fraction(0))
   })
 
   it('should calculate the sign of a complex value', function () {
@@ -105,9 +106,6 @@ describe('sign', function () {
       assert.deepStrictEqual(math.sign(math.complex(0)), math.complex(0))
     })
 
-    it('fraction', function () {
-      assert.deepStrictEqual(math.sign(math.fraction(0)), math.fraction(0))
-    })
   })
 
   it('should throw an in case of wrong type of arguments', function () {

--- a/test/unit-tests/function/arithmetic/sign.test.js
+++ b/test/unit-tests/function/arithmetic/sign.test.js
@@ -105,7 +105,6 @@ describe('sign', function () {
     it('complex', function () {
       assert.deepStrictEqual(math.sign(math.complex(0)), math.complex(0))
     })
-
   })
 
   it('should throw an in case of wrong type of arguments', function () {

--- a/test/unit-tests/function/arithmetic/sign.test.js
+++ b/test/unit-tests/function/arithmetic/sign.test.js
@@ -104,6 +104,10 @@ describe('sign', function () {
     it('complex', function () {
       assert.deepStrictEqual(math.sign(math.complex(0)), math.complex(0))
     })
+
+    it('fraction', function () {
+      assert.deepStrictEqual(math.sign(math.fraction(0)), math.fraction(0))
+    })
   })
 
   it('should throw an in case of wrong type of arguments', function () {


### PR DESCRIPTION
# Original Issue: https://github.com/josdejong/mathjs/issues/3512

```
math.sign(0) // gives 0 ✅
math.sign(math.complex(0,0)) // gives 0+0i ✅
math.sign(math.fraction(0)) // gives 1/1 ❌, it should give 0/1 
```

## Fixed:
issue where math.sign(math.fraction(0)) incorrectly returned 1/1 instead of 0/1. Changed fraction sign detection from checking x.s to checking x.n === 0n (numerator is 

## Modified:
/function/arithmetic/sign.js:55 - Changed from `return new Fraction(x.s)` to `return x.n === 0n ? new Fraction(0) : new Fraction(x.s)`

## Added:
test/unit-tests/function/arithmetic/sign.test.js:108-110 - Added test case for `math.sign(math.fraction(0))`

## `npm run lint` and `npm test` had no issues :) 

