### PR TITLE
feat(units): Add rpm unit

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -2255,6 +2255,14 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
       offset: 0,
       reciprocal: true
     },
+    rpm: {
+      name: 'rpm',
+      base: BASE_UNITS.FREQUENCY,
+      prefixes: PREFIXES.NONE,
+      value: 1 / 60,
+      offset: 0,
+      reciprocal: true
+    },
 
     // Angle
     rad: {


### PR DESCRIPTION
This PR adds [RPM](https://en.wikipedia.org/wiki/Revolutions_per_minute), the standard unit for engine revolutions, to the list of accepted units.

I considered also adding RPS (revolutions per seconds) but I think people could use Hz for that? They do in the cold storage (e.g. fridge compressors) sector.