### PR TITLE
fix(combinatorics): stirlingS2 returns plain number instead of BigNumber for S(n,n) with n>0

### DIFF
--- a/src/function/combinatorics/stirlingS2.js
+++ b/src/function/combinatorics/stirlingS2.js
@@ -92,7 +92,7 @@ export const createStirlingS2 = /* #__PURE__ */ factory(name, dependencies, (
         const prev = cache[m - 1]
         for (let i = row.length; i <= m && i <= nk; ++i) {
           if (i === m) {
-            row[i] = 1
+            row[i] = make(1)
           } else {
             row[i] = addScalar(multiplyScalar(make(i), prev[i]), prev[i - 1])
           }

--- a/test/unit-tests/function/combinatorics/stirlingS2.test.js
+++ b/test/unit-tests/function/combinatorics/stirlingS2.test.js
@@ -26,6 +26,13 @@ describe('stirlingS2', function () {
     assert.deepStrictEqual(stirlingS2(bn(23), 9), bn('12320068811796900'))
     assert.deepStrictEqual(stirlingS2(bn(50), 14),
       bn('16132809270066494376125322988035691981158490930'))
+    // S(n,n) = 1 must return BigNumber when both inputs are BigNumber (n > 0)
+    // S(n,n) = 1 must return BigNumber when both inputs are BigNumber (n > 0)
+    assert.deepStrictEqual(stirlingS2(bn(1), bn(1)), bn(1))
+    assert.deepStrictEqual(stirlingS2(bn(3), bn(3)), bn(1))
+    assert.deepStrictEqual(stirlingS2(bn(7), bn(7)), bn(1))
+    // mixed: one BigNumber input still produces BigNumber when n===k
+    assert.deepStrictEqual(stirlingS2(bn(4), 4), bn(1))
   })
 
   it('should not work with non-integer and negative input', function () {


### PR DESCRIPTION
## Bug

`stirlingS2(bignumber(n), bignumber(n))` returns a plain JS `number` (`1`) instead of a `BigNumber` when `n > 0`, even though both inputs are BigNumbers. The `S(0,0)` case is correct because it is initialised via `cache[0] = [make(1)]` (with `make = bignumber` in BigNumber mode). However, the diagonal entries for `n > 0` are filled by:

```js
if (i === m) {
  row[i] = 1          // BUG: plain literal, not make(1)
}
```

so the result is always the primitive `1` rather than `bignumber(1)`.

Reproduction:
```js
math.typeOf(math.stirlingS2(math.bignumber(3), math.bignumber(3)))
// 'number'  ← should be 'BigNumber'
```

## Fix

Replace `row[i] = 1` with `row[i] = make(1)` so the diagonal entry is created with the same factory function used everywhere else in the loop.

## Verification

```
npx mocha test/unit-tests/function/combinatorics/stirlingS2.test.js
# 5 passing
```

Four regression tests added: `stirlingS2(bn(1),bn(1))`, `stirlingS2(bn(3),bn(3))`, `stirlingS2(bn(7),bn(7))`, and the mixed-input `stirlingS2(bn(4),4)` — all now return `BigNumber(1)`.

> AI-assisted contribution