### PR TITLE
fix: correct numeric collection result types

### DIFF
--- a/test/typescript-tests/testTypes.ts
+++ b/test/typescript-tests/testTypes.ts
@@ -2719,6 +2719,123 @@ Factory Test
 }
 
 /**
+ * Numeric tests preserve collection results, including through chains.
+ */
+{
+  const math = create(all)
+  const values = [2, 'foo', false]
+  const nested = [
+    [2, 'foo'],
+    [false, math.complex(2, 3)]
+  ]
+  const expected = [
+    [true, false],
+    [true, false]
+  ]
+  const matrix = math.matrix([[2, math.complex(2, 3)]])
+
+  for (const test of [math.isNumeric, math.hasNumericValue]) {
+    expectTypeOf(test(2)).toEqualTypeOf<boolean>()
+    expectTypeOf(test('2')).toEqualTypeOf<boolean>()
+    expectTypeOf(test([])).toEqualTypeOf<MathArray<boolean>>()
+    expectTypeOf(test(values)).toEqualTypeOf<MathArray<boolean>>()
+    expectTypeOf(test(nested)).toEqualTypeOf<MathArray<boolean>>()
+    expectTypeOf(test(matrix)).toEqualTypeOf<Matrix<boolean>>()
+    assert.deepStrictEqual(test(values), [true, false, true])
+    assert.deepStrictEqual(test(nested), expected)
+    assert.deepStrictEqual(test(matrix).valueOf(), [[true, false]])
+
+    const checkUnion = (value: number | string[] | Matrix) => {
+      expectTypeOf(test(value)).toEqualTypeOf<
+        boolean | MathCollection<boolean>
+      >()
+    }
+    checkUnion(2)
+    checkUnion(['foo'])
+    checkUnion(math.matrix([2]))
+  }
+
+  // Without strictNullChecks, null and undefined infer the same way as any.
+  expectTypeOf(math.isNumeric(null)).toEqualTypeOf<
+    boolean | MathCollection<boolean>
+  >()
+  expectTypeOf(math.isNumeric(undefined)).toEqualTypeOf<
+    boolean | MathCollection<boolean>
+  >()
+  expectTypeOf(math.hasNumericValue(null)).toEqualTypeOf<
+    boolean | MathCollection<boolean>
+  >()
+  expectTypeOf(math.hasNumericValue(undefined)).toEqualTypeOf<
+    boolean | MathCollection<boolean>
+  >()
+
+  const checkScalar = (value: number | string) => {
+    if (math.isNumeric(value)) {
+      expectTypeOf(value).toEqualTypeOf<number>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<string>()
+    }
+  }
+  checkScalar(2)
+  checkScalar('foo')
+
+  const checkUnknown = (value: unknown) => {
+    expectTypeOf(math.isNumeric(value)).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+    expectTypeOf(math.hasNumericValue(value)).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+    expectTypeOf(math.chain(value).isNumeric().done()).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+    if (math.isNumeric(value)) {
+      // A truthy collection result does not imply that the input is numeric.
+      expectTypeOf(value).toBeUnknown()
+    }
+  }
+  checkUnknown(['foo'])
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const checkAny = (value: any) => {
+    expectTypeOf(math.isNumeric(value)).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+    expectTypeOf(math.hasNumericValue(value)).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+    expectTypeOf(math.chain(value).isNumeric().done()).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+    if (math.isNumeric(value)) {
+      expectTypeOf(value).toBeAny()
+    }
+  }
+  checkAny(['foo'])
+
+  const checkChainUnion = (value: number | string[] | Matrix) => {
+    expectTypeOf(math.chain(value).isNumeric().done()).toEqualTypeOf<
+      boolean | MathCollection<boolean>
+    >()
+  }
+  checkChainUnion(2)
+  checkChainUnion(['foo'])
+  checkChainUnion(matrix)
+
+  expectTypeOf(math.chain(2).isNumeric().done()).toEqualTypeOf<boolean>()
+  expectTypeOf(math.chain(values).isNumeric().done()).toEqualTypeOf<
+    MathArray<boolean>
+  >()
+  expectTypeOf(math.chain(matrix).isNumeric().done()).toEqualTypeOf<
+    Matrix<boolean>
+  >()
+  assert.deepStrictEqual(math.chain(nested).isNumeric().done(), expected)
+  assert.deepStrictEqual(math.chain(matrix).isNumeric().done().valueOf(), [
+    [true, false]
+  ])
+}
+
+/**
  * src/util/is functions
  */
 {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,6 +18,16 @@ export type MathScalarType = MathNumericType | Unit
 export type MathGeneric<T extends MathScalarType = MathNumericType> = T
 export type MathArray<T = MathGeneric> = T[] | Array<MathArray<T>>
 export type MathCollection<T = MathGeneric> = MathArray<T> | Matrix<T>
+
+// Preserve the result container while allowing `any` to include scalar input.
+type NumericCollectionResult<T> = unknown extends T
+  ? boolean | MathCollection<boolean>
+  : T extends null | undefined
+    ? boolean
+    : T extends Matrix<unknown>
+      ? Matrix<boolean>
+      : MathArray<boolean>
+
 export type MathType = MathScalarType | MathCollection
 export type MathExpression = string | string[] | MathCollection
 
@@ -3743,11 +3753,19 @@ export interface MathJsInstance extends MathJsFactory {
    *  true is returned if the string contains a numeric value.
    * @param x Value to be tested
    * @returns Returns true when x is a number, BigNumber, bigint, Fraction, Boolean, or a String containing number.
-   * Returns false for other types.
+   * Returns false for other types. For Arrays and Matrices, returns an
+   * element-wise result with the same container type.
    * Throws an error in case of unknown types.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  hasNumericValue(x: any): boolean | boolean[]
+  // Handle nullable input before collections when strictNullChecks is disabled.
+  hasNumericValue<T extends null | undefined>(x: T): NumericCollectionResult<T>
+  hasNumericValue<T extends MathCollection<unknown>>(
+    x: T
+  ): NumericCollectionResult<T>
+  hasNumericValue(
+    x: MathScalarType | string | boolean | MathNode | null | undefined
+  ): boolean
+  hasNumericValue(x: unknown): boolean | MathCollection<boolean>
 
   /**
    * Test whether a value is bounded
@@ -3803,11 +3821,16 @@ export interface MathJsInstance extends MathJsFactory {
    * element-wise in case of Array or Matrix input.
    * @param x Value to be tested
    * @returns Returns true when x is a number, BigNumber, bigint, Fraction, or
-   * boolean. Returns false for other types. Throws an error in case of
-   * unknown types.
+   * boolean. Returns false for other types. For Arrays and Matrices, returns
+   * an element-wise result with the same container type. Throws an error in
+   * case of unknown types.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  isNumeric(x: any): x is number | BigNumber | bigint | Fraction | boolean
+  isNumeric<T extends null | undefined>(x: T): NumericCollectionResult<T>
+  isNumeric<T extends MathCollection<unknown>>(x: T): NumericCollectionResult<T>
+  isNumeric(
+    x: MathScalarType | string | boolean | MathNode | null | undefined
+  ): x is number | BigNumber | bigint | Fraction | boolean
+  isNumeric(x: unknown): boolean | MathCollection<boolean>
 
   /**
    * Test whether a value is positive: larger than zero. The function
@@ -7418,8 +7441,20 @@ export interface MathJsChain<TValue> {
    * element-wise in case of Array or Matrix input.
    */
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  isNumeric(this: MathJsChain<any>): MathJsChain<boolean>
+  isNumeric<T extends null | undefined>(
+    this: MathJsChain<T>
+  ): MathJsChain<NumericCollectionResult<T>>
+  isNumeric<T extends MathCollection<unknown>>(
+    this: MathJsChain<T>
+  ): MathJsChain<NumericCollectionResult<T>>
+  isNumeric(
+    this: MathJsChain<
+      MathScalarType | string | boolean | MathNode | null | undefined
+    >
+  ): MathJsChain<boolean>
+  isNumeric(
+    this: MathJsChain<unknown>
+  ): MathJsChain<boolean | MathCollection<boolean>>
 
   /**
    * Test whether a value is positive: larger than zero. The function


### PR DESCRIPTION
`isNumeric([3, 4, 5])[0]` works at runtime, but the declaration treats the result as a scalar type guard. `hasNumericValue` also omits Matrix and nested-array results.

This updates the collection overloads to return `MathArray<boolean>` or `Matrix<boolean>`, including the existing `isNumeric` chain method. Scalar inputs retain the `isNumeric` type guard; unknown, any, and scalar/collection unions return a boolean-or-collection union without incorrectly narrowing the input. Runtime behavior is unchanged.

Related to #3380. This addresses the collection typing portion; the issue's broader boolean/Complex semantics and proposed scalar API remain separate.

Validation on macOS and Linux with Node 22:

- The new TypeScript regressions produce 22 diagnostics against the original declarations and pass with this patch, including runtime assertions for arrays, matrices, and chains.
- Complete source tests: 6,652 passing, 22 pending on each platform; generated tests: 36 passing; Node tests: 282 passing on macOS and 295 on Linux.
- Project TypeScript compile/runtime tests, separate strict-null checks, lint, formatting, and library builds pass.

The project's non-strict-null compiler mode infers direct null/undefined like any, so those calls conservatively retain a boolean-or-collection union. Strict-null mode returns boolean. An initial macOS run hit an existing CLI parallel-output ordering failure; its focused rerun and the final full run passed without changing CLI code or tests. Linux used the full gulp library build; the Git-history-based author update ran on macOS only. No generated output is included.
