### PR TITLE
reject double dot after optional chaining operator, etc.

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -685,6 +685,9 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         return new AssignmentNode(new SymbolNode(name), value)
       } else if (isAccessorNode(node)) {
         // parse a matrix subset assignment like 'A[1,2] = 4'
+        if (node.optionalChaining) {
+          throw createSyntaxError(state, 'Cannot assign to optional chain')
+        }
         getTokenSkipNewline(state)
         value = parseAssignment(state)
         return new AssignmentNode(node.object, node.index, value)
@@ -1396,49 +1399,21 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         optional = true
         // consume the '?.' token
         getToken(state)
-
-        // Reject another dot immediately after ?. (e.g., obj?..foo is invalid)
-        if (state.token === '.') {
-          throw createSyntaxError(state, 'Unexpected token . after ?.')
-        }
-
-        // Special case: property access via dot-notation following optional chaining (obj?.foo)
-        // After consuming '?.', the dot is already consumed as part of the token,
-        // so the next token is the property name itself. Handle that here.
-        const isPropertyNameAfterOptional = (!types || types.includes('.')) && (
-          state.tokenType === TOKENTYPE.SYMBOL ||
-          (state.tokenType === TOKENTYPE.DELIMITER && state.token in NAMED_DELIMITERS)
-        )
-        if (isPropertyNameAfterOptional) {
-          params = []
-          params.push(new ConstantNode(state.token))
-          getToken(state)
-          const dotNotation = true
-          node = new AccessorNode(node, new IndexNode(params, dotNotation), true)
-          // Continue parsing, allowing more chaining after this accessor
-          continue
-        }
-        // Otherwise, fall through to allow patterns like obj?.[...]
       }
 
-      // If the next token does not start an accessor, we're done
       const hasNextAccessor =
         (state.token === '(' || state.token === '[' || state.token === '.') &&
         (!types || types.includes(state.token))
 
-      if (!hasNextAccessor) {
-        // A dangling '?.' without a following accessor is a syntax error
-        if (optional) {
-          throw createSyntaxError(state, 'Unexpected operator ?.')
-        }
+      if (!(optional || hasNextAccessor)) {
         break
       }
 
       params = []
 
       if (state.token === '(') {
-        if (isSymbolNode(node) || isAccessorNode(node)) {
-          // function invocation like fn(2, 3) or obj.fn(2, 3)
+        if (optional || isSymbolNode(node) || isAccessorNode(node)) {
+          // function invocation: fn(2, 3) or obj.fn(2, 3) or (anything)?.(2, 3)
           openParams(state)
           getToken(state)
 
@@ -1458,7 +1433,7 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
           closeParams(state)
           getToken(state)
 
-          node = new FunctionNode(node, params)
+          node = new FunctionNode(node, params, optional)
         } else {
           // implicit multiplication like (2+3)(4+5) or sqrt(2)(1+2)
           // don't parse it here but let it be handled by parseImplicitMultiplication
@@ -1489,12 +1464,15 @@ export const createParse = /* #__PURE__ */ factory(name, dependencies, ({
         node = new AccessorNode(node, new IndexNode(params), optional)
       } else {
         // dot notation like variable.prop
-        getToken(state)
+        // consume the `.` (if it was ?., already consumed):
+        if (!optional) getToken(state)
 
         const isPropertyName = state.tokenType === TOKENTYPE.SYMBOL ||
           (state.tokenType === TOKENTYPE.DELIMITER && state.token in NAMED_DELIMITERS)
         if (!isPropertyName) {
-          throw createSyntaxError(state, 'Property name expected after dot')
+          let message = 'Property name expected after '
+          message += optional ? 'optional chain' : 'dot'
+          throw createSyntaxError(state, message)
         }
 
         params.push(new ConstantNode(state.token))

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -956,6 +956,8 @@ describe('parse', function () {
       const res = parseAndEval('obj["b"] = 2', scope)
       assert.strictEqual(res, 2)
       assert.deepStrictEqual(scope, { obj: { a: 3, b: 2 } })
+      assert.deepStrictEqual(
+        parseAndEval('b = {}; b.a = 2; b').valueOf(), [{ a: 2 }])
     })
 
     it('should set a nested object property', function () {
@@ -964,6 +966,17 @@ describe('parse', function () {
       assert.strictEqual(res, 2)
       assert.deepStrictEqual(scope, { obj: { foo: { bar: 2 } } })
     })
+
+    it(
+      'should not set an object property through optional chaining',
+      function () {
+        assert.throws(
+          () => parseAndEval('obj = {a: 2}; obj?.b = 7'), SyntaxError)
+        assert.throws(
+          () => parseAndEval('obj = {a: 2}; obj?.["b"] = 7'), SyntaxError)
+        assert.throws(
+          () => parseAndEval('obj = {a: {}}; obj.a?.b = 7'), SyntaxError)
+      })
 
     it('should throw an error when trying to apply a matrix index as object property', function () {
       const scope = { a: {} }
@@ -1198,9 +1211,9 @@ describe('parse', function () {
 
     it('should throw an error when using double-dot after optional chaining operator', function () {
       // ?.. is not valid in JavaScript and should be rejected
-      assert.throws(function () { parseAndEval('{a: 3}?..a') }, /SyntaxError: Unexpected token \. after \?\. \(char 9\)/)
-      assert.throws(function () { parseAndEval('obj?..foo', { obj: { foo: 2 } }) }, /SyntaxError: Unexpected token \. after \?\. \(char 6\)/)
-      assert.throws(function () { parseAndEval('obj?.["a"]?..b', { obj: { a: { b: 2 } } }) }, /SyntaxError: Unexpected token \. after \?\. \(char 13\)/)
+      assert.throws(function () { parseAndEval('{a: 3}?..a') }, /SyntaxError: Property name expected after optional chain \(char 9\)/)
+      assert.throws(function () { parseAndEval('obj?..foo', { obj: { foo: 2 } }) }, /SyntaxError: Property name expected after optional chain \(char 6\)/)
+      assert.throws(function () { parseAndEval('obj?.["a"]?..b', { obj: { a: { b: 2 } } }) }, /SyntaxError: Property name expected after optional chain \(char 13\)/)
     })
 
     it('should set an object property with dot notation', function () {
@@ -1477,6 +1490,40 @@ describe('parse', function () {
         const scope = {}
         parseAndEval('2(x, 2) = x^2', scope)
       }, SyntaxError)
+    })
+
+    it('should call functions via optional chaining', function () {
+      assert.strictEqual(parseAndEval('square?.(2)'), 4)
+      assert.deepStrictEqual(parseAndEval('f(x) = x+x; f?.(2)').valueOf(), [4])
+      assert.strictEqual(parseAndEval('(_(x) = x^x)?.(2)'), 4)
+      assert.strictEqual(parseAndEval('foo?.(2)', { foo: x => x * x }), 4)
+      assert.deepStrictEqual(
+        parseAndEval('f(x) = 4x/x; bar = {a: f}; bar.a?.(2)').valueOf(), [4])
+    })
+
+    it(
+      'should shortcircuit undefined functions via optional chaining',
+      function () {
+        assert.strictEqual(
+          parseAndEval('foo?.(2)', { foo: undefined }), undefined)
+        assert.strictEqual(parseAndEval('{a: 3}.foo?.(2)'), undefined)
+        assert.strictEqual(
+          parseAndEval('foo.bar?.(2)', { foo: {} }), undefined)
+        assert.deepStrictEqual(
+          parseAndEval('f(x) = undefined; f(0)?.(2)').valueOf(), [undefined])
+        assert.strictEqual(parseAndEval('(undefined)?.(2)'), undefined)
+        assert.strictEqual(parseAndEval('foo?.(2)'), undefined)
+      })
+
+    it('should throw with optional chain call on non-function', function () {
+      // I guess it is OK to consider this a syntax error since we know just
+      // by reading the expression that the function call can't succeed.
+      assert.throws(() => parseAndEval('7?.(2)'), SyntaxError)
+      assert.throws(() => parseAndEval('a = 7; a?.(2)'), TypeError)
+      assert.throws(() => parseAndEval('(3+4)?.(2)'), TypeError)
+      assert.throws(() => parseAndEval('add(3,4)?.(2)'), TypeError)
+      assert.throws(() => parseAndEval('{a: true}.a?.(2)'), Error)
+      assert.throws(() => parseAndEval('[3, 4]?.(2)'), TypeError)
     })
   })
 


### PR DESCRIPTION
Fixes #3585 where mathjs incorrectly accepts ?.. (double-dot after optional chaining), which is invalid in JavaScript.