### PR TITLE
Fix adding a BigNumber scalar to a number-datatype matrix

### DIFF
--- a/src/type/matrix/utils/matAlgo14xDs.js
+++ b/src/type/matrix/utils/matAlgo14xDs.js
@@ -33,12 +33,19 @@ export const createMatAlgo14xDs = /* #__PURE__ */ factory(name, dependencies, ({
 
     // process data types
     if (typeof adt === 'string') {
-      // datatype
-      dt = adt
-      // convert b to the same datatype
-      b = typed.convert(b, dt)
-      // callback
-      cf = typed.find(callback, [dt, dt])
+      // Take the datatype fast-path only when the scalar converts into the
+      // matrix's datatype. When it cannot (e.g. a BigNumber scalar and a
+      // `number` matrix), fall through to the generic callback so the values
+      // promote as usual instead of throwing on the conversion.
+      let converted
+      try {
+        converted = typed.convert(b, adt)
+      } catch {}
+      if (converted !== undefined) {
+        b = converted
+        dt = adt
+        cf = typed.find(callback, [dt, dt])
+      }
     }
 
     // populate cdata, iterate through dimensions

--- a/test/unit-tests/function/arithmetic/add.test.js
+++ b/test/unit-tests/function/arithmetic/add.test.js
@@ -123,6 +123,13 @@ describe('add', function () {
       assert.deepStrictEqual(a4.size(), [2])
       assert.deepStrictEqual(a4.valueOf(), [math.bignumber(8), math.bignumber(10)])
     })
+
+    it('should promote when a scalar does not fit the matrix datatype (#3612)', function () {
+      const a = math.matrix([[1, 2]], 'dense', 'number')
+      const expected = math.matrix([[math.bignumber(4), math.bignumber(5)]])
+      assert.deepStrictEqual(add(a, math.bignumber(3)), expected)
+      assert.deepStrictEqual(add(math.bignumber(3), a), expected)
+    })
   })
 
   describe('SparseMatrix', function () {


### PR DESCRIPTION
---

`add(matrix([[1, 2]], 'dense', 'number'), bignumber(3))` threw `Cannot convert 3 to number` instead of returning `[[4, 5]]` as BigNumbers. Thanks for the pointer to `matAlgo14xDs`.

When a matrix has a declared datatype, the dense scalar path converts the scalar into that datatype first. `BigNumber -> number` is lossy so it throws, instead of promoting like mathjs normally would. Fix takes that fast path only when the scalar actually converts, otherwise it falls back to the generic per-element callback (same path a `number` matrix with no declared datatype already uses). Result is `[[bignumber(4), bignumber(5)]]`, datatype dropped to undefined.

One call for you: I kept this to the reported dense case. The sparse path (`matAlgo11xS0s`) and the other matrix-scalar algos have the same force-conversion and throw the same way (checked sparse). Happy to fix them all here if you'd rather one sweep, but left it contained given your note that there are probably more spots. Some overlap with #3607 too, which rewrites this file for other reasons.

closes #3612