### PR TITLE
fix: preserve original order in setDistinct

### DIFF
--- a/src/function/set/setDistinct.js
+++ b/src/function/set/setDistinct.js
@@ -8,7 +8,7 @@ export const createSetDistinct = /* #__PURE__ */ factory(name, dependencies, ({ 
   /**
    * Collect the distinct elements of a multiset.
    * A multi-dimension array will be converted to a single-dimension array before the operation.
-   * The items of the returned array will be sorted in natural order.
+   * The original order of elements is preserved.
    *
    * Syntax:
    *
@@ -31,11 +31,17 @@ export const createSetDistinct = /* #__PURE__ */ factory(name, dependencies, ({ 
       if (subset(size(a), new Index(0)) === 0) { // if empty, return empty
         result = []
       } else {
-        const b = flatten(Array.isArray(a) ? a : a.toArray()).sort(compareNatural)
+        const b = flatten(Array.isArray(a) ? a : a.toArray())
         result = []
-        result.push(b[0])
-        for (let i = 1; i < b.length; i++) {
-          if (compareNatural(b[i], b[i - 1]) !== 0) {
+        for (let i = 0; i < b.length; i++) {
+          let isDuplicate = false
+          for (let j = 0; j < result.length; j++) {
+            if (compareNatural(b[i], result[j]) === 0) {
+              isDuplicate = true
+              break
+            }
+          }
+          if (!isDuplicate) {
             result.push(b[i])
           }
         }

--- a/test/unit-tests/function/set/setDistinct.test.js
+++ b/test/unit-tests/function/set/setDistinct.test.js
@@ -12,7 +12,7 @@ describe('setDistinct', function () {
   it('should return the distinct elements of a multiset', function () {
     assert.deepStrictEqual(math.setDistinct([1, 1, 2, 2]), [1, 2])
     assert.deepStrictEqual(math.setDistinct([1, 2, 1, 2]), [1, 2])
-    assert.deepStrictEqual(math.setDistinct([1, 2, math.complex(3, 3), 2, math.complex(3, 3)]), [math.complex(3, 3), 1, 2])
+    assert.deepStrictEqual(math.setDistinct([1, 2, math.complex(3, 3), 2, math.complex(3, 3)]), [1, 2, math.complex(3, 3)])
   })
 
   it('should return the same type of output as the inputs', function () {


### PR DESCRIPTION
Fixes #3602

`setDistinct` was sorting elements via `compareNatural` before deduplication, which silently reordered the input. `setDistinct([3, 1, 2])` returned `[1, 2, 3]` instead of `[3, 1, 2]`.

Now uses an insertion-order-preserving approach: iterates through the flattened array and only pushes elements that haven't been seen (using `compareNatural` for equality checking, preserving the existing semantics for complex numbers and mixed types).

**Changes:**
- `src/function/set/setDistinct.js`: Replaced sort-then-dedupe with order-preserving dedupe
- Updated JSDoc to say "original order is preserved" instead of "sorted in natural order"
- Updated test expectation for complex number ordering

---
*This change was made with AI assistance.*

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)