### PR TITLE
docs: document matrix iteration

### DIFF
--- a/docs/datatypes/matrices.md
+++ b/docs/datatypes/matrices.md
@@ -430,13 +430,37 @@ q[q > 3 and r < 4]     # [4]
 
 ## Iterating
 
-Matrices contain functions `map` and `forEach` to iterate over all elements of
-the (multidimensional) matrix. The callback function of `map` and `forEach` has
-three parameters: `value` (the value of the currently iterated element),
+Math.js `Matrix` instances implement the JavaScript iterable protocol. A
+`for...of` loop yields an object containing the current `value` and its `index`.
+Unlike `forEach`, a `for...of` loop can stop early with `break`:
+
+```js
+const a = math.matrix([[4, 7], [2, 9]])
+let firstAboveFive
+
+for (const { value, index } of a) {
+  if (value > 5) {
+    firstAboveFive = { value, index }
+    break
+  }
+}
+
+console.log(firstAboveFive) // { value: 7, index: [0, 1] }
+```
+
+The iterator of a dense matrix visits every element. The iterator of a sparse
+matrix visits only stored entries, matching `matrix.forEach(callback, true)`.
+Regular JavaScript arrays keep their native iteration behavior and yield their
+top-level elements instead of `{ value, index }` objects.
+
+Matrices also contain functions `map` and `forEach` to iterate over all elements
+of the (multidimensional) matrix. The callback function of `map` and `forEach`
+has three parameters: `value` (the value of the currently iterated element),
 `index` (an array with the index value for each dimension), and `matrix` (the
 matrix being iterated). This syntax is similar to the `map` and `forEach`
 functions of native JavaScript Arrays, except that the index is no number but
-an Array with numbers for each dimension.
+an Array with numbers for each dimension. A `forEach` callback's return value
+is ignored, so it cannot be used to stop iteration early.
 
 ```js
 const a = math.matrix([[0, 1], [2, 3], [4, 5]])


### PR DESCRIPTION
## Summary

- document the existing Matrix iterable protocol and its `{ value, index }` items
- show how `for...of` supports short-circuiting with `break`
- clarify dense-matrix, sparse stored-entry, native Array, and `forEach` traversal semantics

Closes #3558.

This is documentation-only and does not change iterator behavior.

## Testing

- executable documentation example — found `{ value: 7, index: [0, 1] }` after two visits
- focused DenseMatrix and SparseMatrix iterator tests — 2 passing
- `npm run build:docs`
- `npm run lint`
- `CI=true npm run build-and-test` — 6,652 source tests, 36 generated-code tests, and 282 Node/docs tests passing, plus type checks and lint
- `git diff --check`

The aggregate suite emitted existing JSDoc, Browserslist, and Node deprecation warnings but completed successfully. No dependency or lockfile changed.

Tooling disclosure: this change was prepared with OpenAI Codex and validated with the commands above.
