### PR TITLE
fix: splitUnit returns original unit when called as a method with array parts (#3644)

### DIFF
--- a/src/type/unit/Unit.js
+++ b/src/type/unit/Unit.js
@@ -1,4 +1,4 @@
-import { isComplex, isUnit, typeOf } from '../../utils/is.js'
+import { isComplex, isMatrix, isUnit, typeOf } from '../../utils/is.js'
 import { factory } from '../../utils/factory.js'
 import { memoize } from '../../utils/function.js'
 import { endsWith } from '../../utils/string.js'
@@ -1320,6 +1320,14 @@ export const createUnitClass = /* #__PURE__ */ factory(name, dependencies, ({
    * @return {Array} An array of units.
    */
   Unit.prototype.splitUnit = function (parts) {
+    // When invoked as a method in the expression parser
+    // (e.g. `(1 m).splitUnit([ft, in])`), `parts` is passed as a Matrix rather
+    // than a plain Array. Normalize it to an Array so the iteration below works
+    // in both cases.
+    if (isMatrix(parts)) {
+      parts = parts.toArray()
+    }
+
     let x = this.clone()
     const ret = []
     for (let i = 0; i < parts.length; i++) {

--- a/test/unit-tests/type/unit/function/splitUnit.test.js
+++ b/test/unit-tests/type/unit/function/splitUnit.test.js
@@ -11,4 +11,13 @@ describe('splitUnit', function () {
 
     assert.strictEqual(math.evaluate('splitUnit(1 m, [ft, in])').toString(), '3 ft,3.3700787401574765 in')
   })
+
+  it('should split a unit when parts are passed as a Matrix', function () {
+    // when splitUnit is called as a method in the expression parser, the parts
+    // are passed as a Matrix rather than an Array (see #3644)
+    assert.strictEqual(splitUnit(new Unit(1, 'm'), math.matrix(['ft', 'in'])).toString(), '3 ft,3.3700787401574765 in')
+
+    assert.strictEqual(math.evaluate('(1 m).splitUnit([ft, in])').toString(), '3 ft,3.3700787401574765 in')
+    assert.strictEqual(math.evaluate('(1 m).splitUnit(["ft", "in"])').toString(), '3 ft,3.3700787401574765 in')
+  })
 })


### PR DESCRIPTION
## What

Fixes the `splitUnit` method-call form in the expression parser, which silently returned the original unit unchanged.

```
(1 m).splitUnit([ft, in])      // before: 1 m        after: 3 ft,3.3700787401574765 in
(1 m).splitUnit(["ft", "in"])  // before: 1 m        after: 3 ft,3.3700787401574765 in
```

Closes #3644.

## Why

`Unit.prototype.splitUnit` iterates over `parts.length`. When `splitUnit` is invoked as a **method** in the expression parser (e.g. `(1 m).splitUnit([ft, in])`), the parser dispatches the call directly to the prototype method via `getSafeMethod`/`fn.apply(object, values)`, passing the array literal as a **Matrix** (the default `matrix: 'Matrix'` config) rather than a plain Array.

A `Matrix` has no `.length` property, so `parts.length` is `undefined`, the `for` loop never executes, and the method falls through to returning `[this]` — the original, unsplit unit.

The **function** form `splitUnit(1 m, [ft, in])` was unaffected because it goes through the typed-function `'Unit, Array'` signature, which converts the Matrix to an Array before reaching the prototype method.

## Fix

Normalize `parts` to an Array (via `toArray()`) when it is a Matrix, so the method-call form behaves identically to the function-call form. Minimal change, no new dependencies.

## How to test

```js
math.evaluate('(1 m).splitUnit([ft, in])').toString()     // '3 ft,3.3700787401574765 in'
math.evaluate('(1 m).splitUnit(["ft", "in"])').toString() // '3 ft,3.3700787401574765 in'
```

A regression test covering the Matrix/method-call form was added to `test/unit-tests/type/unit/function/splitUnit.test.js`. The full unit-test suite (`npx mocha test/unit-tests`) passes (6653 passing) and `eslint` is clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
