### PR TITLE
Fix types of abs(complex)

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -615,7 +615,7 @@ Chaining examples
     MathJsChain<Fraction>
   >()
   expectTypeOf(math.chain(math.complex(1, 2)).abs()).toMatchTypeOf<
-    MathJsChain<Complex>
+    MathJsChain<number>
   >()
   expectTypeOf(math.chain([1, 2]).abs()).toMatchTypeOf<MathJsChain<MathArray>>()
   expectTypeOf(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1126,6 +1126,7 @@ export interface MathJsInstance extends MathJsFactory {
    * @param x A number or matrix for which to get the absolute value
    * @returns Absolute value of x
    */
+  abs(x: Complex): number
   abs<T extends MathType>(x: T): T
 
   /**
@@ -5076,6 +5077,7 @@ export interface MathJsChain<TValue> {
    * Calculate the absolute value of a number. For matrices, the function
    * is evaluated element wise.
    */
+  abs(this: MathJsChain<Complex>): MathJsChain<number>
   abs<T extends MathType>(this: MathJsChain<T>): MathJsChain<T>
 
   /**


### PR DESCRIPTION
The absolute value of a complex number is a plain number.