### PR TITLE
fix: allow zero values in multinomial

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 # unpublished changes since 15.2.0
 
+- Fix: `multinomial` threw a `TypeError` on arrays containing a zero, like
+  `multinomial([2, 0, 1])`. Zero is a valid count (`0! = 1`), consistent with
+  `combinations` and `factorial`.
 - Docs: fix the browser example `rocket_trajectory_optimization.html` (#3654).
   Thanks @dvd101x.
 

--- a/src/function/probability/multinomial.js
+++ b/src/function/probability/multinomial.js
@@ -2,14 +2,14 @@ import { deepForEach } from '../../utils/collection.js'
 import { factory } from '../../utils/factory.js'
 
 const name = 'multinomial'
-const dependencies = ['typed', 'add', 'divide', 'multiply', 'factorial', 'isInteger', 'isPositive']
+const dependencies = ['typed', 'add', 'divide', 'multiply', 'factorial', 'isInteger', 'isNegative']
 
-export const createMultinomial = /* #__PURE__ */ factory(name, dependencies, ({ typed, add, divide, multiply, factorial, isInteger, isPositive }) => {
+export const createMultinomial = /* #__PURE__ */ factory(name, dependencies, ({ typed, add, divide, multiply, factorial, isInteger, isNegative }) => {
   /**
    * Multinomial Coefficients compute the number of ways of picking a1, a2, ..., ai unordered outcomes from `n` possibilities.
    *
    * multinomial takes one array of integers as an argument.
-   * The following condition must be enforced: every ai <= 0
+   * The following condition must be enforced: every ai >= 0
    *
    * Syntax:
    *
@@ -32,7 +32,7 @@ export const createMultinomial = /* #__PURE__ */ factory(name, dependencies, ({ 
       let denom = 1
 
       deepForEach(a, function (ai) {
-        if (!isInteger(ai) || !isPositive(ai)) {
+        if (!isInteger(ai) || isNegative(ai)) {
           throw new TypeError('Positive integer value expected in function multinomial')
         }
         sum = add(sum, ai)

--- a/test/unit-tests/function/probability/multinomial.test.js
+++ b/test/unit-tests/function/probability/multinomial.test.js
@@ -15,6 +15,16 @@ describe('multinomial', function () {
     assert.deepStrictEqual(multinomial([math.bignumber(10), math.bignumber(1), math.bignumber(2)]), math.bignumber(858))
   })
 
+  it('should allow zero values (0! = 1), consistent with combinations', function () {
+    assert.strictEqual(multinomial([0]), 1)
+    assert.strictEqual(multinomial([3, 0]), 1)
+    assert.strictEqual(multinomial([2, 0, 1]), 3)
+    assert.strictEqual(multinomial([0, 4, 4]), 70)
+    // multinomial([k, n - k]) must agree with combinations(n, k)
+    assert.strictEqual(multinomial([5, 0]), math.combinations(5, 5))
+    assert.deepStrictEqual(multinomial([math.bignumber(3), math.bignumber(0)]), math.bignumber(1))
+  })
+
   it('should not work with non-integer and negative input', function () {
     assert.throws(function () { multinomial([0.5, 3]) }, TypeError)
     assert.throws(function () { multinomial([math.bignumber(3), math.bignumber(0.5)]) }, TypeError)


### PR DESCRIPTION
## What

`multinomial` threw a `TypeError` for any input array containing a zero:

```js
math.multinomial([2, 0, 1]) // TypeError: Positive integer value expected in function multinomial
math.multinomial([3, 0])    // TypeError
math.multinomial([0])       // TypeError
```

A zero count is mathematically valid. The multinomial coefficient is

> multinomial([k₁, …, kₘ]) = (Σ kᵢ)! / ∏ (kᵢ!)

and since `0! = 1`, a zero part simply contributes a factor of 1. The expected values are:

| call | correct value |
|------|---------------|
| `multinomial([2, 0, 1])` | 3 |
| `multinomial([3, 0])` | 1 |
| `multinomial([0])` | 1 |
| `multinomial([0, 4, 4])` | 70 |

(verified against Python's `math.factorial`.)

## Why it's a bug (inconsistency)

The multinomial coefficient is the standard generalization of the binomial coefficient, and `multinomial([k, n - k])` should equal `combinations(n, k)`. But:

```js
math.combinations(5, 5)   // 1   ✅
math.multinomial([5, 0])  // TypeError ❌  (same quantity!)
```

`combinations` (both the `number` and `BigNumber` paths), `combinationsWithRep`, and `factorial` all accept non-negative integers (their "positive integer" checks use `>= 0`). Only `multinomial` rejected zero, because it validated with `!isPositive(ai)` and `isPositive(0) === false`.

## Fix

Reject only negatives (`isNegative(ai)`) instead of non-positives (`!isPositive(ai)`); the existing `isInteger` check still rejects non-integers. `isNegative(0)` is `false` for `number`, `BigNumber`, `bigint`, and `Fraction`, so a zero now passes while negatives and non-integers still throw. Also fixes the doc-comment typo (`every ai <= 0` → `every ai >= 0`).

## Tests

- Added a test covering zero parts for both `number` and `BigNumber`, including the `multinomial([k, n - k]) === combinations(n, k)` identity.
- Verified it **fails without** the source change (with the exact `TypeError`) and **passes with** it.
- Full suite green: `6653 passing`. ESLint clean.