### PR TITLE
Faster map with mulitple arguments

### DIFF
--- a/src/function/matrix/map.js
+++ b/src/function/matrix/map.js
@@ -162,9 +162,8 @@ export const createMap = /* #__PURE__ */ factory(name, dependencies, ({ typed })
 
   function mapMultiple (Collections, callback) {
   // collections can be matrices or arrays
-  // callback must be a function of the form (collcetions, [index])
+  // callback must be a function of the form (collections, [index])
     const firstCollection = Collections[0]
-    const firstCollectionIsMatrix = Boolean(firstCollection.isMatrix)
     const Arrays = Collections.map((collection) =>
       collection.isMatrix ? collection.valueOf() : collection
     )
@@ -178,11 +177,11 @@ export const createMap = /* #__PURE__ */ factory(name, dependencies, ({ typed })
     const callbackUsesIndex = callback.length > 1
     const index = callbackUsesIndex ? [] : null
     const resultsArray = iterate(Arrays, 0)
-    if (firstCollectionIsMatrix) {
-      const returnMatrix = firstCollection.create()
-      returnMatrix._data = resultsArray
-      returnMatrix._size = finalSize
-      return returnMatrix
+    if (firstCollection.isMatrix) {
+      const resultsMatrix = firstCollection.create()
+      resultsMatrix._data = resultsArray
+      resultsMatrix._size = finalSize
+      return resultsMatrix
     } else {
       return resultsArray
     }

--- a/src/function/matrix/map.js
+++ b/src/function/matrix/map.js
@@ -193,7 +193,7 @@ export const createMap = /* #__PURE__ */ factory(name, dependencies, ({ typed })
       if (depth < maxDepth) {
         for (let i = 0; i < N; i++) {
           if (index) index[depth] = i
-          // if there is an offset greather than the current dimension
+          // if there is an offset greater than the current dimension
           // pass the array, if the size of the array is 1 pass the first
           // element of the array
           result[i] = iterate(

--- a/src/function/matrix/map.js
+++ b/src/function/matrix/map.js
@@ -140,6 +140,14 @@ export const createMap = /* #__PURE__ */ factory(name, dependencies, ({ typed })
     }
 
     function _getCallbackCase (callback, numberOfArrays) {
+      const callbackStr = callback.toString()
+      // Check if the callback function uses `arguments`
+      if (/arguments/.test(callbackStr)) return 2
+
+      // Extract the parameters of the callback function
+      const paramsStr = callbackStr.match(/\(.*?\)/)
+      // Check if the callback function uses rest parameters
+      if (/\.\.\./.test(paramsStr)) return 2
       if (callback.length > numberOfArrays + 1) { return 2 }
       if (callback.length === numberOfArrays + 1) { return 1 }
       return 0

--- a/test/benchmark/map.js
+++ b/test/benchmark/map.js
@@ -6,6 +6,13 @@ const genericMatrix = map(ones(10, 10, 'dense'), _ => round(random(-5, 5), 2))
 const numberMatrix = new DenseMatrix(genericMatrix, 'number')
 const array = genericMatrix.toArray()
 
+const rowMatrix = map(ones(1, 10, 'dense'), _ => round(random(-5, 5), 2))
+const columnMatrix = map(ones(10, 1, 'dense'), _ => round(random(-5, 5), 2))
+const rowArray = rowMatrix.toArray()
+const columnArray = columnMatrix.toArray()
+const multiCallback = (value1, value2) => abs(value1 - value2)
+const multiCallback1 = (value1, value2, index) => abs(value1 - value2)
+const multiCallback2 = (value1, value2, index, array1, array2) => abs(value1 - value2)
 // console.log('data', array)
 // console.log('abs(data)', abs(array))npm run
 
@@ -48,6 +55,24 @@ const bench = new Bench({ time: 100, iterations: 100 })
     for (const v of genericMatrix) {
       result.set(v.index, abs(v.value))
     }
+  })
+  .add('map(rowMatrix, columnMatrix, multiCallback)', () => {
+    map(rowMatrix, columnMatrix, multiCallback)
+  })
+  .add('map(rowArray, columnArray, multiCallback)', () => {
+    map(rowArray, columnArray, multiCallback)
+  })
+  .add('map(rowMatrix, columnMatrix, multiCallback1)', () => {
+    map(rowMatrix, columnMatrix, multiCallback1)
+  })
+  .add('map(rowArray, columnArray, multiCallback1)', () => {
+    map(rowArray, columnArray, multiCallback1)
+  })
+  .add('map(rowMatrix, columnMatrix, multiCallback2)', () => {
+    map(rowMatrix, columnMatrix, multiCallback2)
+  })
+  .add('map(rowArray, columnArray, multiCallback2)', () => {
+    map(rowArray, columnArray, multiCallback2)
   })
 
 bench.addEventListener('cycle', (event) => console.log(formatTaskResult(bench, event.task)))


### PR DESCRIPTION
Hi Jos,

This makes it faster to map multiple arrays or matrices (with broadcasting), by not creating the internally broadcasted matrices unless the callback specifically needs it.

About 4x faster when no index is needed, 3x faster when an index is needed and is the same when also the broadcasted arrays or matrices are needed.

<img width="872" height="455" alt="image" src="https://github.com/user-attachments/assets/b29a5807-7fae-4446-8503-04c81445b3ba" />

develop

```
abs(genericMatrix)                               1.41 µs   ±0.13%
abs(array)                                       1.28 µs   ±0.24%
abs(numberMatrix)                                1.42 µs   ±0.22%
genericMatrix.map(abs)                           5.01 µs   ±0.19%
numberMatrix.map(abs)                            5.01 µs   ±0.17%
map(genericMatrix, abs)                          5.03 µs   ±0.19%
map(numberMatrix, abs)                           5.01 µs   ±0.19%
map(array, abs)                                  5.01 µs   ±0.20%
map(array, abs.signatures.number)                2.23 µs   ±0.26%
genericMatrix.map(abs.signatures.number)         1.80 µs   ±5.91%
numberMatrix.map(abs.signatures.number)          1.70 µs   ±0.24%
genericMatrix iterate                            7.46 µs   ±0.25%
map(rowMatrix, columnMatrix, multiCallback)     35.78 µs   ±0.25%
map(rowArray, columnArray, multiCallback)       29.32 µs   ±0.20%
map(rowMatrix, columnMatrix, multiCallback1)    40.34 µs   ±0.19%
map(rowArray, columnArray, multiCallback1)      34.08 µs   ±0.19%
map(rowMatrix, columnMatrix, multiCallback2)    40.48 µs   ±0.17%
map(rowArray, columnArray, multiCallback2)      34.28 µs   ±0.20%
```

this PR
```
abs(genericMatrix)                               1.43 µs   ±0.11%
abs(array)                                       1.28 µs   ±0.25%
abs(numberMatrix)                                1.45 µs   ±1.80%
genericMatrix.map(abs)                           5.16 µs   ±0.94%
numberMatrix.map(abs)                            5.13 µs   ±0.30%
map(genericMatrix, abs)                          5.11 µs   ±0.18%
map(numberMatrix, abs)                           5.09 µs   ±0.24%
map(array, abs)                                  5.01 µs   ±0.17%
map(array, abs.signatures.number)                2.22 µs   ±0.29%
genericMatrix.map(abs.signatures.number)         1.71 µs   ±0.27%
numberMatrix.map(abs.signatures.number)          1.72 µs   ±0.62%
genericMatrix iterate                           12.31 µs   ±6.69%
map(rowMatrix, columnMatrix, multiCallback)      6.89 µs   ±0.25%
map(rowArray, columnArray, multiCallback)        6.75 µs   ±0.22%
map(rowMatrix, columnMatrix, multiCallback1)    12.42 µs   ±0.23%
map(rowArray, columnArray, multiCallback1)      12.28 µs   ±0.21%
map(rowMatrix, columnMatrix, multiCallback2)    39.67 µs   ±0.21%
map(rowArray, columnArray, multiCallback2)      32.78 µs   ±0.20%
```