### PR TITLE
fix: #3530 throw an error when trying to `flatten` a `SparseMatrix`

### DIFF
--- a/src/function/matrix/flatten.js
+++ b/src/function/matrix/flatten.js
@@ -21,18 +21,24 @@ export const createFlatten = /* #__PURE__ */ factory(name, dependencies, ({ type
    *
    *    concat, resize, size, squeeze
    *
-   * @param {Matrix | Array} x   Matrix to be flattened
-   * @return {Matrix | Array} Returns the flattened matrix
+   * @param {DenseMatrix | Array} x   Matrix to be flattened
+   * @return {DenseMatrix | Array} Returns the flattened matrix
    */
   return typed(name, {
     Array: function (x) {
       return flattenArray(x)
     },
 
-    Matrix: function (x) {
+    DenseMatrix: function (x) {
       // Return the same matrix type as x (Dense or Sparse Matrix)
       // Return the same data type as x
       return x.create(flattenArray(x.valueOf(), true), x.datatype())
+    },
+
+    SparseMatrix: function (_x) {
+      throw new TypeError('SparseMatrix is not supported by function flatten ' +
+        'because it does not support 1D vectors. ' +
+        'Convert to a DenseMatrix or Array first. Example: flatten(x.toArray())')
     }
   })
 })

--- a/test/unit-tests/function/matrix/flatten.test.js
+++ b/test/unit-tests/function/matrix/flatten.test.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import math from '../../../../src/defaultInstance.js'
 const matrix = math.matrix
 const flatten = math.flatten
+const sparse = math.sparse
 
 describe('flatten', function () {
   it('should flatten an empty array', function () {
@@ -37,6 +38,10 @@ describe('flatten', function () {
 
   it('should flatten a 3 dimensional matrix', function () {
     assert.deepStrictEqual(flatten(matrix([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])), matrix([1, 2, 3, 4, 5, 6, 7, 8]))
+  })
+
+  it('should throw an error in case of SparseMatrix input', function () {
+    assert.throws(function () { flatten(sparse([1, 2])) }, /TypeError: SparseMatrix is not supported/)
   })
 
   it('should throw an error on invalid arguments', function () {


### PR DESCRIPTION
Addresses #3530