### PR TITLE
fix: report the actual function name in the non-angle Unit error of trig functions

### DIFF
--- a/src/function/trigonometry/trigUnit.js
+++ b/src/function/trigonometry/trigUnit.js
@@ -4,7 +4,7 @@ export const createTrigUnit = /* #__PURE__ */ factory(
   'trigUnit', ['typed'], ({ typed }) => ({
     Unit: typed.referToSelf(self => x => {
       if (!x.hasBase(x.constructor.BASE_UNITS.ANGLE)) {
-        throw new TypeError('Unit in function cot is no angle')
+        throw new TypeError('Unit in function ' + self.name + ' is no angle')
       }
       return typed.find(self, x.valueType())(x.value)
     })

--- a/test/unit-tests/function/trigonometry/cos.test.js
+++ b/test/unit-tests/function/trigonometry/cos.test.js
@@ -92,7 +92,7 @@ describe('cos', function () {
   })
 
   it('should throw an error if called with an invalid unit', function () {
-    assert.throws(function () { cos(unit('5 celsius')) })
+    assert.throws(function () { cos(unit('5 celsius')) }, /Unit in function cos is no angle/)
   })
 
   it('should throw an error if called with a string', function () {

--- a/test/unit-tests/function/trigonometry/cot.test.js
+++ b/test/unit-tests/function/trigonometry/cot.test.js
@@ -69,7 +69,7 @@ describe('cot', function () {
   })
 
   it('should throw an error if called with an invalid unit', function () {
-    assert.throws(function () { cot(unit('5 celsius')) })
+    assert.throws(function () { cot(unit('5 celsius')) }, /Unit in function cot is no angle/)
   })
 
   it('should throw an error if called with a string', function () {

--- a/test/unit-tests/function/trigonometry/csc.test.js
+++ b/test/unit-tests/function/trigonometry/csc.test.js
@@ -64,7 +64,7 @@ describe('csc', function () {
   })
 
   it('should throw an error if called with an invalid unit', function () {
-    assert.throws(function () { csc(unit('5 celsius')) })
+    assert.throws(function () { csc(unit('5 celsius')) }, /Unit in function csc is no angle/)
   })
 
   it('should throw an error if called with a string', function () {

--- a/test/unit-tests/function/trigonometry/sec.test.js
+++ b/test/unit-tests/function/trigonometry/sec.test.js
@@ -80,7 +80,7 @@ describe('sec', function () {
   })
 
   it('should throw an error if called with an invalid unit', function () {
-    assert.throws(function () { sec(unit('5 celsius')) })
+    assert.throws(function () { sec(unit('5 celsius')) }, /Unit in function sec is no angle/)
   })
 
   it('should throw an error if called with a string', function () {

--- a/test/unit-tests/function/trigonometry/sin.test.js
+++ b/test/unit-tests/function/trigonometry/sin.test.js
@@ -95,7 +95,7 @@ describe('sin', function () {
   })
 
   it('should throw an error if called with an invalid unit', function () {
-    assert.throws(function () { sin(unit('5 celsius')) })
+    assert.throws(function () { sin(unit('5 celsius')) }, /Unit in function sin is no angle/)
   })
 
   it('should throw an error if called with a string', function () {

--- a/test/unit-tests/function/trigonometry/tan.test.js
+++ b/test/unit-tests/function/trigonometry/tan.test.js
@@ -64,7 +64,7 @@ describe('tan', function () {
   })
 
   it('should throw an error if called with an invalid unit', function () {
-    assert.throws(function () { tan(unit('5 celsius')) })
+    assert.throws(function () { tan(unit('5 celsius')) }, /Unit in function tan is no angle/)
   })
 
   it('should throw an error if called with a string', function () {


### PR DESCRIPTION
The shared `trigUnit` helper hard-codes `cot` in the "is no angle" error, so every function that uses it (`sin`, `cos`, `tan`, `sec`, `csc`, and `cot`) reports `cot` when it is given a unit that is not an angle. Five of the six name the wrong function:

```js
math.sin(math.unit('5 celsius'))
// TypeError: Unit in function cot is no angle
```

That should read "function sin". The message already follows the pattern "Unit in function <name> is no angle", so the name just needs to come from the function that was actually called instead of being hard-coded to `cot`. The fix reads it from `self.name`, which resolves to `sin`, `cos`, `tan`, `sec`, `csc`, or `cot` depending on which function the signature ends up in.

All six trig functions had an "invalid unit" test that only checked that an error was thrown, never the message, so the wrong name went unnoticed. I tightened those assertions to also check the message. The five non-`cot` tests fail on the current code and pass with this change; `cot` was already correct.
