### PR TITLE
fix: restore BigNumber precision state when decimal.js trig throws precision-limit errors

### DIFF
--- a/src/type/bignumber/BigNumber.js
+++ b/src/type/bignumber/BigNumber.js
@@ -3,10 +3,41 @@ import { factory } from '../../utils/factory.js'
 
 const name = 'BigNumber'
 const dependencies = ['?on', 'config']
+const trigonometricMethods = [
+  'acos', 'acosh', 'asin', 'asinh', 'atan', 'atanh',
+  'cos', 'cosh', 'sin', 'sinh', 'tan', 'tanh',
+  'cosine', 'hyperbolicCosine', 'hyperbolicSine', 'hyperbolicTangent',
+  'inverseCosine', 'inverseHyperbolicCosine', 'inverseHyperbolicSine',
+  'inverseHyperbolicTangent', 'inverseSine', 'inverseTangent', 'sine', 'tangent'
+]
 
 export const createBigNumberClass = /* #__PURE__ */ factory(name, dependencies, ({ on, config }) => {
   const BigNumber = Decimal.clone({ precision: config.precision, modulo: Decimal.EUCLID })
   BigNumber.prototype = Object.create(BigNumber.prototype)
+
+  trigonometricMethods.forEach(method => {
+    const originalMethod = BigNumber.prototype[method]
+
+    BigNumber.prototype[method] = function (...args) {
+      const precision = BigNumber.precision
+      const rounding = BigNumber.rounding
+
+      try {
+        return originalMethod.apply(this, args)
+      } catch (error) {
+        if (error instanceof Error &&
+          error.message.includes('Precision limit exceeded') &&
+          !error.message.includes('decimal.js trigonometric functions are limited')) {
+          error.message += '; decimal.js trigonometric functions are limited to approximately ' +
+            `1000 digits of working precision (configured precision is ${config.precision})`
+        }
+        throw error
+      } finally {
+        BigNumber.precision = precision
+        BigNumber.rounding = rounding
+      }
+    }
+  })
 
   /**
    * Attach type information

--- a/test/unit-tests/function/trigonometry/tan.test.js
+++ b/test/unit-tests/function/trigonometry/tan.test.js
@@ -41,6 +41,17 @@ describe('tan', function () {
     assert.deepStrictEqual(bigTan(bigPi.div(4)).toString(), '0.999999999999999999999')
   })
 
+  it('should restore BigNumber precision after a decimal.js precision error', function () {
+    const highPrecisionMath = math.create({ number: 'BigNumber', precision: 509 })
+
+    assert.throws(
+      () => highPrecisionMath.evaluate('tan(pi/2)'),
+      /decimal\.js trigonometric functions are limited/
+    )
+    assert.strictEqual(highPrecisionMath.BigNumber.precision, 509)
+    assert.strictEqual(highPrecisionMath.evaluate('1.1 + 2.2').toString(), '3.3')
+  })
+
   it('should return the tangent of a complex number', function () {
     const re = 0.00376402564150425
     const im = 1.00323862735360980

--- a/test/unit-tests/type/bignumber/BigNumber.test.js
+++ b/test/unit-tests/type/bignumber/BigNumber.test.js
@@ -32,4 +32,32 @@ describe('BigNumber', function () {
 
     assert.strictEqual(a.toJSON(), '2')
   })
+
+  it('should restore precision and rounding when a trigonometric method throws', function () {
+    const bigmath = math.create({ number: 'BigNumber', precision: 509 })
+    const BigNumber = bigmath.BigNumber
+
+    assert.throws(
+      () => bigmath.pi.div(2).tangent(),
+      error => {
+        assert.ok(error instanceof Error)
+        assert.match(error.message, /decimal\.js trigonometric functions are limited/)
+        assert.match(error.message, /configured precision is 509/)
+        return true
+      }
+    )
+    assert.strictEqual(BigNumber.precision, 509)
+    assert.strictEqual(BigNumber.rounding, Decimal.ROUND_HALF_UP)
+
+    bigmath.config({ precision: 100 })
+
+    const UnwrappedBigNumber = Decimal.clone({ precision: 100, modulo: Decimal.EUCLID })
+    const value = bigmath.pi.div(2)
+    const expected = new UnwrappedBigNumber(value.toString()).tan()
+
+    assert.strictEqual(BigNumber.precision, 100)
+    assert.strictEqual(bigmath.tan(value).toString(), expected.toString())
+
+    bigmath.config({ precision: 509 })
+  })
 })


### PR DESCRIPTION
## Summary
Fix at the single choke point where mathjs creates its BigNumber class: `src/type/bignumber/BigNumber.js` (the factory that does `Decimal.clone({precision: config.precision})`). After cloning, wrap the trig-family prototype methods that use decimal.js's PI-based argument reduction (`sin/cos/tan/asin/acos/atan` and their cosecant/secant/cotangent/hyperbolic aliases as exposed by decimal.js: `sine`, `cosine`, `tangent`, etc.) in a thin guard that snapshots `BigNumber.precision` and `BigNumber.rounding` before delegating and restores them in a `finally` block, so a thrown DecimalError can no longer leave the class in a corrupted state. In the catch path, rethrow the DecimalError wrapped with an actionable message (e.g.

## Why this matters
With `math.config({number: 'BigNumber', precision: 509, ...})`, evaluating `tan(pi/2)` (or any trig call on a high-precision argument) throws `[DecimalError] Precision limit exceeded` from decimal.js. The root cause is that decimal.js trig methods internally raise working precision to roughly `precision + sd(x)` guard digits for argument reduction against its PI constant, which is only stored to 1025 digits; 509 + ~509 exceeds that limit. Worse (per the reporter's follow-up comment), decimal.js mutates `Ctor.precision`/`Ctor.rounding` before computing and only restores them on success, so once the error is thrown the mathjs BigNumber class is left with a corrupted precision (~1025), and every subsequent BigNumber evaluation fails with the same error until the page is reloaded. The hard 1025-digit PI limit lives in decimal.js and cannot be lifted from mathjs, but the sticky global-state corruption and the cryptic error are mathjs-side bugs that can be fixed.

See https://github.com/josdejong/mathjs/issues/3676.

## Testing
- Happy path: with default precision (64), `tan(pi/2)`, `sin(0.5)`, `cos(bignumber(1))` still return correct BigNumber results and existing trig unit tests pass unchanged. - Sticky-state regression (core fix): configure a fresh math instance with `{number: 'BigNumber', precision: 509}`; assert `evaluate('tan(pi/2)')` throws, then assert a subsequent unrelated BigNumber evaluation (e.g. `evaluate('1.1 + 2.2')` or `sin(bignumber(0.5))`) succeeds and `BigNumber.precision` still equals 509. - Error path: the thrown error message mentions the precision limit of decimal.js trigonometric functions (not just the bare `[DecimalError] Precision limit exceeded`), and is an Error instance.

Fixes #3676
