### PR TITLE
fix: handle boundary cases for divide and log functions

### DIFF
--- a/src/function/arithmetic/divideScalar.js
+++ b/src/function/arithmetic/divideScalar.js
@@ -1,9 +1,13 @@
 import { factory } from '../../utils/factory.js'
 
 const name = 'divideScalar'
-const dependencies = ['typed', 'numeric']
+const dependencies = ['typed', 'Complex']
 
-export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({ typed, numeric }) => {
+export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({ typed, Complex }) => {
+  function isZeroComplex (z) {
+    return z.re === 0 && z.im === 0
+  }
+
   /**
    * Divide two scalar values, `x / y`.
    * This function is meant for internal use: it is used by the public functions
@@ -18,10 +22,24 @@ export const createDivideScalar = /* #__PURE__ */ factory(name, dependencies, ({
    */
   return typed(name, {
     'number, number': function (x, y) {
+      if (!Number.isFinite(x) && y === 0) {
+        return new Complex(Infinity, NaN)
+      }
+
       return x / y
     },
 
     'Complex, Complex': function (x, y) {
+      if (isZeroComplex(y)) {
+        if (isZeroComplex(x)) {
+          return x.div(y)
+        }
+
+        // Normalize non-zero complex divided by zero to complex infinity
+        // (infinite magnitude with undetermined phase).
+        return new x.constructor(Infinity, NaN)
+      }
+
       return x.div(y)
     },
 

--- a/test/unit-tests/function/arithmetic/divide.test.js
+++ b/test/unit-tests/function/arithmetic/divide.test.js
@@ -71,13 +71,13 @@ describe('divide', function () {
     approxDeepEqual(divide(complex('2+3i'), complex('4i')), complex('0.75 - 0.5i'))
     approxDeepEqual(divide(complex('2i'), complex('4i')), complex('0.5'))
     approxDeepEqual(divide(4, complex('1+2i')), complex('0.8 - 1.6i'))
-    approxDeepEqual(divide(math.i, 0), complex(Infinity, Infinity))
-    approxDeepEqual(divide(complex(0, 1), 0), complex(Infinity, Infinity))
-    approxDeepEqual(divide(complex(1, 0), 0), complex(Infinity, Infinity))
-    approxDeepEqual(divide(complex(0, 1), complex(0, 0)), complex(Infinity, Infinity))
-    approxDeepEqual(divide(complex(1, 1), complex(0, 0)), complex(Infinity, Infinity))
-    approxDeepEqual(divide(complex(1, -1), complex(0, 0)), complex(Infinity, -Infinity))
-    approxDeepEqual(divide(complex(-1, 1), complex(0, 0)), complex(-Infinity, Infinity))
+    approxDeepEqual(divide(math.i, 0), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(0, 1), 0), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(1, 0), 0), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(0, 1), complex(0, 0)), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(1, 1), complex(0, 0)), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(1, -1), complex(0, 0)), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(-1, 1), complex(0, 0)), complex(Infinity, NaN))
     approxDeepEqual(divide(complex(1, 1), complex(0, 1)), complex(1, -1))
     approxDeepEqual(divide(complex(1, 1), complex(1, 0)), complex(1, 1))
 
@@ -228,6 +228,16 @@ describe('divide', function () {
 
   it('should throw an in case of wrong type of arguments', function () {
     assert.throws(function () { divide(null, 2) }, /TypeError: Unexpected type of argument/)
+  })
+
+  it('should normalize complex divide-by-zero boundaries', function () {
+    approxDeepEqual(divide(math.i, 0), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(0, 1), 0), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(1, 0), 0), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(0, 1), complex(0, 0)), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(1, 1), complex(0, 0)), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(1, -1), complex(0, 0)), complex(Infinity, NaN))
+    approxDeepEqual(divide(complex(-1, 1), complex(0, 0)), complex(Infinity, NaN))
   })
 
   it('should LaTeX divide', function () {

--- a/test/unit-tests/function/arithmetic/log.test.js
+++ b/test/unit-tests/function/arithmetic/log.test.js
@@ -134,6 +134,13 @@ describe('log', function () {
       matrix([[0, 0.693147180559945], [1.098612288668110, 1.386294361119891]]))
   })
 
+  it('should handle boundary cases for log(x, base)', function () {
+    approxDeepEqual(log(0, 1), complex(Infinity, NaN))
+    approxDeepEqual(log(-1, 1), complex(Infinity, NaN))
+    approxDeepEqual(log(-1, -1), complex(1, 0))
+    assert(isNaN(log(0, 0)))
+  })
+
   it('should LaTeX log', function () {
     const expr1 = math.parse('log(e)')
     const expr2 = math.parse('log(32,2)')


### PR DESCRIPTION
# Description
- Resolves issue: https://github.com/josdejong/mathjs/issues/1277
- Root cause is scalar division edge behavior, surfaced via `log(x, base)` (`log(x) / log(base)`).
- Normalizes divide-by-zero boundaries to complex-infinity semantics (`Complex(Infinity, NaN)`) for:
  - `Complex/Complex` with zero denominator
  - `number/number` when numerator is `±Infinity` and denominator is `0`
- This aligns with issue discussion, pointing out `-Infinity/0` and complex divide-by-zero inconsistencies and proposing complex infinity style handling:
  - https://github.com/josdejong/mathjs/issues/1277#issuecomment-430752635
  - https://github.com/josdejong/mathjs/issues/1277#issuecomment-569914271
- Related design discussion on complex infinity consistency in PR thread:
  - https://github.com/josdejong/mathjs/pull/2097

## Tests
- Updated boundary expectations in:
  - `test/unit-tests/function/arithmetic/divide.test.js`
  - `test/unit-tests/function/arithmetic/log.test.js`
- Added/covered key regressions:
  - `log(0, 1)`
  - `log(-1, 1)`
  - `log(-1, -1)`
  - `log(0, 0)`
  - Complex divide-by-zero paths like `i/0`, `(1+i)/0`, `(1-i)/(0+0i)`.
- Verified locally:
  - `npx mocha test/unit-tests/function/arithmetic/log.test.js test/unit-tests/function/arithmetic/divide.test.js`

## Breaking Changes
- No API signature changes.
- Behavioral change in edge cases:
  - Some operations that previously returned directional infinities like `Infinity + Infinity i` now return `Complex(Infinity, NaN)`.
  - Scalar `±Infinity / 0` now returns `Complex(Infinity, NaN)` instead of numeric `±Infinity`.
- Consumers asserting exact real/imag infinity signs in these boundary cases may need test updates.
- Consumers expecting numeric return type for `±Infinity / 0` must adapt to Complex output in that boundary case.

## Impact on Codebase
- **Positive consistency impact**
  - Edge handling is centralized in `src/function/arithmetic/divideScalar.js`, reducing duplicated special-case logic in higher-level functions.
  - `src/function/arithmetic/log.js` remains generic (`divideScalar(self(x), self(base))`), improving maintainability.

- **Cross-function behavioral impact**
  - Function paths using scalar `Complex/Complex` and `number/number` (`±Infinity / 0`) division now inherit normalized complex-infinity behavior.
  - This improves mathematical coherence for complex limits but can alter legacy outputs in rare edge cases.

- **Testing impact**
  - Existing tests that encoded directional infinity for divide-by-zero were updated to undetermined-phase semantics.
  - Added regression coverage reduces risk of reintroducing inconsistent infinity behavior through future refactors.

- **Risk profile**
  - Low-to-moderate runtime risk: scope is small and localized to scalar division branches.
  - Main risk is downstream expectation drift (user code/tests depending on old directional outputs or numeric type for `±Infinity / 0`), not broad numerical regressions in finite-domain operations.
  
  
> Note I reviewed the code and made sure to understand the issue to the best of my ability, but I mainly used agentic coding to try and solve the issue. If there is any fundamental misunderstanding or issue arising from this approach, please let me know.
