### PR TITLE
feat(units): Add reactive energy units VAh and VARh

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -2525,6 +2525,20 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       value: 3600,
       offset: 0
     },
+    VAh: {
+      name: 'VAh',
+      base: BASE_UNITS.ENERGY,
+      prefixes: PREFIXES.SHORT,
+      value: 3600,
+      offset: 0
+    },
+    VARh: {
+      name: 'VARh',
+      base: BASE_UNITS.ENERGY,
+      prefixes: PREFIXES.SHORT,
+      value: 3600,
+      offset: 0
+    },
     BTU: {
       name: 'BTU',
       base: BASE_UNITS.ENERGY,


### PR DESCRIPTION
This PR adds the units `VARh` and `VAh`, on the rationale that the other common unit of energy, `Wh`, is already implemented.
This means that currently `1 Wh` is accepted, but `1 VAR` is not, and one is forced to insert a space and write `1VAR h`, which is not best practice in the energy field, where `varh` and `vah` are used daily.

Notice that if PR #3615 is accepted, this will have to be rebased and modified to account for that.