### PR TITLE
Fix: Add missing nullishDependencies TypeScript declaration

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -14,6 +14,7 @@ import {
   create,
   divideDependencies,
   EvalFunction,
+  evaluate,
   factory,
   formatDependencies,
   Fraction,
@@ -23,6 +24,7 @@ import {
   Help,
   Index,
   IndexNode,
+  isResultSet,
   isSymbolNode,
   LUDecomposition,
   MapLike,
@@ -38,6 +40,7 @@ import {
   MathType,
   Matrix,
   Node,
+  nullishDependencies,
   ObjectNode,
   OperatorNode,
   OperatorNodeFn,
@@ -50,8 +53,6 @@ import {
   SLUDecomposition,
   SymbolNode,
   Unit,
-  evaluate,
-  isResultSet,
   UnitPrefix
 } from 'mathjs'
 
@@ -2647,12 +2648,13 @@ Factory Test
   }
 
   // Create just the functions we need
-  const { fraction, add, divide, format } = create(
+  const { fraction, add, divide, format, nullish } = create(
     {
       fractionDependencies,
       addDependencies,
       divideDependencies,
-      formatDependencies
+      formatDependencies,
+      nullishDependencies
     },
     config
   )
@@ -2667,6 +2669,9 @@ Factory Test
   assert.strictEqual(format(255, { notation: 'bin' }), '0b11111111')
   assert.strictEqual(format(255, { notation: 'hex' }), '0xff')
   assert.strictEqual(format(255, { notation: 'oct' }), '0o377')
+  assert.strictEqual(nullish(null, 42), 42)
+  assert.strictEqual(nullish(undefined, 'foo'), 'foo')
+  assert.strictEqual(nullish(0, 42), 0)
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1890,6 +1890,18 @@ export interface MathJsInstance extends MathJsFactory {
   ): boolean | MathCollection
 
   /**
+   * Nullish coalescing operator (??). Returns the right-hand side operand
+   * when the left-hand side operand is null or undefined, and otherwise
+   * returns the left-hand side operand. For matrices, the function is
+   * evaluated element wise.
+   * @param x First value to check
+   * @param y Fallback value
+   * @returns Returns y when x is null or undefined, otherwise returns x
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nullish(x: any, y: any): any
+
+  /**
    * Logical or. Test if at least one value is defined with a
    * nonzero/nonempty value. For matrices, the function is evaluated
    * element wise.
@@ -4081,6 +4093,7 @@ export const {
   // logical dependencies
   andDependencies,
   notDependencies,
+  nullishDependencies,
   orDependencies,
   xorDependencies,
 
@@ -5989,6 +6002,16 @@ export interface MathJsChain<TValue> {
   ): MathJsChain<boolean | MathCollection>
 
   /**
+   * Nullish coalescing operator (??). Returns the right-hand side operand
+   * when the left-hand side operand is null or undefined, and otherwise
+   * returns the left-hand side operand. For matrices, the function is
+   * evaluated element wise.
+   * @param y Fallback value
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nullish(this: MathJsChain<any>, y: any): MathJsChain<any>
+
+  /**
    * Logical or. Test if at least one value is defined with a
    * nonzero/nonempty value. For matrices, the function is evaluated
    * element wise.
@@ -7610,6 +7633,7 @@ export const {
   // logical
   and,
   not,
+  nullish,
   or,
   xor,
 


### PR DESCRIPTION
This PR adds the missing nullishDependencies export to index.d.ts.
The JavaScript bundle correctly exports this dependency factory, but the TypeScript definition file does not declare it, causing a compile-time error

Resolves #3597 