### PR TITLE
fix: BigNumber eigenvalue computation broken by Decimal.js string comparison

### DIFF
--- a/src/function/matrix/eigs/realSymmetric.js
+++ b/src/function/matrix/eigs/realSymmetric.js
@@ -1,6 +1,23 @@
 import { clone } from '../../../utils/object.js'
 
 export function createRealSymmetric ({ config, addScalar, subtract, abs, atan, cos, sin, multiplyScalar, inv, bignumber, multiply, add }) {
+  // BigNumber comparison helpers — Decimal.js valueOf() returns strings,
+  // so JavaScript >=/</<= operators do lexicographic comparison instead of
+  // numeric (e.g., "1" < "5e-13" because '1' < '5' in ASCII). Use Decimal's
+  // native .gte()/.lt()/.lte() methods for correct numeric comparison.
+  function bigGte (a, b) {
+    if (typeof a === 'number' && typeof b === 'number') return a >= b
+    return a.gte ? a.gte(b) : a >= b
+  }
+  function bigLt (a, b) {
+    if (typeof a === 'number' && typeof b === 'number') return a < b
+    return a.lt ? a.lt(b) : a < b
+  }
+  function bigLte (a, b) {
+    if (typeof a === 'number' && typeof b === 'number') return a <= b
+    return a.lte ? a.lte(b) : a <= b
+  }
+
   /**
    * @param {number[] | BigNumber[]} arr
    * @param {number} N
@@ -53,20 +70,22 @@ export function createRealSymmetric ({ config, addScalar, subtract, abs, atan, c
   // diagonalization implementation for bigNumber
   function diagBig (x, precision, computeVectors) {
     const N = x.length
-    const e0 = abs(precision / N)
+    const e0 = abs(bignumber(precision) / N)
     let psi
     let Sij
     if (computeVectors) {
       Sij = new Array(N)
-      // Sij is Identity Matrix
+      // Sij is Identity Matrix — use BigNumber values for type consistency
       for (let i = 0; i < N; i++) {
-        Sij[i] = Array(N).fill(0)
-        Sij[i][i] = 1.0
+        Sij[i] = new Array(N)
+        for (let j = 0; j < N; j++) {
+          Sij[i][j] = bignumber(i === j ? 1 : 0)
+        }
       }
     }
     // initial error
     let Vab = getAijBig(x)
-    while (abs(Vab[1]) >= abs(e0)) {
+    while (bigGte(abs(Vab[1]), abs(e0))) {
       const i = Vab[0][0]
       const j = Vab[0][1]
       psi = getThetaBig(x[i][i], x[j][j], x[i][j])
@@ -74,11 +93,10 @@ export function createRealSymmetric ({ config, addScalar, subtract, abs, atan, c
       if (computeVectors) Sij = Sij1Big(Sij, psi, i, j)
       Vab = getAijBig(x)
     }
-    const Ei = Array(N).fill(0) // eigenvalues
+    const Ei = new Array(N)
     for (let i = 0; i < N; i++) {
       Ei[i] = x[i][i]
     }
-    // return [clone(Ei), clone(Sij)]
     return sorting(clone(Ei), Sij, computeVectors)
   }
 
@@ -95,7 +113,7 @@ export function createRealSymmetric ({ config, addScalar, subtract, abs, atan, c
   // get angle
   function getThetaBig (aii, ajj, aij) {
     const denom = subtract(ajj, aii)
-    if (abs(denom) <= config.relTol) {
+    if (bigLte(abs(denom), bignumber(config.relTol))) {
       return bignumber(-1).acos().div(4)
     } else {
       return multiplyScalar(0.5, atan(multiply(2.0, aij, inv(denom))))
@@ -226,11 +244,11 @@ export function createRealSymmetric ({ config, addScalar, subtract, abs, atan, c
   // get max off-diagonal value from Upper Diagonal
   function getAijBig (Mij) {
     const N = Mij.length
-    let maxMij = 0
+    let maxMij = bignumber(0)
     let maxIJ = [0, 1]
     for (let i = 0; i < N; i++) {
       for (let j = i + 1; j < N; j++) {
-        if (abs(maxMij) < abs(Mij[i][j])) {
+        if (bigLt(abs(maxMij), abs(Mij[i][j]))) {
           maxMij = abs(Mij[i][j])
           maxIJ = [i, j]
         }
@@ -254,7 +272,7 @@ export function createRealSymmetric ({ config, addScalar, subtract, abs, atan, c
       let minID = 0
       let minE = E[0]
       for (let j = 0; j < E.length; j++) {
-        if (abs(E[j]) < abs(minE)) {
+        if (bigLt(abs(E[j]), abs(minE))) {
           minID = j
           minE = E[minID]
         }


### PR DESCRIPTION
## Summary

BigNumber eigenvalue computation (`eigs()`) silently returns incorrect results for all BigNumber matrix inputs. The Jacobi rotation convergence loop never executes because JavaScript's comparison operators perform lexicographic string comparison on Decimal.js objects instead of numeric comparison.

## Root Cause

`Decimal.js`'s `valueOf()` returns a **string**, not a number. When JavaScript's `>=`, `<`, `<=` operators compare two objects, they call `valueOf()` on both operands. With strings, comparison is lexicographic:

```javascript
new Decimal(1) >= new Decimal('5e-13')  // false! ('1' < '5' in ASCII)
new Decimal(1).gte(new Decimal('5e-13')) // true (correct)
```

This affects 4 comparison sites in `realSymmetric.js`:
1. `diagBig` convergence loop: `abs(Vab[1]) >= abs(e0)` — loop never executes
2. `getThetaBig` threshold: `abs(denom) <= config.relTol` — wrong branch taken
3. `getAijBig` max finding: `abs(maxMij) < abs(Mij[i][j])` — wrong max selected
4. `sorting` eigenvalue ordering: `abs(E[j]) < abs(minE)` — wrong sort order

## Fix

Added helper functions that use Decimal.js's native comparison methods (`.gte()`, `.lt()`, `.lte()`) which perform correct numeric comparison. The helpers fall through to native operators for plain `number` types.

Also fixes:
- `getAijBig`: initialize `maxMij` as `bignumber(0)` instead of plain `0`
- `diagBig`: initialize identity matrix with `bignumber()` values instead of plain numbers
- `getThetaBig`: wrap `config.relTol` in `bignumber()` for type-safe comparison

## Test Plan

- [x] Verified `eigs([[0,1],[1,0]])` returns eigenvalues `{-1, 1}` (was returning `{0, 0}`)
- [x] Verified `eigs([[1,1],[1,1]])` returns eigenvalues `{0, 2}` (was returning `{1, 1}`)
- [x] Verified 6x6 BigNumber matrix eigenvalue decomposition
- [x] Verified BigNumber precision is maintained (64 decimal digits)
- [x] Verified number-type eigenvalue computation still works (no regression)
- [x] All existing eigs tests pass (16 passing, 0 failing)

## Impact

This bug affects **all** BigNumber eigenvalue computations. Any user calling `eigs()` with BigNumber matrix inputs gets incorrect results (the unchanged diagonal entries instead of actual eigenvalues). Number-type inputs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)