### PR TITLE
fix: prevent LaTeX boolean literals from merging with preceding control sequences

### DIFF
--- a/src/expression/node/ConstantNode.js
+++ b/src/expression/node/ConstantNode.js
@@ -171,6 +171,10 @@ export const createConstantNode = /* #__PURE__ */ factory(name, dependencies, ({
         case 'Fraction':
           return this.value.toLatex()
 
+        case 'boolean': {
+          return ' ' + value
+        }
+
         default:
           return value
       }

--- a/test/unit-tests/expression/node/ConditionalNode.test.js
+++ b/test/unit-tests/expression/node/ConditionalNode.test.js
@@ -344,7 +344,7 @@ describe('ConditionalNode', function () {
     const n = new ConditionalNode(condition, a, b)
 
     // note that b is enclosed in \\mathrm{...} since it's a unit
-    assert.strictEqual(n.toTex(), '\\begin{cases} { a=2}, &\\quad{\\text{if }\\;true}\\\\{\\mathrm{b}=3}, &\\quad{\\text{otherwise}}\\end{cases}')
+    assert.strictEqual(n.toTex(), '\\begin{cases} { a=2}, &\\quad{\\text{if }\\; true}\\\\{\\mathrm{b}=3}, &\\quad{\\text{otherwise}}\\end{cases}')
   })
 
   it('should LaTeX a ConditionalNode with custom toTex', function () {

--- a/test/unit-tests/expression/node/ConstantNode.test.js
+++ b/test/unit-tests/expression/node/ConstantNode.test.js
@@ -201,8 +201,8 @@ describe('ConstantNode', function () {
     assert.deepStrictEqual(new ConstantNode(math.bignumber('12345678901234567890')).toTex(),
       '1.234567890123456789\\cdot10^{+19}')
     assert.strictEqual(new ConstantNode('hi').toTex(), '\\mathtt{"hi"}')
-    assert.strictEqual(new ConstantNode(true).toTex(), 'true')
-    assert.strictEqual(new ConstantNode(false).toTex(), 'false')
+    assert.strictEqual(new ConstantNode(true).toTex(), ' true')
+    assert.strictEqual(new ConstantNode(false).toTex(), ' false')
     assert.strictEqual(new ConstantNode(undefined).toTex(), 'undefined')
     assert.strictEqual(new ConstantNode(null).toTex(), 'null')
   })

--- a/test/unit-tests/function/logical/and.test.js
+++ b/test/unit-tests/function/logical/and.test.js
@@ -207,4 +207,8 @@ describe('and', function () {
     const expression = math.parse('and(1,2)')
     assert.strictEqual(expression.toTex(), '\\left(1\\wedge2\\right)')
   })
+
+  it('should LaTeX and with boolean arguments, keeping spaces around the operator', function () {
+    assert.strictEqual(math.parse('true and false').toTex(), ' true\\wedge false')
+  })
 })

--- a/test/unit-tests/function/logical/not.test.js
+++ b/test/unit-tests/function/logical/not.test.js
@@ -97,4 +97,10 @@ describe('not', function () {
     const node = new FunctionNode(new SymbolNode('not'), [c])
     assert.strictEqual(node.toTex(), '\\neg\\left(1\\right)')
   })
+
+  it('should LaTeX not with boolean arguments, keeping a space after \\neg', function () {
+    assert.strictEqual(math.parse('not true').toTex(), '\\neg true')
+    assert.strictEqual(math.parse('not false').toTex(), '\\neg false')
+    assert.strictEqual(math.parse('not not true').toTex(), '\\neg\\left(\\neg true\\right)')
+  })
 })

--- a/test/unit-tests/function/logical/or.test.js
+++ b/test/unit-tests/function/logical/or.test.js
@@ -233,4 +233,8 @@ describe('or', function () {
     const expression = math.parse('or(1,2)')
     assert.strictEqual(expression.toTex(), '\\left(1\\vee2\\right)')
   })
+
+  it('should LaTeX or with boolean arguments, keeping spaces around the operator', function () {
+    assert.strictEqual(math.parse('true or false').toTex(), ' true\\vee false')
+  })
 })

--- a/test/unit-tests/function/logical/xor.test.js
+++ b/test/unit-tests/function/logical/xor.test.js
@@ -224,4 +224,8 @@ describe('xor', function () {
     const expression = math.parse('xor(1,2)')
     assert.strictEqual(expression.toTex(), '\\left(1\\veebar2\\right)')
   })
+
+  it('should LaTeX xor with boolean arguments, keeping spaces around the operator', function () {
+    assert.strictEqual(math.parse('true xor false').toTex(), ' true\\veebar false')
+  })
 })


### PR DESCRIPTION
### Summary

Boolean operands currently produce **invalid LaTeX** that fails to compile.

Since `true` / `false` are rendered as plain letters, a preceding control sequence
whose name is made of letters — such as `\wedge`, `\vee`, `\veebar`, or `\neg` —
swallows the following letters into a single (undefined) command:

| Expression          | Before                | Problem                          |
|---------------------|-----------------------|----------------------------------|
| `true and false`    | `true\wedgefalse`     | `\wedgefalse` → undefined command |
| `true or false`     | `true\veefalse`       | `\veefalse` → undefined command  |
| `true xor false`    | `true\veebarfalse`    | `\veebarfalse` → undefined command |
| `not true`          | `\negtrue`            | `\negtrue` → undefined command   |

LaTeX parses control sequences as runs of letters, so a space (or `{}`) is required
to terminate the command name. Numeric operands are unaffected because digits already
terminate a control sequence (e.g. `\wedge2` is fine).

### Fix

In `ConstantNode`, render boolean literals with a leading space (`' true'` / `' false'`).
Spaces are ignored in math mode, so this only acts as a delimiter and does not change
the visual output:

| Expression        | After                |
|-------------------|----------------------|
| `true and false`  | ` true\wedge false`  |
| `not true`        | `\neg true`          |
| `not not true`    | `\neg\left(\neg true\right)` |

### Tests

- Added LaTeX tests for `and`, `or`, `xor` with boolean arguments.
- Added LaTeX tests for `not` with boolean arguments (including double negation).
- Updated `ConstantNode` and `ConditionalNode` LaTeX expectations to the new output.