### PR TITLE
Fix issue where no performance boost is achieved by having a unary funciton.

### DIFF
--- a/src/utils/optimizeCallback.js
+++ b/src/utils/optimizeCallback.js
@@ -8,10 +8,10 @@ import { typeOf as _typeOf } from './is.js'
  * @param {Function} callback The original callback function to simplify.
  * @param {Array|Matrix} array The array that will be used with the callback function.
  * @param {string} name The name of the function that is using the callback.
- * @param {boolean} [isUnary=false] If true, the callback function is unary and will be optimized as such.
+ * @param {boolean} isUnary If true, the callback function is unary and will be optimized as such.
  * @returns {Function} Returns a simplified version of the callback function.
  */
-export function optimizeCallback (callback, array, name, isUnary = false) {
+export function optimizeCallback (callback, array, name, isUnary) {
   if (typed.isTypedFunction(callback)) {
     let numberOfArguments
     if (isUnary) {


### PR DESCRIPTION
Hi, currently there is an issue where a unary function (not typed) is never checked as such. Thus there are no performance benefits.

```js
const A = math.random([100, 100])
math.map(A , x => x)
// vs
math.map(A , (x, index) => x)
```
The issue is due to a default value of `isUnary` is false at `optimizeCallback` and the check if the callback is unary only happens if it's value is undefined which is never, due to the default value.