### PR TITLE
fix(types): add Unit x array overloads for multiply and dotMultiply

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1343,6 +1343,8 @@ export interface MathJsInstance extends MathJsFactory {
    * @param y Right hand value
    * @returns Multiplication of x and y
    */
+  dotMultiply(x: Unit, y: MathNumericType[]): Unit[]
+  dotMultiply(x: MathNumericType[], y: Unit): Unit[]
   dotMultiply<T extends MathCollection>(x: T, y: MathType): T
   dotMultiply<T extends MathCollection>(x: MathType, y: T): T
   dotMultiply(x: Unit, y: MathType): Unit
@@ -1526,6 +1528,8 @@ export interface MathJsInstance extends MathJsFactory {
   multiply<T extends MathArray>(x: T[], y: T[]): T[]
   multiply<T extends MathArray>(x: T, y: T): MathScalarType
   multiply(x: Unit, y: Unit): Unit
+  multiply(x: Unit, y: MathNumericType[]): Unit[]
+  multiply(x: MathNumericType[], y: Unit): Unit[]
   multiply(x: number, y: number): number
   multiply(x: MathType, y: MathType, ...values: MathType[]): MathType
   multiply<T extends MathType>(x: T, y: T, ...values: T[]): T


### PR DESCRIPTION
## Summary
`multiply` and `dotMultiply` support multiplying a `Unit` by an array of numbers at runtime (each entry scales the unit), but no declared overload expressed it: `multiply(unit, array)` fell through to the `MathType` catch-all and `dotMultiply(unit, array)` resolved to the generic collection overload returning the array's own element type. This adds `Unit x MathNumericType[]` overloads in both argument orders returning `Unit[]`, matching the runtime result.

## Testing
A scratch file calling all four forms (`multiply`/`dotMultiply` with the unit on either side) failed `tsc --strict` before the change with "Type 'MathType' is not assignable to type 'Unit[]'" and "'number[]' is not assignable to type 'Unit[]'", and compiles cleanly after. Runtime behavior is unchanged; the outputs match the examples in #3660. eslint passes on types/index.d.ts.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
