### PR TITLE
Fix: calculate `log10` for a bigint with value zero (fixes #3539)

### DIFF
--- a/src/utils/bigint.js
+++ b/src/utils/bigint.js
@@ -22,6 +22,11 @@ export function promoteLogarithm (log16, numberLog, config, cplx) {
       const s15 = s.substring(0, 15)
       return log16 * (s.length - s15.length) + numberLog(Number('0x' + s15))
     }
+
+    if (b === 0n) {
+      return -Infinity
+    }
+
     return cplx(Number(b))
   }
 }

--- a/test/unit-tests/function/arithmetic/log.test.js
+++ b/test/unit-tests/function/arithmetic/log.test.js
@@ -5,6 +5,7 @@ import { approxDeepEqual } from '../../../../tools/approx.js'
 import math from '../../../../src/defaultInstance.js'
 const mathPredictable = math.create({ predictable: true })
 const complex = math.complex
+const bignumber = math.bignumber
 const matrix = math.matrix
 const unit = math.unit
 const fraction = math.fraction
@@ -36,7 +37,17 @@ describe('log', function () {
   })
 
   it('should return the log of zero', function () {
-    approxDeepEqual(log(0), -Infinity)
+    assert.deepStrictEqual(log(0), -Infinity)
+    assert.deepStrictEqual(log(0n), -Infinity)
+    assert.deepStrictEqual(log(bignumber('0')), bignumber('-Infinity'))
+    assert.deepStrictEqual(log(false), -Infinity)
+  })
+
+  it('should return the log of zero with predicable:true', function () {
+    assert.deepStrictEqual(mathPredictable.log(0), -Infinity)
+    assert.deepStrictEqual(mathPredictable.log(0n), NaN)
+    assert.deepStrictEqual(mathPredictable.log(bignumber('0')), bignumber('-Infinity'))
+    assert.deepStrictEqual(mathPredictable.log(false), -Infinity)
   })
 
   it('should return the log base N of a number', function () {

--- a/test/unit-tests/function/arithmetic/log10.test.js
+++ b/test/unit-tests/function/arithmetic/log10.test.js
@@ -42,7 +42,7 @@ describe('log10', function () {
 
   it('should return the log base 10 of zero', function () {
     assert.deepStrictEqual(log10(0), -Infinity)
-    assert.deepStrictEqual(log10(0n), complex(Infinity, Infinity))
+    assert.deepStrictEqual(log10(0n), -Infinity)
     assert.deepStrictEqual(log10(bignumber('0')), bignumber('-Infinity'))
     assert.deepStrictEqual(log10(false), -Infinity)
   })

--- a/test/unit-tests/function/arithmetic/log2.test.js
+++ b/test/unit-tests/function/arithmetic/log2.test.js
@@ -5,6 +5,7 @@ import { approxDeepEqual } from '../../../../tools/approx.js'
 import math from '../../../../src/defaultInstance.js'
 const mathPredictable = math.create({ predictable: true })
 const complex = math.complex
+const bignumber = math.bignumber
 const matrix = math.matrix
 const unit = math.unit
 const log2 = math.log2
@@ -38,7 +39,17 @@ describe('log2', function () {
   })
 
   it('should return the log base 2 of zero', function () {
-    approxDeepEqual(log2(0), -Infinity)
+    assert.deepStrictEqual(log2(0), -Infinity)
+    assert.deepStrictEqual(log2(0n), -Infinity)
+    assert.deepStrictEqual(log2(bignumber('0')), bignumber('-Infinity'))
+    assert.deepStrictEqual(log2(false), -Infinity)
+  })
+
+  it('should return the log base 2 of zero with predicable:true', function () {
+    assert.deepStrictEqual(mathPredictable.log2(0), -Infinity)
+    assert.deepStrictEqual(mathPredictable.log2(0n), NaN)
+    assert.deepStrictEqual(mathPredictable.log2(bignumber('0')), bignumber('-Infinity'))
+    assert.deepStrictEqual(mathPredictable.log2(false), -Infinity)
   })
 
   it('should return the log of positive bignumbers', function () {


### PR DESCRIPTION
Addresses the first case of `log10(0n)` in #3539.

We may want to think through the behavior for all numeric types. Current behavior (with this bugfix applied):

data type | test                              | `predictable:false`           | `predictable:true`
--------- | --------------------------------- | ----------------------------- | ------------------------
number    | `math.log10(0)`                   | `-Infinity`                   | `-Infinity`
BigNumber | `math.log10(math.bignumber('0'))` | `bignumber('-Infinity')`      | `bignumber('-Infinity')`
bigint    | `math.log10(0n)`                  | `complex(Infinity, Infinity)` | `NaN`
boolean   | `math.log10(false)`               | `-Infinity`                   | `-Infinity`

For consistency, it may be better to return `complex(Infinity, Infinity)` for every data type. Or the other way around: 
return `-Infinity` in case of a bigint (depending on the configured `numberFallback`).

Any thoughs on this @gwhitney?
