### PR TITLE
fix: optional chaining short-circuits only one link, and pollutes indexed objects

### DIFF
--- a/src/expression/node/AccessorNode.js
+++ b/src/expression/node/AccessorNode.js
@@ -12,6 +12,11 @@ import {
 import { getSafeProperty } from '../../utils/customs.js'
 import { factory } from '../../utils/factory.js'
 import { accessFactory } from './utils/access.js'
+import {
+  continuesOptionalChain,
+  optionalChainOf,
+  shortCircuitOptionalChain
+} from './utils/optionalChain.js'
 
 const name = 'AccessorNode'
 const dependencies = [
@@ -99,20 +104,19 @@ export const createAccessorNode = /* #__PURE__ */ factory(name, dependencies, ({
       const evalIndex = this.index._compile(math, argNames)
 
       const optionalChaining = this.optionalChaining
-      const prevOptionalChaining = isAccessorNode(this.object) && this.object.optionalChaining
+      const inOptionalChain = continuesOptionalChain(this.object)
 
       if (this.index.isObjectProperty()) {
         const prop = this.index.getObjectProperty()
         return function evalAccessorNode (scope, args, context) {
-          const ctx = context || {}
-          const object = evalObject(scope, args, ctx)
+          const chain = optionalChainOf(context)
+          const object = evalObject(scope, args, chain)
 
           if (optionalChaining && object == null) {
-            ctx.optionalShortCircuit = true
-            return undefined
+            return shortCircuitOptionalChain(chain)
           }
 
-          if (prevOptionalChaining && ctx?.optionalShortCircuit) {
+          if (inOptionalChain && chain.shortCircuited) {
             return undefined
           }
 
@@ -121,15 +125,14 @@ export const createAccessorNode = /* #__PURE__ */ factory(name, dependencies, ({
         }
       } else {
         return function evalAccessorNode (scope, args, context) {
-          const ctx = context || {}
-          const object = evalObject(scope, args, ctx)
+          const chain = optionalChainOf(context)
+          const object = evalObject(scope, args, chain)
 
           if (optionalChaining && object == null) {
-            ctx.optionalShortCircuit = true
-            return undefined
+            return shortCircuitOptionalChain(chain)
           }
 
-          if (prevOptionalChaining && ctx?.optionalShortCircuit) {
+          if (inOptionalChain && chain.shortCircuited) {
             return undefined
           }
 

--- a/src/expression/node/FunctionNode.js
+++ b/src/expression/node/FunctionNode.js
@@ -5,6 +5,11 @@ import { getSafeProperty, getSafeMethod } from '../../utils/customs.js'
 import { createSubScope } from '../../utils/scope.js'
 import { factory } from '../../utils/factory.js'
 import { defaultTemplate, latexFunctions } from '../../utils/latex.js'
+import {
+  continuesOptionalChain,
+  detachOptionalChain,
+  shortCircuitOptionalChain
+} from './utils/optionalChain.js'
 
 const name = 'FunctionNode'
 const dependencies = [
@@ -140,10 +145,18 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
      *                        evalNode(scope: Object, args: Object, context: *)
      */
     _compile (math, argNames) {
-      // compile arguments
-      const evalArgs = this.args.map((arg) => arg._compile(math, argNames))
-      const fromOptionalChaining = this.optional ||
-        (isAccessorNode(this.fn) && this.fn.optionalChaining)
+      const fromOptionalChaining = this.optional || continuesOptionalChain(this.fn)
+
+      // compile arguments. When this call is part of an optional chain, the
+      // arguments are evaluated outside of it, so a short-circuit inside an
+      // argument does not short-circuit the chain around the call itself.
+      const evalArgs = this.args.map((arg) => {
+        const evalArg = arg._compile(math, argNames)
+
+        return fromOptionalChaining
+          ? (scope, args, context) => evalArg(scope, args, detachOptionalChain(context))
+          : evalArg
+      })
 
       if (isSymbolNode(this.fn)) {
         const name = this.fn.name
@@ -193,12 +206,12 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
             switch (evalArgs.length) {
               case 0: return function evalFunctionNode (scope, args, context) {
                 const fn = resolveFn(scope)
-                if (fromOptionalChaining && fn === undefined) return undefined
+                if (fromOptionalChaining && fn === undefined) return shortCircuitOptionalChain(context)
                 return fn()
               }
               case 1: return function evalFunctionNode (scope, args, context) {
                 const fn = resolveFn(scope)
-                if (fromOptionalChaining && fn === undefined) return undefined
+                if (fromOptionalChaining && fn === undefined) return shortCircuitOptionalChain(context)
                 const evalArg0 = evalArgs[0]
                 return fn(
                   evalArg0(scope, args, context)
@@ -206,7 +219,7 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
               }
               case 2: return function evalFunctionNode (scope, args, context) {
                 const fn = resolveFn(scope)
-                if (fromOptionalChaining && fn === undefined) return undefined
+                if (fromOptionalChaining && fn === undefined) return shortCircuitOptionalChain(context)
                 const evalArg0 = evalArgs[0]
                 const evalArg1 = evalArgs[1]
                 return fn(
@@ -216,7 +229,7 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
               }
               default: return function evalFunctionNode (scope, args, context) {
                 const fn = resolveFn(scope)
-                if (fromOptionalChaining && fn === undefined) return undefined
+                if (fromOptionalChaining && fn === undefined) return shortCircuitOptionalChain(context)
                 const values = evalArgs.map((evalArg) => evalArg(scope, args, context))
                 return fn(...values)
               }
@@ -226,7 +239,7 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
           const rawArgs = this.args
           return function evalFunctionNode (scope, args, context) {
             const fn = getSafeProperty(args, name)
-            if (fromOptionalChaining && fn === undefined) return undefined
+            if (fromOptionalChaining && fn === undefined) return shortCircuitOptionalChain(context)
             if (typeof fn !== 'function') {
               throw new TypeError(
                 `Argument '${name}' was not a function; received: ${strin(fn)}`
@@ -260,7 +273,7 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
           // Optional chaining: if the base object is nullish, short-circuit to undefined
           if (fromOptionalChaining &&
               (object == null || object[prop] === undefined)) {
-            return undefined
+            return shortCircuitOptionalChain(context)
           }
 
           const fn = getSafeMethod(object, prop)
@@ -284,7 +297,7 @@ export const createFunctionNode = /* #__PURE__ */ factory(name, dependencies, ({
 
         return function evalFunctionNode (scope, args, context) {
           const fn = evalFn(scope, args, context)
-          if (fromOptionalChaining && fn === undefined) return undefined
+          if (fromOptionalChaining && fn === undefined) return shortCircuitOptionalChain(context)
           if (typeof fn !== 'function') {
             throw new TypeError(
               `Expression '${fnExpr}' did not evaluate to a function; value is:` +

--- a/src/expression/node/utils/optionalChain.js
+++ b/src/expression/node/utils/optionalChain.js
@@ -1,0 +1,69 @@
+import { isAccessorNode, isFunctionNode } from '../../../utils/is.js'
+
+/**
+ * The shared state of a single optional chain like `a?.b.c`: as soon as one of
+ * its links short-circuits, all the links after it must return undefined too.
+ *
+ * This state is passed along the chain instead of being stored in the
+ * evaluation context, since the context of an index expression is the object
+ * that is being indexed, like `A` in `A[a?.b]`.
+ */
+export class OptionalChain {
+  constructor () {
+    this.shortCircuited = false
+  }
+}
+
+/**
+ * Get the optional chain that a given evaluation context belongs to, or start
+ * a new one when the context is not part of a chain.
+ * @param {*} context
+ * @return {OptionalChain}
+ */
+export function optionalChainOf (context) {
+  return context instanceof OptionalChain ? context : new OptionalChain()
+}
+
+/**
+ * Get the evaluation context to use outside of an optional chain, like in the
+ * arguments of a function call: a short-circuit there belongs to a chain of
+ * its own, like `y?.z` does in `x?.f(y?.z).g`.
+ * @param {*} context
+ * @return {*}
+ */
+export function detachOptionalChain (context) {
+  return context instanceof OptionalChain ? undefined : context
+}
+
+/**
+ * Short-circuit the optional chain of a given evaluation context, so the links
+ * after it return undefined instead of accessing a property of undefined.
+ * @param {*} context
+ * @return {undefined}
+ */
+export function shortCircuitOptionalChain (context) {
+  if (context instanceof OptionalChain) {
+    context.shortCircuited = true
+  }
+
+  return undefined
+}
+
+/**
+ * Test whether a node continues an optional chain, like `a?.b` does in
+ * `a?.b.c` and `a?.b()`: accessing or invoking the result of such a node must
+ * return undefined when the chain short-circuited.
+ * @param {Node} node
+ * @return {boolean}
+ */
+export function continuesOptionalChain (node) {
+  if (isAccessorNode(node)) {
+    return node.optionalChaining || continuesOptionalChain(node.object)
+  }
+
+  if (isFunctionNode(node)) {
+    return node.optional || continuesOptionalChain(node.fn)
+  }
+
+  return false
+}

--- a/test/unit-tests/expression/parse.test.js
+++ b/test/unit-tests/expression/parse.test.js
@@ -1070,6 +1070,34 @@ describe('parse', function () {
       assert.throws(function () { parseAndEval('obj?.foo.bar', { obj: { foo: null } }) }, TypeError)
     })
 
+    it('should return undefined accessing the rest of the chain after optional chaining short-circuited', function () {
+      assert.deepStrictEqual(parseAndEval('obj?.foo.bar.baz', { obj: undefined }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj?.foo.bar.baz.qux', { obj: null }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj.foo?.bar.baz', { obj: { foo: undefined } }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj?.["foo"]["bar"]["baz"]', { obj: undefined }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj?.foo["bar"].baz', { obj: null }), undefined)
+    })
+
+    it('should not short-circuit the rest of the chain when optional chaining did not', function () {
+      const scope = { obj: { foo: { bar: { baz: 2 } } } }
+      assert.deepStrictEqual(parseAndEval('obj?.foo.bar.baz', scope), 2)
+      assert.deepStrictEqual(parseAndEval('obj.foo?.bar.baz', scope), 2)
+      assert.throws(function () { parseAndEval('obj?.foo.bar.qux.quux', scope) }, TypeError)
+    })
+
+    it('should not remember the optional chaining state of an index expression', function () {
+      const scope = {
+        A: [10, 20, 30],
+        first: function () { return 1 },
+        obj: { foo: { bar: 1 } },
+        nothing: null
+      }
+
+      assert.deepStrictEqual(parseAndEval('A[first(nothing?.foo)]', scope), 10)
+      assert.deepStrictEqual(parseAndEval('A[obj?.foo.bar]', scope), 10)
+      assert.deepStrictEqual(Object.keys(scope.A), ['0', '1', '2'])
+    })
+
     it('should get a nested object property e using dot notation', function () {
       // in the past, the parser was trying to parse '.e' as a number
       const scope = { a: { e: { x: 2 } } }
@@ -1147,6 +1175,30 @@ describe('parse', function () {
       }
       assert.deepStrictEqual(parseAndEval('obj.fn(2)?.foo', scope), undefined)
       assert.deepStrictEqual(parseAndEval('obj["fn"](2)?.foo', scope), undefined)
+    })
+
+    it('should return undefined invoking a function after optional chaining short-circuited', function () {
+      assert.deepStrictEqual(parseAndEval('obj?.foo.fn(2)', { obj: undefined }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj?.["foo"]["fn"](2)', { obj: null }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj.foo?.bar.fn(2)', { obj: { foo: null } }), undefined)
+    })
+
+    it('should return undefined accessing a function result after optional chaining short-circuited', function () {
+      assert.deepStrictEqual(parseAndEval('obj?.fn().foo', { obj: undefined }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj?.fn().foo.bar', { obj: null }), undefined)
+      assert.deepStrictEqual(parseAndEval('obj?.["fn"]().foo', { obj: undefined }), undefined)
+    })
+
+    it('should not short-circuit a chain when an argument of a call in it short-circuits', function () {
+      const scope = {
+        obj: {
+          fn: function () {
+            return { foo: 2 }
+          }
+        },
+        nothing: null
+      }
+      assert.deepStrictEqual(parseAndEval('obj?.fn(nothing?.bar).foo', scope), 2)
     })
 
     it('should apply implicit multiplication after a function call', function () {


### PR DESCRIPTION
Optional chaining keeps its short-circuit state in the evaluation context, and only the accessor directly after the optional one looks at it. Two things follow from that.

**1. The chain stops short-circuiting after one link**

```js
math.evaluate('obj?.foo.bar', { obj: null })      // undefined
math.evaluate('obj?.foo.bar.baz', { obj: null })  // TypeError: Cannot access property "baz": object is undefined
```

`bar` is the only link that consults the state `?.` set (`prevOptionalChaining` was `isAccessorNode(this.object) && this.object.optionalChaining`, so it looked exactly one accessor back), so `baz` is read off the `undefined` that `bar` returned. The same applies to a call at the end of a chain (`obj?.foo.fn()` threw "No access to method") and to a property of a call result (`obj?.fn().foo`).

**2. The state is written onto the object of an index expression**

The context of an index expression is the object being indexed, so the flag ends up on the user's own array or matrix, and is still there for the next evaluation:

```js
const A = [10, 20, 30]
const scope = { A, first: () => 1, obj: { foo: { bar: 1 } }, nothing: null }

math.evaluate('A[first(nothing?.foo)]', scope)  // 10
Object.keys(A)                                  // ['0', '1', '2', 'optionalShortCircuit']  <-- A was mutated

math.evaluate('A[obj?.foo.bar]', scope)         // TypeError: Dimension must be an Array, Matrix, number, bigint, string, or Range
```

That last expression evaluates to `10` on its own; it only fails because it read the stale flag left on `A`. A `math.matrix` is affected the same way.

**The fix**

The short-circuit state is now an `OptionalChain` object that travels along the chain instead of living in the evaluation context, so it can never be confused with — or written onto — the object of an index expression. Every link of a chain honours it, not just the first one after `?.`, which also covers calls in a chain and accesses of a call result. Arguments of a call are evaluated outside the chain (`x?.f(y?.z).g` keeps working when `y` is nullish), matching how a nested chain behaves in JavaScript.

Behaviour that was already correct is unchanged: a chain still throws when nothing short-circuited (`obj?.foo.bar` with `obj.foo === undefined` throws, as its existing test requires), and `(obj?.foo).bar` still ends the chain at the parentheses.

**Tests**

Six cases added to `test/unit-tests/expression/parse.test.js`, next to the existing optional chaining tests: chains longer than two links in dot and bracket notation, calls in a chain, accesses of a call result, an argument that short-circuits inside a chain, and the index-expression case above (asserting the value *and* that `A` is untouched). Five of them fail on `develop`; the sixth guards against short-circuiting a chain that should not short-circuit.

`npm run test:all` (6658 unit + 36 generated + 282 node + types) and `npm run lint` pass.
